### PR TITLE
MANAGE-001〜004: 参加者管理（一覧/集計/現金受領/CSV出力）機能の追加 #19

### DIFF
--- a/__tests__/app/events/actions/update-guest-attendance.test.ts
+++ b/__tests__/app/events/actions/update-guest-attendance.test.ts
@@ -34,7 +34,7 @@ const mockAttendanceData = {
     capacity: 50,
     registration_deadline: "2024-12-30T15:00:00Z",
     payment_deadline: "2024-12-30T15:00:00Z",
-    organizer_id: "organizer-123",
+    created_by: "organizer-123",
   },
   payment: {
     id: "payment-123",

--- a/__tests__/components/events/event-stats.test.tsx
+++ b/__tests__/components/events/event-stats.test.tsx
@@ -2,18 +2,13 @@ import { render, screen } from "@testing-library/react";
 import { EventStats } from "@/components/events/event-stats";
 import type { Event, Attendance, Payment } from "@/types/models";
 
-// テスト用の型定義（EventStatsコンポーネントのpropsに合わせて調整）
-interface MockEventData extends Event {
-  organizer_id: string;
-}
-
 // 共通型から必要なフィールドのみを抽出
 type MockAttendanceData = Pick<Attendance, "id" | "status">;
 type MockPaymentData = Pick<Payment, "id" | "method" | "amount" | "status">;
 
 describe("EventStats", () => {
   // テスト用のベースデータ
-  let baseEventData: MockEventData;
+  let baseEventData: Event;
   let baseAttendances: MockAttendanceData[];
   let basePayments: MockPaymentData[];
 
@@ -24,7 +19,7 @@ describe("EventStats", () => {
   });
 
   // ヘルパー関数: モックイベントデータ作成
-  function createMockEventData(overrides: Partial<MockEventData> = {}): MockEventData {
+  function createMockEventData(overrides: Partial<Event> = {}): Event {
     return {
       id: "event-1",
       title: "テストイベント",
@@ -41,7 +36,6 @@ describe("EventStats", () => {
       updated_at: "2024-01-01T00:00:00Z",
       created_by: "user-1",
       invite_token: "test-token",
-      organizer_id: "user-1",
       creator_name: "テストユーザー",
       attendances_count: 0,
       ...overrides,

--- a/__tests__/components/events/guest-management-form.test.tsx
+++ b/__tests__/components/events/guest-management-form.test.tsx
@@ -40,7 +40,7 @@ const mockAttendanceData: GuestAttendanceData = {
     capacity: 50,
     registration_deadline: "2024-12-30T15:00:00Z",
     payment_deadline: "2024-12-30T15:00:00Z",
-    organizer_id: "organizer-123",
+    created_by: "organizer-123",
   },
   payment: {
     id: "payment-123",

--- a/__tests__/components/events/participation-confirmation.test.tsx
+++ b/__tests__/components/events/participation-confirmation.test.tsx
@@ -18,7 +18,7 @@ const mockEventDetail: EventDetail = {
   payment_deadline: "2024-12-29T23:59:59Z",
   payment_methods: ["stripe", "cash"],
   invite_token: "test-invite-token",
-  organizer_id: "test-organizer-id",
+  created_by: "test-organizer-id",
   created_at: "2024-01-01T00:00:00Z",
   updated_at: "2024-01-01T00:00:00Z",
 };

--- a/__tests__/e2e/guest-management.spec.ts
+++ b/__tests__/e2e/guest-management.spec.ts
@@ -34,7 +34,7 @@ test.describe("ゲスト自己管理ページ", () => {
                   capacity: 50,
                   registration_deadline: "2024-12-30T15:00:00Z",
                   payment_deadline: "2024-12-30T15:00:00Z",
-                  organizer_id: "organizer-123",
+                  created_by: "organizer-123",
                 },
                 payment: {
                   id: "payment-123",
@@ -229,7 +229,7 @@ test.describe("ゲスト自己管理ページ", () => {
                 capacity: 50,
                 registration_deadline: "2024-01-01T15:00:00Z",
                 payment_deadline: "2024-01-01T15:00:00Z",
-                organizer_id: "organizer-123",
+                created_by: "organizer-123",
               },
               payment: null,
             },

--- a/__tests__/integration/settlement-report-performance.integration.test.ts
+++ b/__tests__/integration/settlement-report-performance.integration.test.ts
@@ -46,7 +46,7 @@ describe('Settlement Report Performance Integration', () => {
 
       const result = await service.generateSettlementReport({
         eventId: testEventId,
-        organizerId: testOrganizerId,
+        createdBy: testOrganizerId,
 
       })
 
@@ -78,7 +78,7 @@ describe('Settlement Report Performance Integration', () => {
 
       const result = await service.generateSettlementReport({
         eventId: testEventId,
-        organizerId: testOrganizerId,
+        createdBy: testOrganizerId,
 
       })
 
@@ -153,7 +153,7 @@ describe('Settlement Report Performance Integration', () => {
       const promises = testEventIds.map(eventId =>
         service.generateSettlementReport({
           eventId,
-          organizerId: testOrganizerId,
+          createdBy: testOrganizerId,
 
         })
       )
@@ -199,7 +199,7 @@ describe('Settlement Report Performance Integration', () => {
 
       const result = await service.generateSettlementReport({
         eventId: testEventId,
-        organizerId: testOrganizerId,
+        createdBy: testOrganizerId,
 
       })
 

--- a/__tests__/lib/services/settlement-report/performance.test.ts
+++ b/__tests__/lib/services/settlement-report/performance.test.ts
@@ -40,7 +40,7 @@ describe('SettlementReportService Performance Tests (RPC Version)', () => {
 
       const result = await service.generateSettlementReport({
         eventId: 'event-1',
-        organizerId: 'organizer-1'
+        createdBy: 'organizer-1'
       })
 
       const endTime = Date.now()
@@ -55,7 +55,7 @@ describe('SettlementReportService Performance Tests (RPC Version)', () => {
         'generate_settlement_report',
         {
           p_event_id: 'event-1',
-          p_organizer_id: 'organizer-1'
+          p_created_by: 'organizer-1'
         }
       )
 
@@ -74,7 +74,7 @@ describe('SettlementReportService Performance Tests (RPC Version)', () => {
 
       const result = await service.generateSettlementReport({
         eventId: 'event-1',
-        organizerId: 'organizer-1'
+        createdBy: 'organizer-1'
       })
 
       expect(result.success).toBe(false)
@@ -95,7 +95,7 @@ describe('SettlementReportService Performance Tests (RPC Version)', () => {
 
       const result = await service.generateSettlementReport({
         eventId: 'event-1',
-        organizerId: 'organizer-1'
+        createdBy: 'organizer-1'
       })
 
       expect(result.success).toBe(false)
@@ -130,7 +130,7 @@ describe('SettlementReportService Performance Tests (RPC Version)', () => {
         'generate_settlement_report',
         {
           p_event_id: 'event-1',
-          p_organizer_id: 'organizer-1'
+          p_created_by: 'organizer-1'
         }
       )
     })
@@ -152,7 +152,7 @@ describe('SettlementReportService Performance Tests (RPC Version)', () => {
 
         await service.generateSettlementReport({
           eventId: `event-${i}`,
-          organizerId: 'organizer-1'
+          createdBy: 'organizer-1'
         })
 
         const duration = Date.now() - startTime
@@ -183,7 +183,7 @@ describe('SettlementReportService Performance Tests (RPC Version)', () => {
       const promises = Array.from({ length: concurrentRequests }, (_, i) =>
         service.generateSettlementReport({
           eventId: `event-${i}`,
-          organizerId: 'organizer-1'
+          createdBy: 'organizer-1'
         })
       )
 

--- a/__tests__/lib/utils/guest-token.test.ts
+++ b/__tests__/lib/utils/guest-token.test.ts
@@ -28,7 +28,7 @@ const mockAttendanceData = {
     capacity: 50,
     registration_deadline: "2024-12-30T15:00:00Z",
     payment_deadline: "2024-12-30T15:00:00Z",
-    organizer_id: "organizer-123",
+    created_by: "organizer-123",
   },
   payment: {
     id: "payment-123",

--- a/__tests__/lib/utils/test-helpers.util.ts
+++ b/__tests__/lib/utils/test-helpers.util.ts
@@ -21,7 +21,7 @@ export const mockEvent = {
   location: "Test Location",
   price: 1000,
   capacity: 100,
-  organizer_id: "test-user-id",
+  created_by: "test-user-id",
   status: "draft" as const,
   created_at: "2024-01-01T00:00:00Z",
   updated_at: "2024-01-01T00:00:00Z",

--- a/app/(dashboard)/dashboard/settlement-reports/page.tsx
+++ b/app/(dashboard)/dashboard/settlement-reports/page.tsx
@@ -18,7 +18,7 @@ export default async function SettlementReportsPage() {
 
   // 直近のレポートを初期表示（最大50件）
   const initialReports = await service.getSettlementReports({
-    organizerId: user.id,
+    createdBy: user.id,
     limit: 50,
     offset: 0,
   });

--- a/app/(dashboard)/settlement-reports/page.tsx
+++ b/app/(dashboard)/settlement-reports/page.tsx
@@ -47,7 +47,7 @@ export default async function SettlementReportsPage() {
 
   // 初期レポート一覧を取得（最新10件）- RPC関数で動的計算
   const { data: initialReportsRpc } = await (supabase as any).rpc("get_settlement_report_details", {
-    p_organizer_id: user.id,
+    p_created_by: user.id,
     p_event_ids: null,
     p_from_date: null,
     p_to_date: null,
@@ -59,7 +59,7 @@ export default async function SettlementReportsPage() {
     eventId: report.event_id,
     eventTitle: report.event_title,
     eventDate: report.event_date,
-    organizerId: user.id,
+    createdBy: user.id,
     stripeAccountId: report.stripe_account_id,
     transferGroup: report.transfer_group,
     generatedAt: new Date(report.generated_at),

--- a/app/actions/settlement-report-actions.ts
+++ b/app/actions/settlement-report-actions.ts
@@ -45,7 +45,7 @@ export async function generateSettlementReportAction(formData: FormData) {
 
     const result = await service.generateSettlementReport({
       eventId: validatedData.eventId,
-      organizerId: user.id
+      createdBy: user.id
     })
 
     if (!result.success) {
@@ -108,7 +108,7 @@ export async function getSettlementReportsAction(params: {
     const service = new SettlementReportService(supabase)
 
     const reports = await service.getSettlementReports({
-      organizerId: user.id,
+      createdBy: user.id,
       eventIds: validatedParams.eventIds,
       fromDate: validatedParams.fromDate ? new Date(validatedParams.fromDate) : undefined,
       toDate: validatedParams.toDate ? new Date(validatedParams.toDate) : undefined,
@@ -158,7 +158,7 @@ export async function exportSettlementReportsAction(params: {
     const service = new SettlementReportService(supabase)
 
     const result = await service.exportToCsv({
-      organizerId: user.id,
+      createdBy: user.id,
       eventIds: validatedParams.eventIds,
       fromDate: validatedParams.fromDate ? new Date(validatedParams.fromDate) : undefined,
       toDate: validatedParams.toDate ? new Date(validatedParams.toDate) : undefined,

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -43,14 +43,14 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
 
     // 主催者の場合のみ統計データと参加者データを取得
     let attendances: Awaited<ReturnType<typeof cachedActions.getEventAttendances>> = [];
-    let payments: Awaited<ReturnType<typeof cachedActions.getEventPayments>> = [];
+    let paymentsData: Awaited<ReturnType<typeof cachedActions.getEventPayments>> | null = null;
     let participantsData: Awaited<ReturnType<typeof cachedActions.getEventParticipants>> | null =
       null;
 
     if (isOrganizer) {
       try {
         // 基本的な統計データ
-        [attendances, payments] = await Promise.all([
+        [attendances, paymentsData] = await Promise.all([
           cachedActions.getEventAttendances(params.id),
           cachedActions.getEventPayments(params.id),
         ]);
@@ -85,12 +85,12 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
           <EventDetail event={eventDetail} />
 
           {/* 主催者のみに参加者管理セクションを表示 */}
-          {isOrganizer && participantsData && (
+          {isOrganizer && participantsData && paymentsData && (
             <ParticipantsManagement
               eventId={params.id}
               eventData={eventDetail}
               initialAttendances={attendances}
-              initialPayments={payments}
+              initialPaymentsData={paymentsData}
               initialParticipantsData={participantsData}
             />
           )}

--- a/app/events/actions/export-participants-csv.ts
+++ b/app/events/actions/export-participants-csv.ts
@@ -316,7 +316,10 @@ function generateCsvContent(
  * セルの先頭が = + - @ \t などの場合、単一引用符 (') を付与して数式評価を防止する。
  */
 function sanitizeCsvValue(raw: string): string {
-  if (/^[=+\-@\t]/.test(raw)) {
+  // 先頭に空白(半角/全角)や制御文字が続いた後に = + - @ \t が現れる場合も Excel は数式として評価するため、
+  // \s は U+0009–U+000D, U+0020, U+00A0 などを含む。追加で制御文字(0x00-0x1F)を広くカバー。
+  // 例: " =SUM(...)" → 単一引用符付与
+  if (/^[\s\x00-\x1F]*[=+\-@\t]/u.test(raw)) {
     return `'${raw}`;
   }
   return raw;

--- a/app/events/actions/export-participants-csv.ts
+++ b/app/events/actions/export-participants-csv.ts
@@ -91,7 +91,7 @@ export async function exportParticipantsCsvAction(
 
     // フィルター適用
     if (filters?.search) {
-      query = query.or(`nickname.ilike.%${filters.search}%,email.ilike.%${filters.search}%`);
+      query = query.or(`nickname.ilike.%${filters.search}%, email.ilike.%${filters.search}%`);
     }
 
     if (filters?.attendanceStatus) {

--- a/app/events/actions/export-participants-csv.ts
+++ b/app/events/actions/export-participants-csv.ts
@@ -1,0 +1,318 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { SecureSupabaseClientFactory } from "@/lib/security/secure-client-factory.impl";
+import { AdminReason } from "@/lib/security/secure-client-factory.types";
+import { verifyEventAccess } from "@/lib/auth/event-authorization";
+import {
+  ExportParticipantsCsvParamsSchema,
+} from "@/lib/validation/participant-management";
+import { checkRateLimit, createRateLimitStore } from "@/lib/rate-limit";
+import { RATE_LIMIT_CONFIG } from "@/config/security";
+import { formatUtcToJstSafe } from "@/lib/utils/timezone";
+import { logger } from "@/lib/logging/app-logger";
+import { headers } from "next/headers";
+
+/**
+ * 参加者データCSVエクスポート
+ * MANAGE-004: 参加者データ CSV エクスポート（UTF-8 BOM）
+ *
+ * attendancesとpaymentsを結合してCSVファイルを生成
+ */
+export async function exportParticipantsCsvAction(
+  params: unknown
+): Promise<{
+  success: boolean;
+  csvContent?: string;
+  filename?: string;
+  error?: string;
+}> {
+  try {
+    // パラメータバリデーション
+    const validatedParams = ExportParticipantsCsvParamsSchema.parse(params);
+    const { eventId, filters, columns: inputColumns } = validatedParams;
+
+    const columns = inputColumns;
+
+    // レート制限チェック
+    const headersList = headers();
+    const ip = headersList.get("x-forwarded-for") || "unknown";
+
+    // レートリミットストア生成
+    const store = await createRateLimitStore();
+
+    const rateLimitResult = await checkRateLimit(
+      store,
+      `csv_export_${ip}_${eventId}`,
+      RATE_LIMIT_CONFIG.participantsCsvExport
+    );
+
+    if (!rateLimitResult.allowed) {
+      return {
+        success: false,
+        error: "レート制限: CSVエクスポートの実行回数が上限に達しました。しばらく待ってから再度お試しください。"
+      };
+    }
+
+    // 共通の認証・権限確認処理
+    const { user, eventId: validatedEventId } = await verifyEventAccess(eventId);
+
+    const supabase = createClient();
+    const factory = SecureSupabaseClientFactory.getInstance();
+    const admin = await factory.createAuditedAdminClient(
+      AdminReason.CSV_EXPORT,
+      "app/events/actions/export-participants-csv"
+    );
+
+    // CSVデータ取得用クエリの構築
+    let query = supabase
+      .from("attendances")
+      .select(`
+        id,
+        nickname,
+        email,
+        status,
+        created_at,
+        updated_at,
+        payments!left (
+          id,
+          method,
+          status,
+          amount,
+          paid_at,
+          created_at,
+          updated_at
+        )
+      `)
+      .eq("event_id", validatedEventId)
+      // 最新の決済 1 件に絞る
+      .order("updated_at", { foreignTable: "payments", ascending: false })
+      .limit(1, { foreignTable: "payments" })
+
+    // フィルター適用
+    if (filters?.search) {
+      query = query.or(`nickname.ilike.%${filters.search}%,email.ilike.%${filters.search}%`);
+    }
+
+    if (filters?.attendanceStatus) {
+      query = query.eq("status", filters.attendanceStatus);
+    }
+
+    // 決済方法フィルター（payments.method）
+    if (filters?.paymentMethod) {
+      query = query.eq("payments.method", filters.paymentMethod);
+    }
+
+    // 決済ステータスフィルター（payments.status）
+    if (filters?.paymentStatus) {
+      query = query.eq("payments.status", filters.paymentStatus);
+    }
+
+    // データ取得（ページネーションなし - 全件取得）
+    // ただし、大量データ対策として上限を設定
+    query = query.limit(1000); // 最大1,000件
+
+    const { data: participants, error: queryError } = await query;
+
+    if (queryError) {
+      logger.error("Failed to fetch participants for CSV export", {
+        eventId: validatedEventId,
+        userId: user.id,
+        error: queryError
+      });
+
+      return {
+        success: false,
+        error: "参加者データの取得に失敗しました。"
+      };
+    }
+
+    if (!participants || participants.length === 0) {
+      return {
+        success: false,
+        error: "エクスポート対象の参加者が見つかりません。"
+      };
+    }
+
+    // CSV生成
+    const csvContent = generateCsvContent(participants as any[], columns);
+
+    // ファイル名生成（participants-<eventId>-<yyyymmdd>.csv）
+    const now = new Date();
+    const dateStr = now.getFullYear().toString() +
+      (now.getMonth() + 1).toString().padStart(2, '0') +
+      now.getDate().toString().padStart(2, '0');
+    const filename = `participants-${validatedEventId}-${dateStr}.csv`;
+
+    // 監査ログ記録
+    await admin.from("system_logs").insert({
+      operation_type: "participants_csv_export",
+      details: {
+        event_id: validatedEventId,
+        user_id: user.id,
+        participant_count: participants.length,
+        filters: filters || {},
+        columns,
+        filename: filename,
+        ip_address: ip
+      }
+    });
+
+    logger.info("Participants CSV export completed", {
+      eventId: validatedEventId,
+      userId: user.id,
+      participantCount: participants.length,
+      filename: filename
+    });
+
+    return {
+      success: true,
+      csvContent,
+      filename
+    };
+
+  } catch (error) {
+    logger.error("Participants CSV export failed", {
+      error: error instanceof Error ? error.message : "Unknown error",
+      params
+    });
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "CSVエクスポートに失敗しました。"
+    };
+  }
+}
+
+/**
+ * CSV文字列を生成
+ * UTF-8 BOM付きで生成
+ */
+interface CsvParticipant {
+  id: string;
+  nickname: string;
+  email: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  payments?: Array<{
+    id: string;
+    method: string;
+    status: string;
+    amount: number;
+    paid_at: string | null;
+    created_at: string;
+    updated_at: string;
+  }> | null;
+}
+
+function generateCsvContent(
+  participants: CsvParticipant[],
+  columns: string[]
+): string {
+  // CSV ヘッダー行の生成
+  const headerMap: Record<string, string> = {
+    attendance_id: "参加ID",
+    nickname: "ニックネーム",
+    email: "メールアドレス",
+    status: "参加ステータス",
+    payment_method: "決済方法",
+    payment_status: "決済ステータス",
+    amount: "金額",
+    paid_at: "決済日時",
+    created_at: "登録日時",
+    updated_at: "更新日時"
+  };
+
+  const headers = columns.map(col => headerMap[col] || col);
+
+  // CSV行の生成
+  const rows = participants.map(participant => {
+    const latestPayment = (participant.payments as { [key: string]: any }[])?.[0] || null;
+
+    return columns.map(column => {
+      let value: string | number = '';
+
+      switch (column) {
+        case 'attendance_id':
+          value = participant.id;
+          break;
+        case 'nickname':
+          value = participant.nickname;
+          break;
+        case 'email':
+          value = participant.email;
+          break;
+        case 'status':
+          // 参加ステータスの日本語化
+          const statusMap: Record<string, string> = {
+            attending: "参加",
+            not_attending: "不参加",
+            maybe: "未定"
+          };
+          value = statusMap[participant.status] || participant.status;
+          break;
+        case 'payment_method':
+          if (latestPayment?.method) {
+            const methodMap: Record<string, string> = {
+              stripe: "オンライン決済",
+              cash: "現金"
+            };
+            value = methodMap[latestPayment.method] || latestPayment.method;
+          }
+          break;
+        case 'payment_status':
+          if (latestPayment?.status) {
+            const statusMap: Record<string, string> = {
+              pending: "未決済",
+              paid: "決済完了",
+              failed: "決済失敗",
+              received: "現金受領",
+              refunded: "返金済み",
+              waived: "免除",
+              completed: "完了"
+            };
+            value = statusMap[latestPayment.status] || latestPayment.status;
+          }
+          break;
+        case 'amount':
+          value = latestPayment?.amount || '';
+          break;
+        case 'paid_at':
+          value = latestPayment?.paid_at ?
+            formatUtcToJstSafe(latestPayment.paid_at, 'yyyy/MM/dd HH:mm') : '';
+          break;
+        case 'created_at':
+          value = formatUtcToJstSafe(participant.created_at, 'yyyy/MM/dd HH:mm');
+          break;
+        case 'updated_at':
+          value = formatUtcToJstSafe(participant.updated_at, 'yyyy/MM/dd HH:mm');
+          break;
+        default:
+          value = '';
+      }
+
+      // CSV形式用にエスケープ（ダブルクォートで囲み、内部のダブルクォートはエスケープ）
+      const strValue = sanitizeCsvValue(String(value ?? ''));
+      return `"${strValue.replace(/"/g, '""')}"`;
+    });
+  });
+
+  // CSV文字列の組み立て
+  const csvLines = [headers.map(h => `"${h}"`).join(','), ...rows.map(row => row.join(','))];
+  const csvString = csvLines.join('\n');
+
+  // UTF-8 BOMを付与
+  return '\uFEFF' + csvString;
+}
+
+/**
+ * Excel CSV Injection 対策
+ * セルの先頭が = + - @ \t などの場合、単一引用符 (') を付与して数式評価を防止する。
+ */
+function sanitizeCsvValue(raw: string): string {
+  if (/^[=+\-@\t]/.test(raw)) {
+    return `'${raw}`;
+  }
+  return raw;
+}

--- a/app/events/actions/get-event-participants.ts
+++ b/app/events/actions/get-event-participants.ts
@@ -117,7 +117,7 @@ export async function getEventParticipantsAction(
       status: "attending" | "not_attending" | "maybe";
       created_at: string;
       updated_at: string;
-      payments: {
+      payments: Array<{
         id: string;
         method: "stripe" | "cash";
         status: "pending" | "paid" | "failed" | "received" | "refunded" | "waived" | "completed";
@@ -126,18 +126,18 @@ export async function getEventParticipantsAction(
         version: number;
         created_at: string;
         updated_at: string;
-      } | null;
+      }> | null;
     };
 
     // データ変換（参加者ビュー形式に変換）
-    const participants: ParticipantView[] = (attendances || []).map((attendance: SupabaseAttendanceWithPayments) => {
-      const latestPayment = attendance.payments;
+    const participants: ParticipantView[] = (attendances as unknown as SupabaseAttendanceWithPayments[] || []).map((attendance) => {
+      const latestPayment = (attendance.payments || [])[0] || null;
 
       return {
         attendance_id: attendance.id,
         nickname: attendance.nickname,
         email: attendance.email,
-        attendance_status: attendance.status,
+        status: attendance.status,
         attendance_created_at: attendance.created_at,
         attendance_updated_at: attendance.updated_at,
         payment_id: latestPayment?.id || null,

--- a/app/events/actions/get-event-participants.ts
+++ b/app/events/actions/get-event-participants.ts
@@ -70,7 +70,6 @@ export async function getEventParticipantsAction(
         count: "exact",
         head: true,
       })
-      .limit(1, { foreignTable: "payments" })
       .eq("event_id", validatedEventId);
 
     // 検索条件（ニックネーム/メール部分一致）

--- a/app/events/actions/get-event-participants.ts
+++ b/app/events/actions/get-event-participants.ts
@@ -44,6 +44,7 @@ export async function getEventParticipantsAction(
           status,
           amount,
           paid_at,
+          version,
           created_at,
           updated_at
         )
@@ -122,6 +123,7 @@ export async function getEventParticipantsAction(
         status: "pending" | "paid" | "failed" | "received" | "refunded" | "waived" | "completed";
         amount: number;
         paid_at: string | null;
+        version: number;
         created_at: string;
         updated_at: string;
       } | null;
@@ -143,6 +145,7 @@ export async function getEventParticipantsAction(
         payment_status: latestPayment?.status || null,
         amount: latestPayment?.amount || null,
         paid_at: latestPayment?.paid_at || null,
+        payment_version: latestPayment?.version || null,
         payment_created_at: latestPayment?.created_at || null,
         payment_updated_at: latestPayment?.updated_at || null,
       };

--- a/app/events/actions/get-event-participants.ts
+++ b/app/events/actions/get-event-participants.ts
@@ -1,0 +1,246 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { verifyEventAccess, handleDatabaseError } from "@/lib/auth/event-authorization";
+import {
+  GetParticipantsParamsSchema,
+  type GetParticipantsResponse,
+  type ParticipantView
+} from "@/lib/validation/participant-management";
+import { logger } from "@/lib/logging/app-logger";
+
+/**
+ * イベント参加者詳細一覧取得
+ * MANAGE-001: 参加者一覧表示（検索/フィルター/ページング/ソート）
+ *
+ * attendancesとpaymentsを結合して完全な参加者情報を取得
+ */
+export async function getEventParticipantsAction(
+  params: unknown
+): Promise<GetParticipantsResponse> {
+  try {
+    // パラメータバリデーション
+    const validatedParams = GetParticipantsParamsSchema.parse(params);
+    const { eventId, search, attendanceStatus, paymentMethod, paymentStatus, sortField, sortOrder, page, limit } = validatedParams;
+
+    // 共通の認証・権限確認処理
+    const { user, eventId: validatedEventId } = await verifyEventAccess(eventId);
+
+    const supabase = createClient();
+
+    // ベースクエリの構築
+    let query = supabase
+      .from("attendances")
+      .select(`
+        id,
+        nickname,
+        email,
+        status,
+        created_at,
+        updated_at,
+        payments!left (
+          id,
+          method,
+          status,
+          amount,
+          paid_at,
+          created_at,
+          updated_at
+        )
+      `)
+      .eq("event_id", validatedEventId)
+      // 最新の決済 1 件に絞る
+      .order("updated_at", { foreignTable: "payments", ascending: false })
+      .limit(1, { foreignTable: "payments" });
+
+    // 検索条件（ニックネーム/メール部分一致）
+    if (search) {
+      query = query.or(`nickname.ilike.%${search}%, email.ilike.%${search}%`);
+    }
+
+    // 参加ステータスフィルター
+    if (attendanceStatus) {
+      query = query.eq("status", attendanceStatus);
+    }
+
+    // ソート処理（attendances側のフィールドのみ）
+    const attendanceSortFields = ["created_at", "updated_at", "nickname", "email", "status"];
+    if (attendanceSortFields.includes(sortField)) {
+      query = query.order(sortField, { ascending: sortOrder === "asc" });
+    } else {
+      // デフォルトソート
+      query = query.order("updated_at", { ascending: false });
+    }
+
+    // 件数取得用クエリ（同じ条件）
+    let countQuery = supabase
+      .from("attendances")
+      .select("id", { count: "exact", head: true })
+      .eq("event_id", validatedEventId);
+
+    if (search) {
+      countQuery = countQuery.or(`nickname.ilike.%${search}%, email.ilike.%${search}%`);
+    }
+
+    if (attendanceStatus) {
+      countQuery = countQuery.eq("status", attendanceStatus);
+    }
+
+    // ページネーション
+    const offset = (page - 1) * limit;
+    // paymentMethod / paymentStatus フィルタがある場合はクライアント側で再スライスするため
+    // Supabase へは range を適用しない（重複適用を防ぐ）
+    if (!paymentMethod && !paymentStatus) {
+      query = query.range(offset, offset + limit - 1);
+    }
+
+    // 並行実行
+    const [{ data: attendances, error: attendancesError }, { count, error: countError }] = await Promise.all([
+      query,
+      countQuery
+    ]);
+
+    if (attendancesError) {
+      handleDatabaseError(attendancesError, { eventId: validatedEventId, userId: user.id });
+    }
+
+    if (countError) {
+      handleDatabaseError(countError, { eventId: validatedEventId, userId: user.id });
+    }
+
+    // 実際のSupabaseクエリ結果に合わせた型定義
+    type SupabaseAttendanceWithPayments = {
+      id: string;
+      nickname: string;
+      email: string;
+      status: "attending" | "not_attending" | "maybe";
+      created_at: string;
+      updated_at: string;
+      payments: {
+        id: string;
+        method: "stripe" | "cash";
+        status: "pending" | "paid" | "failed" | "received" | "refunded" | "waived" | "completed";
+        amount: number;
+        paid_at: string | null;
+        created_at: string;
+        updated_at: string;
+      } | null;
+    };
+
+    // データ変換（参加者ビュー形式に変換）
+    const participants: ParticipantView[] = (attendances || []).map((attendance: SupabaseAttendanceWithPayments) => {
+      const latestPayment = attendance.payments;
+
+      return {
+        attendance_id: attendance.id,
+        nickname: attendance.nickname,
+        email: attendance.email,
+        attendance_status: attendance.status,
+        attendance_created_at: attendance.created_at,
+        attendance_updated_at: attendance.updated_at,
+        payment_id: latestPayment?.id || null,
+        payment_method: latestPayment?.method || null,
+        payment_status: latestPayment?.status || null,
+        amount: latestPayment?.amount || null,
+        paid_at: latestPayment?.paid_at || null,
+        payment_created_at: latestPayment?.created_at || null,
+        payment_updated_at: latestPayment?.updated_at || null,
+      };
+    });
+
+    // 決済フィルタリング（Supabaseクエリでは複雑なので、後処理で実行）
+    let filteredParticipants = participants;
+    const hasPaymentFilter = paymentMethod || paymentStatus;
+
+    if (paymentMethod) {
+      filteredParticipants = filteredParticipants.filter(p => p.payment_method === paymentMethod);
+    }
+
+    if (paymentStatus) {
+      filteredParticipants = filteredParticipants.filter(p => p.payment_status === paymentStatus);
+    }
+
+    // 決済関連のソート処理（後処理）
+    const paymentSortFields = ["payment_method", "payment_status", "paid_at"];
+    if (paymentSortFields.includes(sortField)) {
+      filteredParticipants.sort((a, b) => {
+        let aValue, bValue;
+
+        switch (sortField) {
+          case "payment_method":
+            aValue = a.payment_method || "";
+            bValue = b.payment_method || "";
+            break;
+          case "payment_status":
+            aValue = a.payment_status || "";
+            bValue = b.payment_status || "";
+            break;
+          case "paid_at":
+            aValue = a.paid_at ? new Date(a.paid_at).getTime() : 0;
+            bValue = b.paid_at ? new Date(b.paid_at).getTime() : 0;
+            break;
+          default:
+            return 0;
+        }
+
+        if (aValue < bValue) return sortOrder === "asc" ? -1 : 1;
+        if (aValue > bValue) return sortOrder === "asc" ? 1 : -1;
+        return 0;
+      });
+    }
+
+    // 件数計算：決済フィルターがある場合はフィルター後の全件数を使用
+    const totalCount = count || 0;
+    const effectiveTotal = hasPaymentFilter ? filteredParticipants.length : totalCount;
+
+    // ページネーション適用
+    const startIndex = (page - 1) * limit;
+    const paginatedParticipants = hasPaymentFilter
+      ? filteredParticipants.slice(startIndex, startIndex + limit)
+      : filteredParticipants;
+
+    const totalPages = Math.ceil(effectiveTotal / limit);
+
+    logger.info("Event participants retrieved", {
+      eventId: validatedEventId,
+      userId: user.id,
+      participantCount: filteredParticipants.length,
+      totalCount: effectiveTotal,
+      page,
+      filters: { search, attendanceStatus, paymentMethod, paymentStatus }
+    });
+
+    return {
+      participants: paginatedParticipants,
+      pagination: {
+        page,
+        limit,
+        total: effectiveTotal,
+        totalPages,
+        hasNext: page < totalPages,
+        hasPrev: page > 1,
+      },
+      filters: {
+        search,
+        attendanceStatus,
+        paymentMethod,
+        paymentStatus,
+      },
+      sort: {
+        field: sortField,
+        order: sortOrder,
+      },
+    };
+
+  } catch (error) {
+    logger.error("Failed to get event participants", {
+      error: error instanceof Error ? error.message : "Unknown error",
+      params
+    });
+
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error("Failed to get event participants");
+  }
+}

--- a/app/events/actions/get-event-payments.ts
+++ b/app/events/actions/get-event-payments.ts
@@ -39,7 +39,7 @@ export async function getEventPaymentsAction(eventId: string): Promise<GetEventP
       paid_at,
       created_at,
       updated_at,
-      attendances!inner()
+      attendances!inner(event_id)
     `
     )
     .eq("attendances.event_id", validatedEventId);

--- a/app/events/actions/get-event-payments.ts
+++ b/app/events/actions/get-event-payments.ts
@@ -2,46 +2,169 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { verifyEventAccess, handleDatabaseError } from "@/lib/auth/event-authorization";
+import {
+  GetEventPaymentsResponseSchema,
+  type GetEventPaymentsResponse,
+  type PaymentMethodSummary,
+  type PaymentStatusSummary,
+  type PaymentSummary,
+  PAYMENT_STATUS_VALUES,
+  PaymentStatusEnum,
+} from "@/lib/validation/participant-management";
+import type { z } from "zod";
+import { logger } from "@/lib/logging/app-logger";
 
-export async function getEventPaymentsAction(eventId: string) {
-  try {
-    // 共通の認証・権限確認処理
-    const { user, eventId: validatedEventId } = await verifyEventAccess(eventId);
+type PaymentStatus = z.infer<typeof PaymentStatusEnum>;
 
-    const supabase = createClient();
+/**
+ * イベント決済情報取得（集計付き）
+ * MANAGE-002: 決済状況確認/集計
+ */
+export async function getEventPaymentsAction(eventId: string): Promise<GetEventPaymentsResponse> {
+  // 認可チェック
+  const { user, eventId: validatedEventId } = await verifyEventAccess(eventId);
 
-    // 決済データ取得（attendancesテーブルを経由してイベントに紐づく決済を取得）
-    const { data: payments, error } = await supabase
-      .from("payments")
-      .select(
-        `
-        id,
-        method,
-        amount,
-        status,
-        attendance_id,
-        attendances!inner(event_id)
+  const supabase = createClient();
+
+  // 決済データ取得
+  const { data: payments, error } = await supabase
+    .from("payments")
+    .select(
       `
-      )
-      .eq("attendances.event_id", validatedEventId);
+      id,
+      method,
+      amount,
+      status,
+      attendance_id,
+      paid_at,
+      created_at,
+      updated_at,
+      attendances!inner()
+    `
+    )
+    .eq("attendances.event_id", validatedEventId);
 
-    if (error) {
-      handleDatabaseError(error, { eventId: validatedEventId, userId: user.id });
-    }
-
-    // attendancesの情報を除去してpayment情報のみ返す
-    const cleanedPayments = (payments || []).map((payment) => ({
-      id: payment.id,
-      method: payment.method,
-      amount: payment.amount,
-      status: payment.status,
-    }));
-
-    return cleanedPayments;
-  } catch (error) {
-    if (error instanceof Error) {
-      throw error;
-    }
-    throw new Error("Unknown error");
+  if (error) {
+    handleDatabaseError(error, { eventId: validatedEventId, userId: user.id });
   }
+
+  const cleanedPayments = (payments || []).map((payment) => ({
+    id: payment.id,
+    method: payment.method,
+    amount: payment.amount,
+    status: payment.status,
+    attendance_id: payment.attendance_id,
+    paid_at: payment.paid_at,
+    created_at: payment.created_at,
+    updated_at: payment.updated_at,
+  }));
+
+  const summary = calculatePaymentSummary(cleanedPayments);
+
+  const validatedResponse = GetEventPaymentsResponseSchema.parse({
+    payments: cleanedPayments,
+    summary,
+  });
+
+  logger.info("決済情報取得完了", {
+    eventId: validatedEventId,
+    userId: user.id,
+    paymentCount: cleanedPayments.length,
+    totalAmount: summary.totalAmount,
+  });
+
+  return validatedResponse;
+}
+
+/**
+ * 決済データから集計情報を計算
+ */
+function calculatePaymentSummary(payments: Array<{
+  method: "stripe" | "cash";
+  amount: number;
+  status: PaymentStatus;
+}>): PaymentSummary {
+  const totalPayments = payments.length;
+  const totalAmount = payments.reduce((sum, p) => sum + p.amount, 0);
+
+  // 方法別集計
+  const methodMap = new Map<"stripe" | "cash", { count: number; totalAmount: number }>();
+
+  // 初期化
+  methodMap.set("stripe", { count: 0, totalAmount: 0 });
+  methodMap.set("cash", { count: 0, totalAmount: 0 });
+
+  // ステータス別集計
+  const statusMap = new Map<PaymentStatus, { count: number; totalAmount: number }>();
+
+  // 初期化
+  PAYMENT_STATUS_VALUES.forEach((status) => {
+    statusMap.set(status as PaymentStatus, { count: 0, totalAmount: 0 });
+  });
+
+  // 決済済み・未決済集計用
+  let paidCount = 0;
+  let paidAmount = 0;
+  let unpaidCount = 0;
+  let unpaidAmount = 0;
+
+  // 決済済みステータス（paid, received, completed, waived）
+  // waived(免除)は管理者による意図的な決済完了として扱う
+  const paidStatuses = new Set<PaymentStatus>(["paid", "received", "completed", "waived"]);
+  // 未決済ステータス（pending, failed, refunded）
+  // refunded(返金済)は実質的に未収金のため未決済として扱う
+  const unpaidStatuses = new Set<PaymentStatus>(["pending", "failed", "refunded"]);
+
+  // 集計処理
+  payments.forEach((payment) => {
+    // 方法別集計
+    const methodStat = methodMap.get(payment.method)!;
+    methodStat.count += 1;
+    methodStat.totalAmount += payment.amount;
+
+    // ステータス別集計（未知ステータスはスキップし警告ログ）
+    const statusStat = statusMap.get(payment.status);
+    if (statusStat) {
+      statusStat.count += 1;
+      statusStat.totalAmount += payment.amount;
+    } else {
+      logger.warn("Unknown payment status encountered while aggregating", {
+        status: payment.status,
+      });
+    }
+
+    // 決済済み・未決済集計
+    if (paidStatuses.has(payment.status)) {
+      paidCount += 1;
+      paidAmount += payment.amount;
+    } else if (unpaidStatuses.has(payment.status)) {
+      unpaidCount += 1;
+      unpaidAmount += payment.amount;
+    }
+  });
+
+  // 方法別結果配列作成
+  const byMethod: PaymentMethodSummary[] = Array.from(methodMap.entries()).map(([method, stat]) => ({
+    method,
+    count: stat.count,
+    totalAmount: stat.totalAmount,
+  }));
+
+  // ステータス別結果配列作成（0件のものも含める）
+  const byStatus: PaymentStatusSummary[] = Array.from(statusMap.entries()).map(([status, stat]) => ({
+    status,
+    count: stat.count,
+    totalAmount: stat.totalAmount,
+  }));
+
+  return {
+    totalPayments,
+    totalAmount,
+    byMethod,
+    byStatus,
+    unpaidCount,
+    unpaidAmount,
+    paidCount,
+    paidAmount,
+  };
 }

--- a/app/events/actions/index.ts
+++ b/app/events/actions/index.ts
@@ -2,3 +2,4 @@ export { getEventsAction } from "./get-events";
 export { createEventAction } from "./create-event";
 export { updateEventAction } from "./update-event";
 export { generateInviteTokenAction } from "./generate-invite-token";
+export { exportParticipantsCsvAction } from "./export-participants-csv";

--- a/app/payments/actions/bulk-update-cash-status.ts
+++ b/app/payments/actions/bulk-update-cash-status.ts
@@ -16,10 +16,19 @@ import {
 } from "@/lib/types/server-actions";
 
 const inputSchema = z.object({
-  paymentId: z.string().uuid(),
+  paymentIds: z.array(z.string().uuid()).min(1).max(50), // 最大50件まで
   status: z.enum(["received", "waived"]),
   notes: z.string().max(1000).optional(),
 });
+
+type BulkUpdateResult = {
+  successCount: number;
+  failedCount: number;
+  failures: Array<{
+    paymentId: string;
+    error: string;
+  }>;
+};
 
 function mapPaymentError(type: PaymentErrorType): ErrorCode {
   switch (type) {
@@ -44,15 +53,14 @@ function mapPaymentError(type: PaymentErrorType): ErrorCode {
     case PaymentErrorType.DATABASE_ERROR:
       return ERROR_CODES.DATABASE_ERROR;
     case PaymentErrorType.STRIPE_API_ERROR:
-    case PaymentErrorType.WEBHOOK_PROCESSING_ERROR:
     default:
       return ERROR_CODES.INTERNAL_ERROR;
   }
 }
 
-export async function updateCashStatusAction(
+export async function bulkUpdateCashStatusAction(
   input: unknown
-): Promise<ServerActionResult<{ paymentId: string; status: "received" | "waived" }>> {
+): Promise<ServerActionResult<BulkUpdateResult>> {
   try {
     const parsed = inputSchema.safeParse(input);
     if (!parsed.success) {
@@ -60,7 +68,7 @@ export async function updateCashStatusAction(
         zodErrors: parsed.error.errors,
       });
     }
-    const { paymentId, status, notes } = parsed.data;
+    const { paymentIds, status, notes } = parsed.data;
 
     const factory = SecureSupabaseClientFactory.getInstance();
     const supabase = await factory.createAuthenticatedClient();
@@ -72,12 +80,12 @@ export async function updateCashStatusAction(
       return createErrorResponse(ERROR_CODES.UNAUTHORIZED, "認証が必要です。");
     }
 
-    // レート制限（ユーザー単位）
+    // レート制限（ユーザー単位、一括更新用の制限）
     try {
       const store = await createRateLimitStore();
       const rl = await checkRateLimit(
         store,
-        `payment_update_status_${user.id}`,
+        `payment_bulk_update_${user.id}`,
         RATE_LIMIT_CONFIG.paymentStatusUpdate
       );
       if (!rl.allowed) {
@@ -91,101 +99,116 @@ export async function updateCashStatusAction(
       // レート制限でのストア初期化失敗時はスキップ（安全側）
     }
 
-    // 対象決済の取得（主催者権限チェックは Validator に委譲）
-    const { data: paymentWithEvent, error: fetchError } = await supabase
-      .from("payments")
-      .select(`id, method, status, attendance_id`)
-      .eq("id", paymentId)
-      .single();
-
-    if (fetchError || !paymentWithEvent) {
-      return createErrorResponse(ERROR_CODES.NOT_FOUND, "決済レコードが見つかりません。");
-    }
-
-    // 基本的な権限チェック（RPC関数内でも再チェックされる）
-    await new PaymentValidator(supabase).validateAttendanceAccess(
-      paymentWithEvent.attendance_id,
-      user.id
-    );
-
-    if (paymentWithEvent.method !== "cash") {
-      return createErrorResponse(
-        ERROR_CODES.BUSINESS_RULE_VIOLATION,
-        "現金決済以外は手動更新できません。"
-      );
-    }
-
-    // 現在のバージョンを取得（権限チェックも兼ねる）
-    const { data: currentPayment, error: fetchPaymentError } = await supabase
+    // 対象決済の一括取得（主催者権限チェック用）
+    const { data: paymentsWithEvent, error: fetchError } = await supabase
       .from("payments")
       .select(`
-        version,
+        id,
         method,
+        status,
+        version,
+        attendance_id,
         attendances!inner (
           id,
+          event_id,
           events!inner (
             id,
             created_by
           )
         )
       `)
-      .eq("id", paymentId)
-      .single();
+      .in("id", paymentIds);
 
-    if (fetchPaymentError || !currentPayment) {
+    if (fetchError) {
+      return createErrorResponse(ERROR_CODES.DATABASE_ERROR, "決済レコードの取得に失敗しました。");
+    }
+
+    if (!paymentsWithEvent || paymentsWithEvent.length === 0) {
       return createErrorResponse(ERROR_CODES.NOT_FOUND, "決済レコードが見つかりません。");
     }
 
-    // 権限チェック：主催者のみ
-    const attendance = Array.isArray(currentPayment.attendances)
-      ? currentPayment.attendances[0]
-      : currentPayment.attendances;
-    const event = Array.isArray(attendance.events)
-      ? attendance.events[0]
-      : attendance.events;
+    // 権限チェック：すべての決済が同じユーザーのイベントに属していることを確認
+    const unauthorizedPayments = paymentsWithEvent.filter((payment) => {
+      const attendance = Array.isArray(payment.attendances) ? payment.attendances[0] : payment.attendances;
+      const event = Array.isArray(attendance.events) ? attendance.events[0] : attendance.events;
+      return event.created_by !== user.id;
+    });
 
-    if (event.created_by !== user.id) {
+    if (unauthorizedPayments.length > 0) {
       return createErrorResponse(ERROR_CODES.FORBIDDEN, "この操作を実行する権限がありません。");
     }
 
-    // 現金決済のみ
-    if (currentPayment.method !== "cash") {
-      return createErrorResponse(
-        ERROR_CODES.BUSINESS_RULE_VIOLATION,
-        "現金決済以外は手動更新できません。"
-      );
+    // 現金決済以外のフィルタリング
+    const nonCashPayments = paymentsWithEvent.filter((p) => p.method !== "cash");
+
+    // 部分成功を許容するため、非現金決済は failures に積むだけで処理続行
+    const initialFailures: BulkUpdateResult["failures"] = nonCashPayments.map((p) => ({
+      paymentId: p.id,
+      error: "現金決済以外は手動更新できません。",
+    }));
+
+    // 現金決済のみを抽出
+    const cashPayments = paymentsWithEvent.filter((p) => p.method === "cash");
+
+    if (cashPayments.length === 0) {
+      return createSuccessResponse({
+        successCount: 0,
+        failedCount: initialFailures.length,
+        failures: initialFailures,
+      });
     }
 
-    // 楽観的ロック付きRPCで更新
+    // 基本的なバリデーション（RPC関数内でも再実行される）
+    const validator = new PaymentValidator(supabase);
+    for (const payment of cashPayments) {
+      await validator.validateUpdatePaymentStatusParams({
+        paymentId: payment.id,
+        status
+      });
+    }
+
+    // 楽観的ロック対応の一括更新用RPCを使用
     const admin = await factory.createAuditedAdminClient(
       AdminReason.PAYMENT_PROCESSING,
-      "app/payments/actions/update-cash-status"
+      "app/payments/actions/bulk-update-cash-status"
     );
 
-    const { data: _rpcResult, error: rpcError } = await admin.rpc('rpc_update_payment_status_safe', {
-      p_payment_id: paymentId,
-      p_new_status: status,
-      p_expected_version: currentPayment.version,
+    // 一括更新用のデータを構築（version情報を含める）
+    const updateData = cashPayments.map(payment => ({
+      payment_id: payment.id,
+      expected_version: payment.version,
+      new_status: status
+    }));
+
+    const { data: rpcResult, error: rpcError } = await admin.rpc('rpc_bulk_update_payment_status_safe', {
+      p_payment_updates: updateData,
       p_user_id: user.id,
       p_notes: notes || null,
     });
 
     if (rpcError) {
-      // 楽観的ロック競合の場合
-      if (rpcError.code === '40001') {
-        return createErrorResponse(
-          ERROR_CODES.CONFLICT,
-          "他のユーザーによって同時に更新されました。最新の状態を確認してから再試行してください。"
-        );
-      }
-
       return createErrorResponse(
         ERROR_CODES.DATABASE_ERROR,
-        `決済ステータスの更新に失敗しました: ${rpcError.message}`
+        `一括決済ステータス更新に失敗しました: ${rpcError.message}`
       );
     }
 
-    return createSuccessResponse({ paymentId, status });
+    // RPC結果をレスポンス形式に変換
+    const rpcFailures: BulkUpdateResult["failures"] = (rpcResult.failures || []).map((f: {
+      payment_id: string;
+      error_message: string;
+    }) => ({
+      paymentId: f.payment_id,
+      error: f.error_message,
+    }));
+
+    const result: BulkUpdateResult = {
+      successCount: rpcResult.success_count || 0,
+      failedCount: (rpcResult.failure_count || 0) + initialFailures.length,
+      failures: [...initialFailures, ...rpcFailures],
+    };
+
+    return createSuccessResponse(result);
   } catch (error) {
     if (error instanceof PaymentError) {
       return createErrorResponse(mapPaymentError(error.type), error.message);

--- a/components/events/event-stats.tsx
+++ b/components/events/event-stats.tsx
@@ -1,17 +1,12 @@
 import React from "react";
 import type { Event, Attendance, Payment } from "@/types/models";
 
-// EventStats専用の型定義 - 共通型をベースに最小限の拡張
-interface EventStatsEventData extends Event {
-  organizer_id: string; // Event詳細ページで追加されるフィールド
-}
-
 // 統計表示に必要な最小限のフィールドのみを抽出
 type EventStatsAttendanceData = Pick<Attendance, "id" | "status">;
 type EventStatsPaymentData = Pick<Payment, "id" | "method" | "amount" | "status">;
 
 interface EventStatsProps {
-  eventData: EventStatsEventData;
+  eventData: Event;
   attendances: EventStatsAttendanceData[];
   payments: EventStatsPaymentData[];
 }

--- a/components/events/participants-management.tsx
+++ b/components/events/participants-management.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { useState, useCallback } from "react";
+import { ParticipantsTable } from "./participants-table";
+import { EventStats } from "./event-stats";
+import { useToast } from "@/components/ui/use-toast";
+import { getEventParticipantsAction } from "@/app/events/actions/get-event-participants";
+import type {
+  GetParticipantsResponse,
+  GetParticipantsParams,
+} from "@/lib/validation/participant-management";
+import type { Event, Attendance, Payment } from "@/types/models";
+
+interface ParticipantsManagementProps {
+  eventId: string;
+  eventData: Event & { organizer_id: string };
+  initialAttendances: Pick<Attendance, "id" | "status">[];
+  initialPayments: Pick<Payment, "id" | "method" | "amount" | "status">[];
+  initialParticipantsData: GetParticipantsResponse;
+}
+
+export function ParticipantsManagement({
+  eventId,
+  eventData,
+  initialAttendances,
+  initialPayments,
+  initialParticipantsData,
+}: ParticipantsManagementProps) {
+  const [participantsData, setParticipantsData] =
+    useState<GetParticipantsResponse>(initialParticipantsData);
+  const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
+
+  // パラメータ変更ハンドラー
+  const handleParamsChange = useCallback(
+    async (newParams: Partial<GetParticipantsParams>) => {
+      setIsLoading(true);
+
+      try {
+        const currentParams = {
+          eventId,
+          search: participantsData.filters.search,
+          attendanceStatus: participantsData.filters.attendanceStatus,
+          paymentMethod: participantsData.filters.paymentMethod,
+          paymentStatus: participantsData.filters.paymentStatus,
+          sortField: participantsData.sort.field,
+          sortOrder: participantsData.sort.order,
+          page: participantsData.pagination.page,
+          limit: participantsData.pagination.limit,
+          ...newParams,
+        };
+
+        const updatedData = await getEventParticipantsAction(currentParams);
+        setParticipantsData(updatedData);
+      } catch (error) {
+        console.error("Failed to update participants data:", error);
+        toast({
+          title: "エラーが発生しました",
+          description: "参加者データの取得に失敗しました。",
+          variant: "destructive",
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [eventId, participantsData, toast]
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* イベント統計 */}
+      <EventStats
+        eventData={eventData}
+        attendances={initialAttendances}
+        payments={initialPayments}
+      />
+
+      {/* 参加者一覧テーブル */}
+      <ParticipantsTable
+        eventId={eventId}
+        initialData={participantsData}
+        onParamsChange={handleParamsChange}
+        isLoading={isLoading}
+      />
+    </div>
+  );
+}

--- a/components/events/participants-management.tsx
+++ b/components/events/participants-management.tsx
@@ -94,6 +94,11 @@ export function ParticipantsManagement({
     [eventId, participantsData, toast, refreshPaymentsData]
   );
 
+  // 決済・参加者の両方をまとめて再取得
+  const refreshAllData = useCallback(async () => {
+    await handleParamsChange({});
+  }, [handleParamsChange]);
+
   return (
     <div className="space-y-6">
       {/* イベント統計 */}
@@ -112,7 +117,7 @@ export function ParticipantsManagement({
         initialData={participantsData}
         onParamsChange={handleParamsChange}
         isLoading={isLoading}
-        onPaymentStatusUpdate={refreshPaymentsData}
+        onPaymentStatusUpdate={refreshAllData}
       />
     </div>
   );

--- a/components/events/participants-management.tsx
+++ b/components/events/participants-management.tsx
@@ -16,7 +16,7 @@ import type { Event, Attendance } from "@/types/models";
 
 interface ParticipantsManagementProps {
   eventId: string;
-  eventData: Event & { organizer_id: string };
+  eventData: Event;
   initialAttendances: Pick<Attendance, "id" | "status">[];
   initialPaymentsData: GetEventPaymentsResponse;
   initialParticipantsData: GetParticipantsResponse;

--- a/components/events/participants-management.tsx
+++ b/components/events/participants-management.tsx
@@ -100,12 +100,7 @@ export function ParticipantsManagement({
       <EventStats
         eventData={eventData}
         attendances={initialAttendances}
-        payments={paymentsData.payments.map((p) => ({
-          id: p.id,
-          method: p.method,
-          amount: p.amount,
-          status: p.status,
-        }))}
+        payments={paymentsData.payments}
       />
 
       {/* 決済状況サマリー（MANAGE-002新機能） */}

--- a/components/events/participants-table.tsx
+++ b/components/events/participants-table.tsx
@@ -406,7 +406,7 @@ export function ParticipantsTable({
       // 注意喚起トースト
       toast({
         title: "CSV エクスポート",
-        description: "個人情報の取り扱いには十分注意してください。",
+        description: "個人情報の取り扱いには十分注意してください。(最大 1,000 件まで) ",
         duration: 3000,
       });
 
@@ -423,24 +423,40 @@ export function ParticipantsTable({
         filters,
       });
 
-      if (result.success && result.csvContent && result.filename) {
-        // CSVファイルをダウンロード
-        const blob = new Blob([result.csvContent], { type: "text/csv;charset=utf-8;" });
-        const link = document.createElement("a");
-        const url = URL.createObjectURL(blob);
+      if (result.success) {
+        if (result.csvContent && result.csvContent.length > 0) {
+          // CSVファイルをダウンロード
+          const blob = new Blob([result.csvContent], { type: "text/csv;charset=utf-8;" });
+          const link = document.createElement("a");
+          const url = URL.createObjectURL(blob);
 
-        link.setAttribute("href", url);
-        link.setAttribute("download", result.filename);
-        link.style.visibility = "hidden";
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(url);
+          link.setAttribute("href", url);
+          link.setAttribute("download", result.filename ?? "participants.csv");
+          link.style.visibility = "hidden";
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+          URL.revokeObjectURL(url);
 
-        toast({
-          title: "エクスポート完了",
-          description: `${result.filename} をダウンロードしました。`,
-        });
+          toast({
+            title: "エクスポート完了",
+            description: `${result.filename ?? "participants.csv"} をダウンロードしました。`,
+          });
+
+          if (result.truncated) {
+            toast({
+              title: "注意: 一部データを省略",
+              description:
+                "1,001 件以上のデータが存在したため、先頭 1,000 件のみを出力しました。フィルターで範囲を絞って再度エクスポートしてください。",
+            });
+          }
+        } else {
+          // 対象 0 件
+          toast({
+            title: "対象データなし",
+            description: "エクスポート対象の参加者がいませんでした。",
+          });
+        }
       } else {
         toast({
           title: "エクスポート失敗",

--- a/components/events/participants-table.tsx
+++ b/components/events/participants-table.tsx
@@ -240,11 +240,6 @@ export function ParticipantsTable({
     setIsUpdatingStatus(true);
     setBulkUpdateMode(status);
 
-    // 現在選択されている決済の最新versionを含めて更新
-    const _selectedPayments = initialData.participants.filter(
-      (p) => p.payment_id && selectedPaymentIds.includes(p.payment_id)
-    );
-
     try {
       const result = await bulkUpdateCashStatusAction({
         paymentIds: selectedPaymentIds,

--- a/components/events/participants-table.tsx
+++ b/components/events/participants-table.tsx
@@ -1,0 +1,490 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+// HTMLテーブルを使用するため、外部Tableコンポーネントは不要
+import { Search, Filter, Download, ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+import { format, parseISO } from "date-fns";
+import { ja } from "date-fns/locale";
+import type {
+  GetParticipantsResponse,
+  GetParticipantsParams,
+} from "@/lib/validation/participant-management";
+
+interface ParticipantsTableProps {
+  eventId: string;
+  initialData: GetParticipantsResponse;
+  onParamsChange: (params: Partial<GetParticipantsParams>) => void;
+  isLoading?: boolean;
+}
+
+export function ParticipantsTable({
+  initialData,
+  onParamsChange,
+  isLoading = false,
+}: ParticipantsTableProps) {
+  const [searchQuery, setSearchQuery] = useState(initialData.filters.search || "");
+  const [attendanceFilter, setAttendanceFilter] = useState<string>(
+    initialData.filters.attendanceStatus || ""
+  );
+  const [paymentMethodFilter, setPaymentMethodFilter] = useState<string>(
+    initialData.filters.paymentMethod || ""
+  );
+  const [paymentStatusFilter, setPaymentStatusFilter] = useState<string>(
+    initialData.filters.paymentStatus || ""
+  );
+  const [currentSort, setCurrentSort] = useState({
+    field: initialData.sort.field,
+    order: initialData.sort.order,
+  });
+
+  // Props変更時にローカルstateを同期
+  useEffect(() => {
+    setSearchQuery(initialData.filters.search || "");
+    setAttendanceFilter(initialData.filters.attendanceStatus || "");
+    setPaymentMethodFilter(initialData.filters.paymentMethod || "");
+    setPaymentStatusFilter(initialData.filters.paymentStatus || "");
+    setCurrentSort({
+      field: initialData.sort.field,
+      order: initialData.sort.order,
+    });
+  }, [initialData]);
+
+  // フィルターハンドラー
+  const handleSearch = () => {
+    onParamsChange({
+      search: searchQuery || undefined,
+      page: 1, // 検索時はページを1に戻す
+    });
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery("");
+    onParamsChange({ search: undefined, page: 1 });
+  };
+
+  const handleAttendanceFilter = (value: string) => {
+    setAttendanceFilter(value);
+    onParamsChange({
+      attendanceStatus:
+        value === "all" ? undefined : (value as "attending" | "not_attending" | "maybe"),
+      page: 1,
+    });
+  };
+
+  const handlePaymentMethodFilter = (value: string) => {
+    setPaymentMethodFilter(value);
+    onParamsChange({
+      paymentMethod: value === "all" ? undefined : (value as "stripe" | "cash"),
+      page: 1,
+    });
+  };
+
+  const handlePaymentStatusFilter = (value: string) => {
+    setPaymentStatusFilter(value);
+    onParamsChange({
+      paymentStatus:
+        value === "all"
+          ? undefined
+          : (value as
+              | "pending"
+              | "paid"
+              | "failed"
+              | "received"
+              | "refunded"
+              | "waived"
+              | "completed"),
+      page: 1,
+    });
+  };
+
+  // ソートハンドラー
+  const handleSort = (field: GetParticipantsParams["sortField"]) => {
+    const newOrder: "asc" | "desc" =
+      currentSort.field === field && currentSort.order === "desc" ? "asc" : "desc";
+    const newSort = { field, order: newOrder };
+    setCurrentSort(newSort);
+    onParamsChange({
+      sortField: field,
+      sortOrder: newOrder,
+      page: 1,
+    });
+  };
+
+  // ページネーションハンドラー
+  const handlePageChange = (newPage: number) => {
+    onParamsChange({ page: newPage });
+  };
+
+  // ステータスバッジのスタイル
+  const getAttendanceStatusBadge = (status: string) => {
+    switch (status) {
+      case "attending":
+        return (
+          <Badge variant="default" className="bg-blue-100 text-blue-800">
+            参加予定
+          </Badge>
+        );
+      case "not_attending":
+        return (
+          <Badge variant="secondary" className="bg-red-100 text-red-800">
+            不参加
+          </Badge>
+        );
+      case "maybe":
+        return (
+          <Badge variant="outline" className="bg-yellow-100 text-yellow-800">
+            未定
+          </Badge>
+        );
+      default:
+        return <Badge variant="outline">{status}</Badge>;
+    }
+  };
+
+  const getPaymentStatusBadge = (status: string | null) => {
+    if (!status)
+      return (
+        <Badge variant="outline" className="bg-gray-100 text-gray-600">
+          未登録
+        </Badge>
+      );
+
+    switch (status) {
+      case "paid":
+        return (
+          <Badge variant="default" className="bg-green-100 text-green-800">
+            支払済み
+          </Badge>
+        );
+      case "received":
+        return (
+          <Badge variant="default" className="bg-green-100 text-green-800">
+            受領済み
+          </Badge>
+        );
+      case "completed":
+        return (
+          <Badge variant="default" className="bg-green-100 text-green-800">
+            完了
+          </Badge>
+        );
+      case "pending":
+        return (
+          <Badge variant="outline" className="bg-yellow-100 text-yellow-800">
+            未決済
+          </Badge>
+        );
+      case "failed":
+        return (
+          <Badge variant="secondary" className="bg-red-100 text-red-800">
+            失敗
+          </Badge>
+        );
+      case "refunded":
+        return (
+          <Badge variant="secondary" className="bg-red-100 text-red-800">
+            返金済み
+          </Badge>
+        );
+      case "waived":
+        return (
+          <Badge variant="outline" className="bg-gray-100 text-gray-600">
+            免除
+          </Badge>
+        );
+      default:
+        return <Badge variant="outline">{status}</Badge>;
+    }
+  };
+
+  const getPaymentMethodBadge = (method: string | null) => {
+    if (!method) return null;
+
+    switch (method) {
+      case "stripe":
+        return (
+          <Badge variant="outline" className="bg-purple-100 text-purple-800">
+            カード
+          </Badge>
+        );
+      case "cash":
+        return (
+          <Badge variant="outline" className="bg-orange-100 text-orange-800">
+            現金
+          </Badge>
+        );
+      default:
+        return <Badge variant="outline">{method}</Badge>;
+    }
+  };
+
+  // 日付フォーマット
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return "-";
+    try {
+      return format(parseISO(dateString), "MM/dd HH:mm", { locale: ja });
+    } catch {
+      return "-";
+    }
+  };
+
+  // 金額フォーマット
+  const formatAmount = (amount: number | null) => {
+    if (amount === null) return "-";
+    return `¥${amount.toLocaleString()}`;
+  };
+
+  const { participants, pagination } = initialData;
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <div className="flex flex-col space-y-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
+          <CardTitle className="flex items-center gap-2">
+            参加者一覧
+            {isLoading && <RefreshCw className="h-4 w-4 animate-spin" />}
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" disabled={isLoading}>
+              <Download className="h-4 w-4 mr-2" />
+              CSV出力
+            </Button>
+          </div>
+        </div>
+
+        {/* 検索・フィルターエリア */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          {/* 検索 */}
+          <div className="flex flex-1 items-center gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <Input
+                placeholder="ニックネーム、メールで検索..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                className="pl-10"
+                disabled={isLoading}
+              />
+            </div>
+            <Button onClick={handleSearch} size="sm" disabled={isLoading}>
+              検索
+            </Button>
+            {(searchQuery || initialData.filters.search) && (
+              <Button onClick={handleClearSearch} variant="outline" size="sm" disabled={isLoading}>
+                クリア
+              </Button>
+            )}
+          </div>
+
+          {/* フィルター */}
+          <div className="flex items-center gap-2">
+            <Filter className="h-4 w-4 text-gray-400" />
+
+            <Select
+              value={attendanceFilter}
+              onValueChange={handleAttendanceFilter}
+              disabled={isLoading}
+            >
+              <SelectTrigger className="w-[120px]">
+                <SelectValue placeholder="参加状況" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">全て</SelectItem>
+                <SelectItem value="attending">参加予定</SelectItem>
+                <SelectItem value="not_attending">不参加</SelectItem>
+                <SelectItem value="maybe">未定</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={paymentMethodFilter}
+              onValueChange={handlePaymentMethodFilter}
+              disabled={isLoading}
+            >
+              <SelectTrigger className="w-[100px]">
+                <SelectValue placeholder="決済方法" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">全て</SelectItem>
+                <SelectItem value="stripe">カード</SelectItem>
+                <SelectItem value="cash">現金</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={paymentStatusFilter}
+              onValueChange={handlePaymentStatusFilter}
+              disabled={isLoading}
+            >
+              <SelectTrigger className="w-[120px]">
+                <SelectValue placeholder="決済状況" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">全て</SelectItem>
+                <SelectItem value="paid">支払済み</SelectItem>
+                <SelectItem value="received">受領済み</SelectItem>
+                <SelectItem value="completed">完了</SelectItem>
+                <SelectItem value="pending">未決済</SelectItem>
+                <SelectItem value="failed">失敗</SelectItem>
+                <SelectItem value="refunded">返金済み</SelectItem>
+                <SelectItem value="waived">免除</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {/* テーブル */}
+        <div className="rounded-md border overflow-x-auto">
+          <table className="w-full">
+            <thead className="bg-gray-50">
+              <tr>
+                <th
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort("nickname")}
+                >
+                  ニックネーム
+                  {currentSort.field === "nickname" && (
+                    <span className="ml-1">{currentSort.order === "asc" ? "↑" : "↓"}</span>
+                  )}
+                </th>
+                <th
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort("email")}
+                >
+                  メール
+                  {currentSort.field === "email" && (
+                    <span className="ml-1">{currentSort.order === "asc" ? "↑" : "↓"}</span>
+                  )}
+                </th>
+                <th
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort("status")}
+                >
+                  参加状況
+                  {currentSort.field === "status" && (
+                    <span className="ml-1">{currentSort.order === "asc" ? "↑" : "↓"}</span>
+                  )}
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  決済方法
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  決済状況
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  金額
+                </th>
+                <th
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort("paid_at")}
+                >
+                  決済日時
+                  {currentSort.field === "paid_at" && (
+                    <span className="ml-1">{currentSort.order === "asc" ? "↑" : "↓"}</span>
+                  )}
+                </th>
+                <th
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                  onClick={() => handleSort("updated_at")}
+                >
+                  更新日時
+                  {currentSort.field === "updated_at" && (
+                    <span className="ml-1">{currentSort.order === "asc" ? "↑" : "↓"}</span>
+                  )}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {participants.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="px-4 py-8 text-center text-gray-500">
+                    {isLoading ? "読み込み中..." : "参加者が見つかりません"}
+                  </td>
+                </tr>
+              ) : (
+                participants.map((participant) => (
+                  <tr key={participant.attendance_id} className="hover:bg-gray-50">
+                    <td className="px-4 py-4 whitespace-nowrap font-medium text-gray-900">
+                      {participant.nickname}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600">
+                      {participant.email}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap">
+                      {getAttendanceStatusBadge(participant.attendance_status)}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap">
+                      {getPaymentMethodBadge(participant.payment_method)}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap">
+                      {getPaymentStatusBadge(participant.payment_status)}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {formatAmount(participant.amount)}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600">
+                      {formatDate(participant.paid_at)}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600">
+                      {formatDate(participant.attendance_updated_at)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* ページネーション */}
+        {pagination.totalPages > 1 && (
+          <div className="flex items-center justify-between mt-4">
+            <div className="text-sm text-gray-600">
+              {pagination.total}件中 {(pagination.page - 1) * pagination.limit + 1}-
+              {Math.min(pagination.page * pagination.limit, pagination.total)}件を表示
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handlePageChange(pagination.page - 1)}
+                disabled={!pagination.hasPrev || isLoading}
+              >
+                <ChevronLeft className="h-4 w-4" />
+                前へ
+              </Button>
+
+              <span className="text-sm">
+                {pagination.page} / {pagination.totalPages}
+              </span>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handlePageChange(pagination.page + 1)}
+                disabled={!pagination.hasNext || isLoading}
+              >
+                次へ
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/events/participants-table.tsx
+++ b/components/events/participants-table.tsx
@@ -418,9 +418,9 @@ export function ParticipantsTable({
       // 現在のフィルター条件でエクスポート
       const filters = {
         search: searchQuery || undefined,
-        attendanceStatus: attendanceFilter || undefined,
-        paymentMethod: paymentMethodFilter || undefined,
-        paymentStatus: paymentStatusFilter || undefined,
+        attendanceStatus: attendanceFilter === "all" ? undefined : attendanceFilter || undefined,
+        paymentMethod: paymentMethodFilter === "all" ? undefined : paymentMethodFilter || undefined,
+        paymentStatus: paymentStatusFilter === "all" ? undefined : paymentStatusFilter || undefined,
       };
 
       const result = await exportParticipantsCsvAction({

--- a/components/events/payment-summary.tsx
+++ b/components/events/payment-summary.tsx
@@ -77,7 +77,8 @@ export function PaymentSummary({ summary, isLoading = false }: PaymentSummaryPro
             <div className="text-2xl font-bold text-green-600" data-testid="total-amount">
               ¥{summary.totalAmount.toLocaleString()}
             </div>
-            <div className="text-sm text-gray-600">決済総額</div>
+            {/* 決済総額は未決済・失敗を含む全ステータス合算のためラベルを明確化 */}
+            <div className="text-sm text-gray-600">総金額（全ステータス）</div>
           </div>
           <div className="text-center p-4 bg-emerald-50 rounded-lg">
             <div

--- a/components/events/payment-summary.tsx
+++ b/components/events/payment-summary.tsx
@@ -3,8 +3,9 @@
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { CreditCard, Banknote, AlertTriangle, CheckCircle } from "lucide-react";
+import { CreditCard, Banknote, AlertTriangle, CheckCircle, Info } from "lucide-react";
 import type { PaymentSummary as PaymentSummaryType } from "@/lib/validation/participant-management";
+import { TooltipContent, TooltipTrigger, TooltipWrapper } from "@/components/ui/tooltip";
 
 interface PaymentSummaryProps {
   summary: PaymentSummaryType;
@@ -77,8 +78,18 @@ export function PaymentSummary({ summary, isLoading = false }: PaymentSummaryPro
             <div className="text-2xl font-bold text-green-600" data-testid="total-amount">
               ¥{summary.totalAmount.toLocaleString()}
             </div>
-            {/* 決済総額は未決済・失敗を含む全ステータス合算のためラベルを明確化 */}
-            <div className="text-sm text-gray-600">総金額（全ステータス）</div>
+            {/* 決済総額は未決済・失敗を含む全ステータス合算。参加者ごとに最新取引のみ集計である旨をツールチップで補足 */}
+            <div className="flex items-center justify-center gap-1 text-sm text-gray-600">
+              <span>総金額（全ステータス）</span>
+              <TooltipWrapper>
+                <TooltipTrigger asChild>
+                  <Info className="w-4 h-4 cursor-pointer text-gray-400" aria-label="説明" />
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  各参加者の最新取引 1 件のみを合算した金額です
+                </TooltipContent>
+              </TooltipWrapper>
+            </div>
           </div>
           <div className="text-center p-4 bg-emerald-50 rounded-lg">
             <div

--- a/components/events/payment-summary.tsx
+++ b/components/events/payment-summary.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { CreditCard, Banknote, AlertTriangle, CheckCircle } from "lucide-react";
+import type { PaymentSummary as PaymentSummaryType } from "@/lib/validation/participant-management";
+
+interface PaymentSummaryProps {
+  summary: PaymentSummaryType;
+  isLoading?: boolean;
+}
+
+export function PaymentSummary({ summary, isLoading = false }: PaymentSummaryProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>決済状況</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="animate-pulse space-y-4">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="h-16 bg-gray-200 rounded-lg"></div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // 方法別データの準備
+  const stripeData = summary.byMethod.find((m) => m.method === "stripe");
+  const cashData = summary.byMethod.find((m) => m.method === "cash");
+
+  // 未決済ハイライト判定
+  const hasUnpaidPayments = summary.unpaidCount > 0;
+
+  const STATUS_META: Record<
+    PaymentSummaryType["byStatus"][number]["status"],
+    { bg: string; text: string; label: string }
+  > = {
+    paid: { bg: "bg-blue-50", text: "text-blue-600", label: "Stripe決済済み" },
+    received: { bg: "bg-green-50", text: "text-green-600", label: "現金受領済み" },
+    completed: { bg: "bg-emerald-50", text: "text-emerald-600", label: "完了" },
+    pending: { bg: "bg-yellow-50", text: "text-yellow-600", label: "未決済" },
+    failed: { bg: "bg-red-50", text: "text-red-600", label: "失敗" },
+    refunded: { bg: "bg-purple-50", text: "text-purple-600", label: "返金済み" },
+    waived: { bg: "bg-indigo-50", text: "text-indigo-600", label: "免除" },
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          決済状況
+          {hasUnpaidPayments && (
+            <Badge variant="destructive" className="ml-2">
+              <AlertTriangle className="w-3 h-3 mr-1" />
+              未決済あり
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* 全体サマリー */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="text-center p-4 bg-blue-50 rounded-lg">
+            <div className="text-2xl font-bold text-blue-600" data-testid="total-payments">
+              {summary.totalPayments}
+            </div>
+            <div className="text-sm text-gray-600">総決済数</div>
+          </div>
+          <div className="text-center p-4 bg-green-50 rounded-lg">
+            <div className="text-2xl font-bold text-green-600" data-testid="total-amount">
+              ¥{summary.totalAmount.toLocaleString()}
+            </div>
+            <div className="text-sm text-gray-600">決済総額</div>
+          </div>
+          <div className="text-center p-4 bg-emerald-50 rounded-lg">
+            <div
+              className="text-2xl font-bold text-emerald-600 flex items-center justify-center gap-1"
+              data-testid="paid-summary"
+            >
+              <CheckCircle className="w-5 h-5" />
+              {summary.paidCount}
+            </div>
+            <div className="text-sm text-gray-600">
+              決済済み・¥{summary.paidAmount.toLocaleString()}
+            </div>
+          </div>
+          <div
+            className={`text-center p-4 rounded-lg ${hasUnpaidPayments ? "bg-red-50" : "bg-gray-50"}`}
+          >
+            <div
+              className={`text-2xl font-bold flex items-center justify-center gap-1 ${hasUnpaidPayments ? "text-red-600" : "text-gray-600"}`}
+              data-testid="unpaid-summary"
+            >
+              {hasUnpaidPayments && <AlertTriangle className="w-5 h-5" />}
+              {summary.unpaidCount}
+            </div>
+            <div className="text-sm text-gray-600">
+              未決済・¥{summary.unpaidAmount.toLocaleString()}
+            </div>
+          </div>
+        </div>
+
+        {/* 決済方法別 */}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">決済方法別</h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="p-4 border rounded-lg">
+              <div className="flex items-center gap-2 mb-2">
+                <CreditCard className="w-5 h-5 text-blue-600" />
+                <span className="font-medium text-gray-900">Stripe決済</span>
+              </div>
+              <div className="space-y-1">
+                <div className="text-2xl font-bold text-blue-600" data-testid="stripe-count">
+                  {stripeData?.count || 0}件
+                </div>
+                <div className="text-sm text-gray-600" data-testid="stripe-amount">
+                  ¥{(stripeData?.totalAmount || 0).toLocaleString()}
+                </div>
+              </div>
+            </div>
+            <div className="p-4 border rounded-lg">
+              <div className="flex items-center gap-2 mb-2">
+                <Banknote className="w-5 h-5 text-green-600" />
+                <span className="font-medium text-gray-900">現金決済</span>
+              </div>
+              <div className="space-y-1">
+                <div className="text-2xl font-bold text-green-600" data-testid="cash-count">
+                  {cashData?.count || 0}件
+                </div>
+                <div className="text-sm text-gray-600" data-testid="cash-amount">
+                  ¥{(cashData?.totalAmount || 0).toLocaleString()}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ステータス別詳細（0件でないもののみ表示） */}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">ステータス別内訳</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {summary.byStatus
+              .filter((s) => s.count > 0)
+              .map((status) => {
+                const meta = STATUS_META[status.status];
+                return (
+                  <div key={status.status} className={`text-center p-3 ${meta.bg} rounded-lg`}>
+                    <div
+                      className={`text-lg font-bold ${meta.text}`}
+                      data-testid={`status-${status.status}-count`}
+                    >
+                      {status.count}
+                    </div>
+                    <div className="text-xs text-gray-600 mb-1">{meta.label}</div>
+                    <div
+                      className="text-xs text-gray-500"
+                      data-testid={`status-${status.status}-amount`}
+                    >
+                      ¥{status.totalAmount.toLocaleString()}
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/events/payment-summary.tsx
+++ b/components/events/payment-summary.tsx
@@ -55,7 +55,7 @@ export function PaymentSummary({ summary, isLoading = false }: PaymentSummaryPro
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
-          決済状況
+          決済状況（イベント全体）
           {hasUnpaidPayments && (
             <Badge variant="destructive" className="ml-2">
               <AlertTriangle className="w-3 h-3 mr-1" />

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const TooltipRoot = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipPortal = TooltipPrimitive.Portal;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPortal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPortal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export {
+  TooltipProvider as Tooltip,
+  TooltipRoot as TooltipWrapper,
+  TooltipTrigger,
+  TooltipContent,
+};

--- a/config/security.ts
+++ b/config/security.ts
@@ -97,6 +97,13 @@ export const RATE_LIMIT_CONFIG = {
     maxAttempts: 5, // 最大5回（より慎重）
     blockDurationMs: 5 * 60 * 1000, // 5分ブロック
   } as RateLimitConfig,
+
+  // 参加者CSVエクスポート（内部UI）
+  participantsCsvExport: {
+    windowMs: 5 * 60 * 1000, // 5分
+    maxAttempts: 5, // 最大5回
+    blockDurationMs: 15 * 60 * 1000, // 15分ブロック
+  } as RateLimitConfig,
 } as const;
 
 // Cookie設定

--- a/jest.setup.mjs
+++ b/jest.setup.mjs
@@ -28,7 +28,7 @@ global.testUtils = {
     location: "Test Location",
     price: 1000,
     capacity: 100,
-    organizer_id: "test-user-id",
+    created_by: "test-user-id",
   },
 
   // Helper to reset all mocks
@@ -44,9 +44,9 @@ global.testSupabaseConnection =
   typeof jest !== "undefined" ? jest.fn().mockResolvedValue(true) : () => Promise.resolve(true);
 
 // Essential JSDOM polyfills for modern web APIs
-Object.defineProperty(window, 'matchMedia', {
+Object.defineProperty(window, "matchMedia", {
   writable: true,
-  value: jest.fn().mockImplementation(query => ({
+  value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
     onchange: null,
@@ -59,43 +59,43 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 // HTMLFormElement.prototype.requestSubmit polyfill for JSDOM
-Object.defineProperty(HTMLFormElement.prototype, 'requestSubmit', {
-  value: function(submitter) {
-    const event = new Event('submit', { bubbles: true, cancelable: true });
+Object.defineProperty(HTMLFormElement.prototype, "requestSubmit", {
+  value: function (submitter) {
+    const event = new Event("submit", { bubbles: true, cancelable: true });
     if (submitter) {
-      Object.defineProperty(event, 'submitter', {
+      Object.defineProperty(event, "submitter", {
         value: submitter,
         writable: false,
-        configurable: true
+        configurable: true,
       });
     }
     this.dispatchEvent(event);
   },
   writable: true,
-  configurable: true
+  configurable: true,
 });
 
 // Comprehensive JSDOM polyfills for Radix UI pointer capture
 const addPointerCaptureMethods = (target) => {
   if (!target.hasPointerCapture) {
-    Object.defineProperty(target, 'hasPointerCapture', {
+    Object.defineProperty(target, "hasPointerCapture", {
       value: () => false,
       writable: true,
-      configurable: true
+      configurable: true,
     });
   }
   if (!target.setPointerCapture) {
-    Object.defineProperty(target, 'setPointerCapture', {
+    Object.defineProperty(target, "setPointerCapture", {
       value: () => {},
       writable: true,
-      configurable: true
+      configurable: true,
     });
   }
   if (!target.releasePointerCapture) {
-    Object.defineProperty(target, 'releasePointerCapture', {
+    Object.defineProperty(target, "releasePointerCapture", {
       value: () => {},
       writable: true,
-      configurable: true
+      configurable: true,
     });
   }
 };
@@ -107,31 +107,39 @@ const addPointerCaptureMethods = (target) => {
 const originalError = console.error;
 console.error = (...args) => {
   const message = args[0];
-  if (typeof message === 'string' && 
-      (message.includes('hasPointerCapture') || 
-       message.includes('setPointerCapture') ||
-       message.includes('releasePointerCapture'))) {
+  if (
+    typeof message === "string" &&
+    (message.includes("hasPointerCapture") ||
+      message.includes("setPointerCapture") ||
+      message.includes("releasePointerCapture"))
+  ) {
     return; // Suppress pointer capture errors
   }
   originalError.apply(console, args);
 };
 
 // Mock modern web APIs for Radix UI components
-global.PointerEvent = global.PointerEvent || function(type, init) {
-  return new Event(type, init);
-};
+global.PointerEvent =
+  global.PointerEvent ||
+  function (type, init) {
+    return new Event(type, init);
+  };
 
-global.IntersectionObserver = global.IntersectionObserver || class {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
+global.IntersectionObserver =
+  global.IntersectionObserver ||
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
 
-global.ResizeObserver = global.ResizeObserver || class {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
+global.ResizeObserver =
+  global.ResizeObserver ||
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
 
 // Setup and cleanup
 beforeEach(() => {

--- a/lib/security/secure-client-factory.types.ts
+++ b/lib/security/secure-client-factory.types.ts
@@ -15,6 +15,7 @@ export enum AdminReason {
   SECURITY_INVESTIGATION = "security_investigation",
   PAYOUT_PROCESSING = "payout_processing",
   PAYMENT_PROCESSING = "payment_processing",
+  CSV_EXPORT = "csv_export",
 }
 
 // エラーハンドリングは専用ファイルから再エクスポート

--- a/lib/services/payment/error-mapping.ts
+++ b/lib/services/payment/error-mapping.ts
@@ -18,6 +18,7 @@ export const HTTP_STATUS_BY_ERROR: Record<PaymentErrorType, number> = {
   // ビジネスロジック
   [PaymentErrorType.INVALID_STATUS_TRANSITION]: 400,
   [PaymentErrorType.PAYMENT_ALREADY_EXISTS]: 409,
+  [PaymentErrorType.CONCURRENT_UPDATE]: 409,
   [PaymentErrorType.EVENT_NOT_FOUND]: 404,
   [PaymentErrorType.ATTENDANCE_NOT_FOUND]: 404,
   [PaymentErrorType.PAYMENT_NOT_FOUND]: 404,
@@ -60,6 +61,11 @@ export const ERROR_HANDLING_BY_TYPE: Record<PaymentErrorType, ErrorHandlingResul
     userMessage: "この参加に対する決済は既に作成されています。",
     shouldRetry: false,
     logLevel: "info",
+  },
+  [PaymentErrorType.CONCURRENT_UPDATE]: {
+    userMessage: "他のユーザーによって同時に更新されました。画面を更新して最新状態を確認してください。",
+    shouldRetry: false,
+    logLevel: "warn",
   },
   [PaymentErrorType.ATTENDANCE_NOT_FOUND]: {
     userMessage: "指定された参加記録が見つかりません。",

--- a/lib/services/payment/interface.ts
+++ b/lib/services/payment/interface.ts
@@ -4,6 +4,7 @@
 
 import {
   Payment,
+  PaymentStatus,
   CreateStripeSessionParams,
   CreateStripeSessionResult,
   CreateCashPaymentParams,
@@ -39,6 +40,31 @@ export interface IPaymentService {
    * @throws PaymentError 決済ステータス更新に失敗した場合
    */
   updatePaymentStatus(params: UpdatePaymentStatusParams): Promise<void>;
+
+  /**
+   * 複数の決済ステータスを一括更新する（楽観的ロック対応）
+   * @param updates 更新対象の決済リスト
+   * @param userId 実行ユーザーID
+   * @param notes 更新理由・備考
+   * @returns 成功・失敗の詳細結果
+   * @throws PaymentError 一括更新に失敗した場合
+   */
+  bulkUpdatePaymentStatus(
+    updates: Array<{
+      paymentId: string;
+      status: PaymentStatus;
+      expectedVersion: number;
+    }>,
+    userId: string,
+    notes?: string
+  ): Promise<{
+    successCount: number;
+    failureCount: number;
+    failures: Array<{
+      paymentId: string;
+      error: string;
+    }>;
+  }>;
 
   /**
    * 参加記録IDから決済情報を取得する

--- a/lib/services/payment/types.ts
+++ b/lib/services/payment/types.ts
@@ -86,6 +86,9 @@ export interface UpdatePaymentStatusParams {
   status: PaymentStatus;
   paidAt?: Date;
   stripePaymentIntentId?: string;
+  expectedVersion?: number; // 楽観的ロック用
+  userId?: string; // RPC実行用ユーザーID
+  notes?: string; // 更新理由・備考
 }
 
 // 決済エラーの種類
@@ -110,6 +113,7 @@ export enum PaymentErrorType {
   ATTENDANCE_NOT_FOUND = "ATTENDANCE_NOT_FOUND",
   PAYMENT_NOT_FOUND = "PAYMENT_NOT_FOUND",
   INVALID_AMOUNT = "INVALID_AMOUNT",
+  CONCURRENT_UPDATE = "CONCURRENT_UPDATE", // 楽観的ロック競合
 }
 
 // 決済エラークラス

--- a/lib/services/settlement-report/types.ts
+++ b/lib/services/settlement-report/types.ts
@@ -9,7 +9,7 @@ export interface SettlementReportData {
   eventId: string
   eventTitle: string
   eventDate: string
-  organizerId: string
+  createdBy: string
   stripeAccountId: string
   transferGroup: string
   generatedAt: Date
@@ -66,14 +66,14 @@ export interface SettlementReportCsvRow {
  */
 export interface GenerateSettlementReportParams {
   eventId: string
-  organizerId: string
+  createdBy: string
 }
 
 /**
  * レポート検索パラメータ
  */
 export interface GetSettlementReportsParams {
-  organizerId: string
+  createdBy: string
   eventIds?: string[]
   fromDate?: Date
   toDate?: Date
@@ -132,7 +132,7 @@ export interface GenerateSettlementReportRpcRow {
   event_id: string;
   event_title: string;
   event_date: string;
-  organizer_id: string;
+  created_by: string;
   stripe_account_id: string;
   transfer_group: string;
   total_stripe_sales: number;

--- a/lib/services/webhook/webhook-event-handler.ts
+++ b/lib/services/webhook/webhook-event-handler.ts
@@ -327,21 +327,21 @@ export class StripeWebhookEventHandler implements WebhookEventHandler {
         return;
       }
 
-      const organizerId: string = (eventRow as { created_by: string }).created_by;
+      const createdBy: string = (eventRow as { created_by: string }).created_by;
 
       const service = new SettlementReportService(this.supabase);
-      const res = await service.regenerateAfterRefundOrDispute(eventId, organizerId);
+      const res = await service.regenerateAfterRefundOrDispute(eventId, createdBy);
       if (!res.success) {
         await this.securityReporter.logSecurityEvent({
           type: "settlement_regenerate_failed",
-          details: { eventId, organizerId, error: res.error ?? "unknown" },
+          details: { eventId, createdBy, error: res.error ?? "unknown" },
         });
         return;
       }
 
       await this.securityReporter.logSecurityEvent({
         type: "settlement_regenerate_succeeded",
-        details: { eventId, organizerId, reportId: res.reportId },
+        details: { eventId, createdBy, reportId: res.reportId },
       });
     } catch (e) {
       await this.securityReporter.logSecurityEvent({

--- a/lib/validation/participant-management.ts
+++ b/lib/validation/participant-management.ts
@@ -218,7 +218,7 @@ export const PaymentSummarySchema = z.object({
   // ステータス別集計
   byStatus: z.array(PaymentStatusSummarySchema),
 
-  // 未決済ハイライト（pending, failed）
+  // 未決済ハイライト（pending, failed, refunded）
   unpaidCount: z.number().int().min(0),
   unpaidAmount: z.number().int().min(0),
 

--- a/lib/validation/participant-management.ts
+++ b/lib/validation/participant-management.ts
@@ -152,6 +152,7 @@ export const ParticipantViewSchema = z.object({
   payment_status: PaymentStatusEnum.nullable(),
   amount: z.number().nullable(),
   paid_at: z.string().nullable(),
+  payment_version: z.number().nullable(), // 楽観的ロック用
   payment_created_at: z.string().nullable(),
   payment_updated_at: z.string().nullable(),
 });

--- a/lib/validation/participant-management.ts
+++ b/lib/validation/participant-management.ts
@@ -5,6 +5,24 @@
 
 import { z } from "zod";
 
+// ====================================================================
+// 決済ステータス ENUM（集中定義）- 先頭で定義して他から参照可能にする
+// ====================================================================
+
+// 決済ステータス ENUM（集中定義）
+export const PaymentStatusEnum = z.enum([
+  "pending",
+  "paid",
+  "failed",
+  "received",
+  "refunded",
+  "waived",
+  "completed",
+]);
+
+// 利便性のために値配列をエクスポート（runtime 用）
+export const PAYMENT_STATUS_VALUES = PaymentStatusEnum.options;
+
 // 参加ステータスフィルター
 export const AttendanceStatusFilterSchema = z
   .enum(["attending", "not_attending", "maybe"])
@@ -16,9 +34,7 @@ export const PaymentMethodFilterSchema = z
   .optional();
 
 // 決済ステータスフィルター
-export const PaymentStatusFilterSchema = z
-  .enum(["pending", "paid", "failed", "received", "refunded", "waived", "completed"])
-  .optional();
+export const PaymentStatusFilterSchema = PaymentStatusEnum.optional();
 
 // ソートフィールド
 export const ParticipantSortFieldSchema = z
@@ -56,7 +72,6 @@ export const LimitSchema = z
 // 検索クエリ
 export const SearchQuerySchema = z
   .string()
-  .min(0)
   .max(255)
   .optional()
   .transform((val) => val?.trim() || undefined);
@@ -134,7 +149,7 @@ export const ParticipantViewSchema = z.object({
   // payment fields (nullable - 決済情報がない場合もある)
   payment_id: z.string().nullable(),
   payment_method: z.enum(["stripe", "cash"]).nullable(),
-  payment_status: z.enum(["pending", "paid", "failed", "received", "refunded", "waived", "completed"]).nullable(),
+  payment_status: PaymentStatusEnum.nullable(),
   amount: z.number().nullable(),
   paid_at: z.string().nullable(),
   payment_created_at: z.string().nullable(),
@@ -167,3 +182,65 @@ export const GetParticipantsResponseSchema = z.object({
 });
 
 export type GetParticipantsResponse = z.infer<typeof GetParticipantsResponseSchema>;
+
+// ====================================================================
+// 決済集計関連スキーマ（MANAGE-002対応）
+// ====================================================================
+
+// 決済方法別集計
+export const PaymentMethodSummarySchema = z.object({
+  method: z.enum(["stripe", "cash"]),
+  count: z.number().int().min(0),
+  totalAmount: z.number().int().min(0),
+});
+
+export type PaymentMethodSummary = z.infer<typeof PaymentMethodSummarySchema>;
+
+// 決済ステータス別集計
+export const PaymentStatusSummarySchema = z.object({
+  status: PaymentStatusEnum,
+  count: z.number().int().min(0),
+  totalAmount: z.number().int().min(0),
+});
+
+export type PaymentStatusSummary = z.infer<typeof PaymentStatusSummarySchema>;
+
+// 決済集計データ全体
+export const PaymentSummarySchema = z.object({
+  // 基本集計
+  totalPayments: z.number().int().min(0),
+  totalAmount: z.number().int().min(0),
+
+  // 方法別集計
+  byMethod: z.array(PaymentMethodSummarySchema),
+
+  // ステータス別集計
+  byStatus: z.array(PaymentStatusSummarySchema),
+
+  // 未決済ハイライト（pending, failed）
+  unpaidCount: z.number().int().min(0),
+  unpaidAmount: z.number().int().min(0),
+
+  // 決済済み（paid, received, completed）
+  paidCount: z.number().int().min(0),
+  paidAmount: z.number().int().min(0),
+});
+
+export type PaymentSummary = z.infer<typeof PaymentSummarySchema>;
+
+// 決済一覧＋集計レスポンス
+export const GetEventPaymentsResponseSchema = z.object({
+  payments: z.array(z.object({
+    id: z.string(),
+    method: z.enum(["stripe", "cash"]),
+    amount: z.number().int(),
+    status: PaymentStatusEnum,
+    attendance_id: z.string(),
+    paid_at: z.string().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+  })),
+  summary: PaymentSummarySchema,
+});
+
+export type GetEventPaymentsResponse = z.infer<typeof GetEventPaymentsResponseSchema>;

--- a/lib/validation/participant-management.ts
+++ b/lib/validation/participant-management.ts
@@ -1,0 +1,169 @@
+/**
+ * 参加者管理機能 バリデーションスキーマ
+ * MANAGE-001: 参加者一覧表示（検索/フィルター/ページング）
+ */
+
+import { z } from "zod";
+
+// 参加ステータスフィルター
+export const AttendanceStatusFilterSchema = z
+  .enum(["attending", "not_attending", "maybe"])
+  .optional();
+
+// 決済方法フィルター
+export const PaymentMethodFilterSchema = z
+  .enum(["stripe", "cash"])
+  .optional();
+
+// 決済ステータスフィルター
+export const PaymentStatusFilterSchema = z
+  .enum(["pending", "paid", "failed", "received", "refunded", "waived", "completed"])
+  .optional();
+
+// ソートフィールド
+export const ParticipantSortFieldSchema = z
+  .enum([
+    "created_at",
+    "updated_at",
+    "nickname",
+    "email",
+    "status",
+    "payment_method",
+    "payment_status",
+    "paid_at"
+  ])
+  .default("updated_at");
+
+// ソート順序
+export const SortOrderSchema = z
+  .enum(["asc", "desc"])
+  .default("desc");
+
+// ページネーション
+export const PageSchema = z
+  .number()
+  .int()
+  .min(1)
+  .default(1);
+
+export const LimitSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(100)
+  .default(50);
+
+// 検索クエリ
+export const SearchQuerySchema = z
+  .string()
+  .min(0)
+  .max(255)
+  .optional()
+  .transform((val) => val?.trim() || undefined);
+
+// 参加者一覧取得パラメータ
+export const GetParticipantsParamsSchema = z.object({
+  eventId: z.string().uuid(),
+  search: SearchQuerySchema,
+  attendanceStatus: AttendanceStatusFilterSchema,
+  paymentMethod: PaymentMethodFilterSchema,
+  paymentStatus: PaymentStatusFilterSchema,
+  sortField: ParticipantSortFieldSchema,
+  sortOrder: SortOrderSchema,
+  page: PageSchema,
+  limit: LimitSchema,
+});
+
+export type GetParticipantsParams = z.infer<typeof GetParticipantsParamsSchema>;
+
+// CSVエクスポートパラメータ
+export const ExportParticipantsCsvParamsSchema = z.object({
+  eventId: z.string().uuid(),
+  filters: z.object({
+    search: SearchQuerySchema,
+    attendanceStatus: AttendanceStatusFilterSchema,
+    paymentMethod: PaymentMethodFilterSchema,
+    paymentStatus: PaymentStatusFilterSchema,
+  }).optional(),
+  columns: z
+    .array(z.enum([
+      "attendance_id",
+      "nickname",
+      "email",
+      "status",
+      "payment_method",
+      "payment_status",
+      "amount",
+      "paid_at",
+      "created_at",
+      "updated_at"
+    ]))
+    .optional()
+    .default([
+      "attendance_id",
+      "nickname",
+      "email",
+      "status",
+      "payment_method",
+      "payment_status",
+      "paid_at"
+    ]),
+});
+
+export type ExportParticipantsCsvParams = z.infer<typeof ExportParticipantsCsvParamsSchema>;
+
+// 一括現金ステータス更新パラメータ
+export const BulkUpdateCashStatusParamsSchema = z.object({
+  paymentIds: z.array(z.string().uuid()).min(1).max(50), // 一度に最大50件
+  status: z.enum(["received", "waived"]),
+  notes: z.string().max(500).optional(),
+});
+
+export type BulkUpdateCashStatusParams = z.infer<typeof BulkUpdateCashStatusParamsSchema>;
+
+// 参加者詳細表示用型（attendances + payments結合）
+export const ParticipantViewSchema = z.object({
+  // attendance fields
+  attendance_id: z.string(),
+  nickname: z.string(),
+  email: z.string(),
+  attendance_status: z.enum(["attending", "not_attending", "maybe"]),
+  attendance_created_at: z.string(),
+  attendance_updated_at: z.string(),
+
+  // payment fields (nullable - 決済情報がない場合もある)
+  payment_id: z.string().nullable(),
+  payment_method: z.enum(["stripe", "cash"]).nullable(),
+  payment_status: z.enum(["pending", "paid", "failed", "received", "refunded", "waived", "completed"]).nullable(),
+  amount: z.number().nullable(),
+  paid_at: z.string().nullable(),
+  payment_created_at: z.string().nullable(),
+  payment_updated_at: z.string().nullable(),
+});
+
+export type ParticipantView = z.infer<typeof ParticipantViewSchema>;
+
+// レスポンス型
+export const GetParticipantsResponseSchema = z.object({
+  participants: z.array(ParticipantViewSchema),
+  pagination: z.object({
+    page: z.number(),
+    limit: z.number(),
+    total: z.number(),
+    totalPages: z.number(),
+    hasNext: z.boolean(),
+    hasPrev: z.boolean(),
+  }),
+  filters: z.object({
+    search: z.string().optional(),
+    attendanceStatus: AttendanceStatusFilterSchema,
+    paymentMethod: PaymentMethodFilterSchema,
+    paymentStatus: PaymentStatusFilterSchema,
+  }),
+  sort: z.object({
+    field: ParticipantSortFieldSchema,
+    order: SortOrderSchema,
+  }),
+});
+
+export type GetParticipantsResponse = z.infer<typeof GetParticipantsResponseSchema>;

--- a/lib/validation/participant-management.ts
+++ b/lib/validation/participant-management.ts
@@ -142,7 +142,7 @@ export const ParticipantViewSchema = z.object({
   attendance_id: z.string(),
   nickname: z.string(),
   email: z.string(),
-  attendance_status: z.enum(["attending", "not_attending", "maybe"]),
+  status: z.enum(["attending", "not_attending", "maybe"]),
   attendance_created_at: z.string(),
   attendance_updated_at: z.string(),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-tooltip": "^1.2.7",
         "@stripe/stripe-js": "^7.8.0",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.50.0",
@@ -4613,6 +4614,129 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-select": "^2.2.5",
+    "@radix-ui/react-tooltip": "^1.2.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
     "@stripe/stripe-js": "^7.8.0",

--- a/supabase/migrations/20250821000004_fix_settlement_report_already_exists.sql
+++ b/supabase/migrations/20250821000004_fix_settlement_report_already_exists.sql
@@ -9,14 +9,14 @@
 -- Recreate function with improved logic
 CREATE OR REPLACE FUNCTION public.generate_settlement_report(
     p_event_id UUID,
-    p_organizer_id UUID
+    p_created_by UUID
 ) RETURNS TABLE (
     report_id UUID,
     already_exists BOOLEAN,
     event_id UUID,
     event_title VARCHAR(255),
     event_date DATE,
-    organizer_id UUID,
+    created_by UUID,
     stripe_account_id VARCHAR(255),
     transfer_group TEXT,
     total_stripe_sales INTEGER,
@@ -56,8 +56,8 @@ DECLARE
     v_updated_at TIMESTAMPTZ;
 BEGIN
     -- 1) Validation -----------------------------------------------------
-    IF p_event_id IS NULL OR p_organizer_id IS NULL THEN
-        RAISE EXCEPTION 'event_id and organizer_id are required';
+    IF p_event_id IS NULL OR p_created_by IS NULL THEN
+        RAISE EXCEPTION 'event_id and created_by are required';
     END IF;
 
     -- 2) Event & Stripe account check ----------------------------------
@@ -70,7 +70,7 @@ BEGIN
       FROM public.events e
       JOIN public.stripe_connect_accounts sca ON sca.user_id = e.created_by
      WHERE e.id = p_event_id
-       AND e.created_by = p_organizer_id
+       AND e.created_by = p_created_by
        AND sca.payouts_enabled = TRUE;
 
     IF NOT FOUND THEN
@@ -127,7 +127,7 @@ BEGIN
         updated_at
     ) VALUES (
         p_event_id,
-        p_organizer_id,
+        p_created_by,
         v_stripe_sales,
         v_stripe_fee,
         v_net_application_fee,
@@ -171,7 +171,7 @@ BEGIN
     event_id := p_event_id;
     event_title := v_event_data.title;
     event_date := v_event_data.date;
-    organizer_id := p_organizer_id;
+    created_by := p_created_by;
     stripe_account_id := v_event_data.stripe_account_id;
     transfer_group := v_transfer_group;
     total_stripe_sales := v_stripe_sales;

--- a/supabase/migrations/20250823100000_add_payment_status_audit_rpc.sql
+++ b/supabase/migrations/20250823100000_add_payment_status_audit_rpc.sql
@@ -1,0 +1,300 @@
+-- ====================================================================
+-- EventPay: 監査ログ付き決済ステータス更新RPC関数
+-- 目的: トランザクション整合性を保証した決済ステータス更新と監査ログ記録
+-- ====================================================================
+
+BEGIN;
+
+-- ====================================================================
+-- 単体決済ステータス更新（監査ログ付き）
+-- ====================================================================
+
+CREATE OR REPLACE FUNCTION public.update_payment_status_with_audit(
+    p_payment_id UUID,
+    p_new_status public.payment_status_enum,
+    p_paid_at TIMESTAMPTZ DEFAULT NULL,
+    p_notes TEXT DEFAULT NULL,
+    p_user_id UUID DEFAULT NULL,
+    p_stripe_payment_intent_id TEXT DEFAULT NULL
+) RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_old_status public.payment_status_enum;
+    v_payment_method public.payment_method_enum;
+    v_attendance_id UUID;
+    v_event_id UUID;
+    v_updated_rows INTEGER;
+    v_result JSON;
+BEGIN
+    -- 入力値検証
+    IF p_payment_id IS NULL THEN
+        RAISE EXCEPTION 'payment_id cannot be null';
+    END IF;
+
+    IF p_new_status IS NULL THEN
+        RAISE EXCEPTION 'new_status cannot be null';
+    END IF;
+
+    -- 既存の決済レコード取得と権限チェック用データ取得
+    SELECT
+        p.status,
+        p.method,
+        p.attendance_id,
+        a.event_id
+    INTO
+        v_old_status,
+        v_payment_method,
+        v_attendance_id,
+        v_event_id
+    FROM public.payments p
+    INNER JOIN public.attendances a ON p.attendance_id = a.id
+    WHERE p.id = p_payment_id;
+
+    -- 決済レコードの存在確認
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Payment record not found: %', p_payment_id;
+    END IF;
+
+    -- 現金決済のみ手動更新可能（Stripe決済はWebhook経由のみ）
+    IF v_payment_method = 'stripe' AND p_user_id IS NOT NULL THEN
+        RAISE EXCEPTION 'Stripe payments can only be updated via webhooks';
+    END IF;
+
+    -- ステータス遷移の妥当性チェック
+    -- received/waived は pending/failed からのみ可能
+    IF p_new_status IN ('received', 'waived') THEN
+        IF v_old_status NOT IN ('pending', 'failed') THEN
+            RAISE EXCEPTION 'Invalid status transition from % to %', v_old_status, p_new_status;
+        END IF;
+    END IF;
+
+    -- 決済ステータス更新
+    UPDATE public.payments
+    SET
+        status = p_new_status,
+        updated_at = NOW(),
+        paid_at = CASE
+            WHEN p_new_status IN ('paid', 'received', 'completed') AND p_paid_at IS NOT NULL
+            THEN p_paid_at
+            WHEN p_new_status IN ('paid', 'received', 'completed') AND p_paid_at IS NULL
+            THEN NOW()
+            ELSE paid_at
+        END,
+        stripe_payment_intent_id = COALESCE(p_stripe_payment_intent_id, stripe_payment_intent_id)
+    WHERE id = p_payment_id;
+
+    GET DIAGNOSTICS v_updated_rows = ROW_COUNT;
+
+    IF v_updated_rows = 0 THEN
+        RAISE EXCEPTION 'Failed to update payment status for payment_id: %', p_payment_id;
+    END IF;
+
+    -- 監査ログ記録
+    INSERT INTO public.system_logs (
+        operation_type,
+        details,
+        created_at
+    ) VALUES (
+        'payment_status_update',
+        json_build_object(
+            'payment_id', p_payment_id,
+            'attendance_id', v_attendance_id,
+            'event_id', v_event_id,
+            'old_status', v_old_status,
+            'new_status', p_new_status,
+            'payment_method', v_payment_method,
+            'user_id', p_user_id,
+            'notes', p_notes,
+            'stripe_payment_intent_id', p_stripe_payment_intent_id,
+            'updated_at', NOW()
+        ),
+        NOW()
+    );
+
+    -- 結果返却
+    v_result := json_build_object(
+        'success', true,
+        'payment_id', p_payment_id,
+        'old_status', v_old_status,
+        'new_status', p_new_status,
+        'updated_at', NOW()
+    );
+
+    RETURN v_result;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        -- エラーログ記録（可能な限り）
+        BEGIN
+            INSERT INTO public.system_logs (
+                operation_type,
+                details,
+                created_at
+            ) VALUES (
+                'payment_status_update_error',
+                json_build_object(
+                    'payment_id', p_payment_id,
+                    'new_status', p_new_status,
+                    'user_id', p_user_id,
+                    'error_message', SQLERRM,
+                    'error_state', SQLSTATE
+                ),
+                NOW()
+            );
+        EXCEPTION
+            WHEN OTHERS THEN
+                NULL; -- ログ記録失敗は無視
+        END;
+
+        -- 元のエラーを再発生
+        RAISE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.update_payment_status_with_audit IS '決済ステータスを更新し、監査ログを記録する。トランザクション整合性を保証。';
+
+-- ====================================================================
+-- 一括決済ステータス更新（監査ログ付き）
+-- ====================================================================
+
+CREATE OR REPLACE FUNCTION public.bulk_update_payment_status_with_audit(
+    p_payment_ids UUID[],
+    p_new_status public.payment_status_enum,
+    p_notes TEXT DEFAULT NULL,
+    p_user_id UUID DEFAULT NULL
+) RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_payment_id UUID;
+    v_success_count INTEGER := 0;
+    v_failed_count INTEGER := 0;
+    v_failures JSON[] := '{}';
+    v_single_result JSON;
+    v_error_message TEXT;
+    v_result JSON;
+BEGIN
+    -- 入力値検証
+    IF p_payment_ids IS NULL OR array_length(p_payment_ids, 1) IS NULL THEN
+        RAISE EXCEPTION 'payment_ids cannot be null or empty';
+    END IF;
+
+    IF array_length(p_payment_ids, 1) > 50 THEN
+        RAISE EXCEPTION 'Cannot update more than 50 payments at once, got: %', array_length(p_payment_ids, 1);
+    END IF;
+
+    IF p_new_status IS NULL THEN
+        RAISE EXCEPTION 'new_status cannot be null';
+    END IF;
+
+    -- 各決済を順次処理（個別エラーハンドリング）
+    FOREACH v_payment_id IN ARRAY p_payment_ids
+    LOOP
+        BEGIN
+            -- 単体更新関数を呼び出し
+            SELECT public.update_payment_status_with_audit(
+                v_payment_id,
+                p_new_status,
+                NULL, -- paid_at は受領時に自動設定
+                p_notes,
+                p_user_id,
+                NULL  -- stripe_payment_intent_id
+            ) INTO v_single_result;
+
+            v_success_count := v_success_count + 1;
+
+        EXCEPTION
+            WHEN OTHERS THEN
+                v_failed_count := v_failed_count + 1;
+                v_error_message := SQLERRM;
+
+                -- 失敗情報を配列に追加
+                v_failures := v_failures || json_build_object(
+                    'payment_id', v_payment_id,
+                    'error', v_error_message
+                );
+        END;
+    END LOOP;
+
+    -- 一括操作の監査ログ記録
+    INSERT INTO public.system_logs (
+        operation_type,
+        details,
+        created_at
+    ) VALUES (
+        'payment_bulk_status_update',
+        json_build_object(
+            'payment_ids', p_payment_ids,
+            'new_status', p_new_status,
+            'user_id', p_user_id,
+            'notes', p_notes,
+            'success_count', v_success_count,
+            'failed_count', v_failed_count,
+            'failures', v_failures,
+            'total_count', array_length(p_payment_ids, 1)
+        ),
+        NOW()
+    );
+
+    -- 結果返却
+    v_result := json_build_object(
+        'success', true,
+        'success_count', v_success_count,
+        'failed_count', v_failed_count,
+        'total_count', array_length(p_payment_ids, 1),
+        'failures', v_failures
+    );
+
+    RETURN v_result;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        -- 全体エラーログ記録
+        BEGIN
+            INSERT INTO public.system_logs (
+                operation_type,
+                details,
+                created_at
+            ) VALUES (
+                'payment_bulk_status_update_error',
+                json_build_object(
+                    'payment_ids', p_payment_ids,
+                    'new_status', p_new_status,
+                    'user_id', p_user_id,
+                    'error_message', SQLERRM,
+                    'error_state', SQLSTATE
+                ),
+                NOW()
+            );
+        EXCEPTION
+            WHEN OTHERS THEN
+                NULL; -- ログ記録失敗は無視
+        END;
+
+        -- 元のエラーを再発生
+        RAISE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.bulk_update_payment_status_with_audit IS '複数の決済ステータスを一括更新し、監査ログを記録する。部分成功・失敗に対応。';
+
+-- ====================================================================
+-- 関数の権限設定
+-- ====================================================================
+
+-- 認証済みユーザーのみ実行可能
+-- 一般ユーザー (authenticated) からの実行権限は付与しない
+REVOKE ALL ON FUNCTION public.update_payment_status_with_audit FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.update_payment_status_with_audit FROM authenticated;
+
+REVOKE ALL ON FUNCTION public.bulk_update_payment_status_with_audit FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.bulk_update_payment_status_with_audit FROM authenticated;
+
+-- Service roleは全権限（Webhook処理用）
+GRANT EXECUTE ON FUNCTION public.update_payment_status_with_audit TO service_role;
+GRANT EXECUTE ON FUNCTION public.bulk_update_payment_status_with_audit TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20250824000000_payment_optimistic_lock.sql
+++ b/supabase/migrations/20250824000000_payment_optimistic_lock.sql
@@ -1,0 +1,226 @@
+-- 楽観的ロック実装：payments テーブルに version 列を追加
+-- 同時更新による Lost Update を防止
+
+-- 1. payments テーブルに version 列を追加
+ALTER TABLE payments
+ADD COLUMN version integer NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN payments.version IS 'Optimistic lock version to prevent concurrent updates';
+
+-- 2. version を自動更新するトリガー関数
+CREATE OR REPLACE FUNCTION update_payment_version()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- UPDATE 時に version を自動インクリメント（手動更新された場合のフォールバック）
+  IF TG_OP = 'UPDATE' AND OLD.version = NEW.version THEN
+    NEW.version = OLD.version + 1;
+  END IF;
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. payments テーブルに version 自動更新トリガーを追加
+DROP TRIGGER IF EXISTS trigger_update_payment_version ON payments;
+CREATE TRIGGER trigger_update_payment_version
+  BEFORE UPDATE ON payments
+  FOR EACH ROW
+  EXECUTE FUNCTION update_payment_version();
+
+-- 4. 楽観的ロック付き決済ステータス更新 RPC
+CREATE OR REPLACE FUNCTION rpc_update_payment_status_safe(
+  p_payment_id       uuid,
+  p_new_status       payment_status_enum,
+  p_expected_version integer,
+  p_user_id          uuid,
+  p_notes            text DEFAULT NULL
+) RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER AS $$
+DECLARE
+  v_updated_rows     integer;
+  v_payment_record   payments%ROWTYPE;
+  v_attendance_record attendances%ROWTYPE;
+  v_event_record     events%ROWTYPE;
+  v_result           json;
+BEGIN
+  -- 個別にSELECTして各ROWTYPE変数へ格納（複数 INTO 禁止エラー回避）
+  SELECT *
+    INTO v_payment_record
+    FROM payments
+   WHERE id = p_payment_id
+   FOR UPDATE;
+
+  SELECT *
+    INTO v_attendance_record
+    FROM attendances
+   WHERE id = v_payment_record.attendance_id;
+
+  SELECT *
+    INTO v_event_record
+    FROM events
+   WHERE id = v_attendance_record.event_id;
+
+  -- 決済レコードが存在しない
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Payment record not found: %', p_payment_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 主催者権限チェック
+  IF v_event_record.created_by != p_user_id THEN
+    RAISE EXCEPTION 'Unauthorized: User % is not the event creator', p_user_id
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- 現金決済でない場合はエラー
+  IF v_payment_record.method != 'cash' THEN
+    RAISE EXCEPTION 'Only cash payments can be manually updated'
+      USING ERRCODE = 'P0003';
+  END IF;
+
+  -- 2. 楽観的ロック付きステータス更新
+  UPDATE payments
+  SET status = p_new_status,
+      paid_at = CASE
+        WHEN p_new_status = 'received' THEN now()
+        WHEN p_new_status = 'waived' THEN paid_at  -- 免除時はpaid_atは変更しない
+        ELSE paid_at
+      END,
+      version = version + 1,
+      updated_at = now()
+  WHERE id = p_payment_id
+    AND version = p_expected_version
+    AND method = 'cash';
+
+  GET DIAGNOSTICS v_updated_rows = ROW_COUNT;
+
+  -- バージョン競合検出
+  IF v_updated_rows = 0 THEN
+    RAISE EXCEPTION 'Concurrent update detected for payment %', p_payment_id
+      USING ERRCODE = '40001'; -- serialization_failure
+  END IF;
+
+  -- 3. 監査ログ記録
+  INSERT INTO system_logs (operation_type, details, created_at)
+  VALUES (
+    'payment_status_update_safe',
+    jsonb_build_object(
+      'payment_id', p_payment_id,
+      'old_status', v_payment_record.status,
+      'new_status', p_new_status,
+      'expected_version', p_expected_version,
+      'new_version', v_payment_record.version + 1,
+      'user_id', p_user_id,
+      'notes', p_notes,
+      'event_id', v_event_record.id,
+      'attendance_id', v_attendance_record.id
+    ),
+    now()
+  );
+
+  -- 4. 結果返却
+  v_result := jsonb_build_object(
+    'payment_id', p_payment_id,
+    'status', p_new_status,
+    'new_version', v_payment_record.version + 1,
+    'updated_at', now()
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+-- 5. 一括更新用 RPC（内部で safe 版を呼ぶ）
+CREATE OR REPLACE FUNCTION rpc_bulk_update_payment_status_safe(
+  p_payment_updates jsonb, -- [{"payment_id": "uuid", "expected_version": 1, "new_status": "received"}]
+  p_user_id         uuid,
+  p_notes           text DEFAULT NULL
+) RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER AS $$
+DECLARE
+  v_update_item     jsonb;
+  v_payment_id      uuid;
+  v_expected_version integer;
+  v_new_status      payment_status_enum;
+  v_success_count   integer := 0;
+  v_failure_count   integer := 0;
+  v_failures        jsonb := '[]'::jsonb;
+  v_result          json;
+BEGIN
+  -- 入力検証
+  IF jsonb_array_length(p_payment_updates) > 50 THEN
+    RAISE EXCEPTION 'Too many payments to update at once (max 50)'
+      USING ERRCODE = 'P0004';
+  END IF;
+
+  -- 各決済を順次更新
+  FOR v_update_item IN SELECT * FROM jsonb_array_elements(p_payment_updates)
+  LOOP
+    BEGIN
+      v_payment_id := (v_update_item->>'payment_id')::uuid;
+      v_expected_version := (v_update_item->>'expected_version')::integer;
+      v_new_status := (v_update_item->>'new_status')::payment_status_enum;
+
+      -- 個別の安全更新を実行
+      PERFORM rpc_update_payment_status_safe(
+        v_payment_id,
+        v_new_status,
+        v_expected_version,
+        p_user_id,
+        p_notes
+      );
+
+      v_success_count := v_success_count + 1;
+
+    EXCEPTION
+      WHEN OTHERS THEN
+        v_failure_count := v_failure_count + 1;
+        v_failures := v_failures || jsonb_build_object(
+          'payment_id', v_payment_id,
+          'error_code', SQLSTATE,
+          'error_message', SQLERRM
+        );
+    END;
+  END LOOP;
+
+  -- 一括処理の監査ログ
+  INSERT INTO system_logs (operation_type, details, created_at)
+  VALUES (
+    'payment_bulk_status_update_safe',
+    jsonb_build_object(
+      'user_id', p_user_id,
+      'total_count', jsonb_array_length(p_payment_updates),
+      'success_count', v_success_count,
+      'failure_count', v_failure_count,
+      'failures', v_failures,
+      'notes', p_notes
+    ),
+    now()
+  );
+
+  -- 結果返却
+  v_result := jsonb_build_object(
+    'success_count', v_success_count,
+    'failure_count', v_failure_count,
+    'failures', v_failures
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+-- 6. サービスロール（admin）のみに実行権限付与
+GRANT EXECUTE ON FUNCTION rpc_update_payment_status_safe TO service_role;
+GRANT EXECUTE ON FUNCTION rpc_bulk_update_payment_status_safe TO service_role;
+
+-- 7. インデックス追加（version を含む複合クエリの最適化）
+CREATE INDEX IF NOT EXISTS idx_payments_id_version ON payments(id, version);
+
+-- 8. 既存レコードの version 初期化（すべて 1 で開始）
+-- DEFAULT 1 が設定されているので、新規 INSERT は自動的に 1 から開始される
+UPDATE payments SET version = 1 WHERE version IS NULL;
+
+COMMENT ON FUNCTION rpc_update_payment_status_safe IS 'Optimistic-lock aware payment status update with audit logging';
+COMMENT ON FUNCTION rpc_bulk_update_payment_status_safe IS 'Bulk payment status update with optimistic locking and detailed failure reporting';

--- a/supabase/migrations/20250826000000_drop_payment_audit_rpc.sql
+++ b/supabase/migrations/20250826000000_drop_payment_audit_rpc.sql
@@ -1,0 +1,33 @@
+-- Remove obsolete audit RPC functions
+-- このマイグレーションでは、現在アプリケーションから参照されていない
+-- 旧版の監査付き決済ステータス更新 RPC を削除します。
+--
+-- 関数一覧:
+--   - update_payment_status_with_audit
+--   - bulk_update_payment_status_with_audit
+--
+-- 依存関係:
+--   現行ロジックは rpc_update_payment_status_safe / rpc_bulk_update_payment_status_safe
+--   を使用しており、本マイグレーションによる影響はありません。
+
+BEGIN;
+
+-- 単体更新 RPC の削除
+DROP FUNCTION IF EXISTS public.update_payment_status_with_audit(
+  UUID,
+  public.payment_status_enum,
+  TIMESTAMPTZ,
+  TEXT,
+  UUID,
+  TEXT
+);
+
+-- 一括更新 RPC の削除
+DROP FUNCTION IF EXISTS public.bulk_update_payment_status_with_audit(
+  UUID[],
+  public.payment_status_enum,
+  TEXT,
+  UUID
+);
+
+COMMIT;

--- a/types/database.ts
+++ b/types/database.ts
@@ -441,6 +441,7 @@ export type Database = {
           tax_included: boolean
           transfer_group: string | null
           updated_at: string
+          version: number
           webhook_event_id: string | null
           webhook_processed_at: string | null
         }
@@ -475,6 +476,7 @@ export type Database = {
           tax_included?: boolean
           transfer_group?: string | null
           updated_at?: string
+          version?: number
           webhook_event_id?: string | null
           webhook_processed_at?: string | null
         }
@@ -509,6 +511,7 @@ export type Database = {
           tax_included?: boolean
           transfer_group?: string | null
           updated_at?: string
+          version?: number
           webhook_event_id?: string | null
           webhook_processed_at?: string | null
         }
@@ -1014,6 +1017,15 @@ export type Database = {
       }
     }
     Functions: {
+      bulk_update_payment_status_with_audit: {
+        Args: {
+          p_new_status: Database["public"]["Enums"]["payment_status_enum"]
+          p_notes?: string
+          p_payment_ids: string[]
+          p_user_id?: string
+        }
+        Returns: Json
+      }
       calc_payout_amount: {
         Args: { p_event_id: string }
         Returns: {
@@ -1082,10 +1094,6 @@ export type Database = {
           p_process_id: string
         }
         Returns: boolean
-      }
-      finalize_event_settlement: {
-        Args: { p_event_id: string; p_user_id: string }
-        Returns: string
       }
       find_eligible_events_basic: {
         Args: {
@@ -1259,6 +1267,20 @@ export type Database = {
         Args: { p_lock_name: string; p_process_id?: string }
         Returns: boolean
       }
+      rpc_bulk_update_payment_status_safe: {
+        Args: { p_notes?: string; p_payment_updates: Json; p_user_id: string }
+        Returns: Json
+      }
+      rpc_update_payment_status_safe: {
+        Args: {
+          p_expected_version: number
+          p_new_status: Database["public"]["Enums"]["payment_status_enum"]
+          p_notes?: string
+          p_payment_id: string
+          p_user_id: string
+        }
+        Returns: Json
+      }
       set_test_guest_token: {
         Args: { token: string }
         Returns: undefined
@@ -1284,6 +1306,17 @@ export type Database = {
           p_status: Database["public"]["Enums"]["attendance_status_enum"]
         }
         Returns: undefined
+      }
+      update_payment_status_with_audit: {
+        Args: {
+          p_new_status: Database["public"]["Enums"]["payment_status_enum"]
+          p_notes?: string
+          p_paid_at?: string
+          p_payment_id: string
+          p_stripe_payment_intent_id?: string
+          p_user_id?: string
+        }
+        Returns: Json
       }
       update_payout_status_safe: {
         Args: {

--- a/types/database.ts
+++ b/types/database.ts
@@ -1017,15 +1017,6 @@ export type Database = {
       }
     }
     Functions: {
-      bulk_update_payment_status_with_audit: {
-        Args: {
-          p_new_status: Database["public"]["Enums"]["payment_status_enum"]
-          p_notes?: string
-          p_payment_ids: string[]
-          p_user_id?: string
-        }
-        Returns: Json
-      }
       calc_payout_amount: {
         Args: { p_event_id: string }
         Returns: {
@@ -1306,17 +1297,6 @@ export type Database = {
           p_status: Database["public"]["Enums"]["attendance_status_enum"]
         }
         Returns: undefined
-      }
-      update_payment_status_with_audit: {
-        Args: {
-          p_new_status: Database["public"]["Enums"]["payment_status_enum"]
-          p_notes?: string
-          p_paid_at?: string
-          p_payment_id: string
-          p_stripe_payment_intent_id?: string
-          p_user_id?: string
-        }
-        Returns: Json
       }
       update_payout_status_safe: {
         Args: {

--- a/types/database.ts
+++ b/types/database.ts
@@ -1138,16 +1138,16 @@ export type Database = {
         Returns: boolean
       }
       generate_settlement_report: {
-        Args: { p_event_id: string; p_organizer_id: string }
+        Args: { p_created_by: string; p_event_id: string }
         Returns: {
           already_exists: boolean
+          created_by: string
           dispute_count: number
           event_date: string
           event_id: string
           event_title: string
           generated_at: string
           net_payout_amount: number
-          organizer_id: string
           payment_count: number
           refunded_count: number
           report_id: string
@@ -1204,11 +1204,11 @@ export type Database = {
       }
       get_settlement_report_details: {
         Args: {
+          p_created_by: string
           p_event_ids?: string[]
           p_from_date?: string
           p_limit?: number
           p_offset?: number
-          p_organizer_id: string
           p_to_date?: string
         }
         Returns: {

--- a/types/test.d.ts
+++ b/types/test.d.ts
@@ -24,7 +24,7 @@ declare global {
         location: string;
         price: number;
         capacity: number;
-        organizer_id: string;
+        created_by: string;
       };
       resetAllMocks: () => void;
     };
@@ -58,4 +58,4 @@ declare global {
   }
 }
 
-export {};
+export { };


### PR DESCRIPTION
### 概要
本PRはイベント主催者向けの参加者管理機能を段階的に実装します。参加者一覧（検索/フィルター/ページング/ソート）、決済状況サマリー、現金受領ステータスの単体/一括更新（監査・楽観的ロック対応）、CSVエクスポート（UTF-8 BOM・Excel数式注入対策）を追加します。

## 変更概要
- 参加者管理UIを`/app/events/[id]/page.tsx`に統合表示（主催者のみ）
  - `ParticipantsManagement`（新規）
  - `ParticipantsTable`（新規）：検索・複合フィルター・ページング・ソート・未決済ハイライト・現金受領操作
  - `PaymentSummary`（新規）：方法別/ステータス別・未決済/決済済み集計表示
- Server Actions
  - `get-event-participants.ts`（新規）：attendances+paymentsの結合取得、後段フィルタ/ソート、ページング
  - `get-event-payments.ts`（拡張）：決済一覧＋集計（方法別/ステータス別/未決済・決済済み）
  - `update-cash-status.ts`（改修）：RPCによる楽観的ロック更新と競合検出
  - `bulk-update-cash-status.ts`（新規）：最大50件の一括更新、部分成功対応、監査
  - `export-participants-csv.ts`（新規）：UTF-8 BOM、Excel注入対策、レート制限、監査
- バリデーション
  - `lib/validation/participant-management.ts`（新規）：クエリ/レスポンス/集計/PaymentStatusの集中定義
- 支払いサービス層
  - `lib/services/payment/*`：競合（CONCURRENT_UPDATE）マッピング追加、一括更新IF、RPCセーフ更新メソッド追加
- セキュリティ・運用
  - 権限判定は`verifyEventAccess`やRPC内の主催者チェックで多層化
  - 監査ログ：`system_logs`へCSV出力・支払更新・一括更新を記録
  - レート制限：CSV出力/支払更新に`RATE_LIMIT_CONFIG`追加（`participantsCsvExport`ほか）
  - AdminReasonに`CSV_EXPORT`追加、監査付き管理クライアント経由で操作
- DB（Supabase）
  - `payments`に`version`列追加（楽観的ロック）
  - トリガーで`version`自動インクリメント・`updated_at`更新
  - RPC
    - `rpc_update_payment_status_safe`
    - `rpc_bulk_update_payment_status_safe`
    - 既存の監査付き関数（単体/一括）も同梱
  - 付随インデックス・型定義（`types/database.ts`）更新

## マイグレーション
- `supabase/migrations/20250823100000_add_payment_status_audit_rpc.sql`
- `supabase/migrations/20250824000000_payment_optimistic_lock.sql`
- デプロイ前に適用必須。`payments.version`追加とRPC導入があります。

## セキュリティ/プライバシー
- 主催者限定表示・操作（UI側＋RLS/関数側の多層チェック）
- CSVはUTF-8 BOM付与、先頭記号のサニタイズでExcel CSV Injection対策
- 管理操作は監査ログに詳細記録（ユーザーID、IP、フィルタ条件など）
- レート制限導入（内部UI悪用・過負荷防止）

## パフォーマンス
- 最新決済1件に絞る結合取得
- 参加者一覧はサーバー側ページング（決済フィルタ時は後処理＋再スライス）
- CSVは最大1,000件上限

## 互換性
- イベント主催者判定を`organizer_id`→`created_by`に合わせる変更あり（参照箇所は本PRで対応済み）

## 動作確認
- マイグレーション適用後、主催者で`/events/[id]`へ
  - 参加者一覧：検索/参加状況/決済方法/ステータス/ソート/ページングが動作する
  - 未決済ハイライト表示
  - 現金の単体「受領/免除」更新が成功し、競合時は「CONFLICT」メッセージが出る
  - 一括更新（最大50件）が成功し、部分成功/失敗の件数が表示される
  - 決済サマリーの件数・金額が実データと一致
  - CSV出力がダウンロードでき、Excel表示で文字化けせず、数式評価されない
  - CSV/更新のレート制限が閾値超過でブロックされる

- 関連: #19