### PR TITLE
feat(deadline-management): 締切管理の再定義（grace対応・例外操作・DB更新）

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -52,7 +52,7 @@ function getStatusBadge(status: string) {
     upcoming: { label: "開催予定", variant: "default" as const },
     ongoing: { label: "開催中", variant: "secondary" as const },
     past: { label: "終了", variant: "outline" as const },
-    cancelled: { label: "中止", variant: "destructive" as const },
+    canceled: { label: "中止", variant: "destructive" as const },
   };
 
   const config = statusConfig[status as keyof typeof statusConfig] || {

--- a/app/api/payments/verify-session/route.ts
+++ b/app/api/payments/verify-session/route.ts
@@ -34,7 +34,7 @@ interface VerificationResult {
    * success フラグが true の場合のみ必ず含まれる。
    * リクエストエラー時（success: false）のレスポンスでは省略される。
    */
-  payment_status?: "success" | "failed" | "cancelled" | "processing" | "pending";
+  payment_status?: "success" | "failed" | "canceled" | "processing" | "pending";
   /**
    * このセッションで支払いが必要か（無料・全額割引は false）
    * success フラグが true の場合に付与され得る。
@@ -359,7 +359,7 @@ export async function GET(request: NextRequest) {
       case "unpaid":
         // セッションが期限切れかキャンセルされた場合
         if (cs2.status === "expired") {
-          paymentStatus = "cancelled";
+          paymentStatus = "canceled";
         } else {
           paymentStatus = "pending";
         }

--- a/app/guest/[token]/guest-page-client.tsx
+++ b/app/guest/[token]/guest-page-client.tsx
@@ -41,7 +41,7 @@ export function GuestPageClient({
     setIsProcessingPayment(true);
     try {
       // 現在のURLに安全にクエリパラメータを追加してリダイレクト先を生成
-      const buildRedirectUrl = (status: "success" | "cancelled") => {
+      const buildRedirectUrl = (status: "success" | "canceled") => {
         const url = new URL(window.location.href);
         url.searchParams.delete("session_id");
         // 既存の payment パラメータを置き換える / 存在しなければ追加する
@@ -52,7 +52,7 @@ export function GuestPageClient({
       const result = await createGuestStripeSessionAction({
         guestToken: attendance.guest_token,
         successUrl: buildRedirectUrl("success"),
-        cancelUrl: buildRedirectUrl("cancelled"),
+        cancelUrl: buildRedirectUrl("canceled"),
       });
 
       if (result.success && result.data) {

--- a/app/guest/[token]/page.tsx
+++ b/app/guest/[token]/page.tsx
@@ -56,7 +56,7 @@ export default async function GuestPage({ params, searchParams }: GuestPageProps
   const { payment: paymentParam, session_id } = searchParams;
   const VALID_PAYMENT_STATUSES = new Set([
     "success",
-    "cancelled",
+    "canceled",
     "failed",
     "processing",
     "pending",

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -64,7 +64,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
               icon: "business" as const,
               description: "既に終了したイベントには参加申し込みできません。",
             };
-          case "EVENT_CANCELLED":
+          case "EVENT_CANCELED":
             return {
               title: "定員到達",
               icon: "business" as const,

--- a/core/api/problem-details.ts
+++ b/core/api/problem-details.ts
@@ -293,9 +293,9 @@ const ERROR_DEFINITIONS: Record<string, ErrorDefinition> = {
     defaultDetail: "無効な招待リンクです",
     retryable: false,
   },
-  EVENT_CANCELLED: {
-    type: "https://api.eventpay.app/errors/event_cancelled",
-    title: "Event Cancelled",
+  EVENT_CANCELED: {
+    type: "https://api.eventpay.app/errors/event_canceled",
+    title: "Event Canceled",
     defaultStatus: 410,
     defaultDetail: "このイベントはキャンセルされました",
     retryable: false,

--- a/core/constants/event-filters.ts
+++ b/core/constants/event-filters.ts
@@ -19,7 +19,7 @@ export const STATUS_FILTER_OPTIONS: readonly StatusFilter[] = [
   "upcoming",
   "ongoing",
   "past",
-  "cancelled",
+  "canceled",
 ] as const;
 export const PAYMENT_FILTER_OPTIONS: readonly PaymentFilter[] = ["all", "free", "paid"] as const;
 
@@ -42,7 +42,7 @@ export const STATUS_FILTER_LABELS: Record<StatusFilter, string> = {
   upcoming: "開催予定",
   ongoing: "開催中",
   past: "終了済み",
-  cancelled: "キャンセル",
+  canceled: "キャンセル",
 } as const;
 
 export const PAYMENT_FILTER_LABELS: Record<PaymentFilter, string> = {

--- a/core/event-status-updater.ts
+++ b/core/event-status-updater.ts
@@ -37,11 +37,11 @@ function shouldUpdateEventStatus(event: Event, currentTime: Date): StatusUpdateR
   const { status, date } = event;
 
   // キャンセル済みイベントは更新しない
-  if (status === EVENT_STATUS.CANCELLED) {
+  if (status === EVENT_STATUS.CANCELED) {
     return {
       shouldUpdate: false,
       newStatus: status,
-      reason: "Cancelled events are not updated",
+      reason: "Canceled events are not updated",
     };
   }
 

--- a/core/security/guest-token-validator.ts
+++ b/core/security/guest-token-validator.ts
@@ -47,6 +47,8 @@ export interface RLSGuestAttendanceData {
     capacity: number | null;
     registration_deadline: string | null;
     payment_deadline: string | null;
+    allow_payment_after_deadline?: boolean;
+    grace_period_days?: number | null;
     created_by: string;
     status: Database["public"]["Enums"]["event_status_enum"];
   };
@@ -133,6 +135,9 @@ export class RLSGuestTokenValidator implements IGuestTokenValidator {
             id,
             date,
             registration_deadline,
+            payment_deadline,
+            allow_payment_after_deadline,
+            grace_period_days,
             status
           )
         `
@@ -248,6 +253,8 @@ export class RLSGuestTokenValidator implements IGuestTokenValidator {
             capacity,
             registration_deadline,
             payment_deadline,
+            allow_payment_after_deadline,
+            grace_period_days,
             created_by,
             status
           ),

--- a/core/types/enums.ts
+++ b/core/types/enums.ts
@@ -18,7 +18,7 @@ export type EventStatus =
   | "upcoming" // 開催予定（デフォルト）
   | "ongoing" // 開催中
   | "past" // 終了
-  | "cancelled"; // キャンセル
+  | "canceled"; // キャンセル
 
 /**
  * イベントステータスの定数定義
@@ -27,7 +27,7 @@ export const EVENT_STATUS = {
   UPCOMING: "upcoming" as const,
   ONGOING: "ongoing" as const,
   PAST: "past" as const,
-  CANCELLED: "cancelled" as const,
+  CANCELED: "canceled" as const,
 } as const;
 
 /**
@@ -201,7 +201,7 @@ export const EVENT_STATUS_LABELS: Record<EventStatus, string> = {
   upcoming: "開催予定",
   ongoing: "開催中",
   past: "終了",
-  cancelled: "キャンセル",
+  canceled: "キャンセル",
 };
 
 /**

--- a/core/types/events.ts
+++ b/core/types/events.ts
@@ -10,7 +10,7 @@
 /**
  * イベントステータスフィルタ型
  */
-export type StatusFilter = "all" | "upcoming" | "ongoing" | "past" | "cancelled";
+export type StatusFilter = "all" | "upcoming" | "ongoing" | "past" | "canceled";
 
 /**
  * 支払いフィルタ型

--- a/core/types/models.ts
+++ b/core/types/models.ts
@@ -25,6 +25,8 @@ export interface Event {
   payment_methods: Database["public"]["Enums"]["payment_method_enum"][];
   registration_deadline: string | null;
   payment_deadline: string | null;
+  allow_payment_after_deadline: boolean;
+  grace_period_days: number;
   created_at: string;
   updated_at: string;
   created_by: string;
@@ -58,6 +60,8 @@ export interface EventFormData {
   payment_methods: string[]; // 既存実装では配列
   registration_deadline: string;
   payment_deadline: string;
+  allow_payment_after_deadline?: boolean;
+  grace_period_days?: string; // 数値入力だがフォームでは文字列
 }
 
 // ====================================================================

--- a/core/utils/deadlines.ts
+++ b/core/utils/deadlines.ts
@@ -1,0 +1,69 @@
+/**
+ * 締切関連のユーティリティ
+ * - effective_registration_deadline = registration_deadline ?? date
+ * - effective_payment_deadline = payment_deadline ?? date
+ * - final_payment_limit = allow
+ *     ? min(effective_payment_deadline + grace_days, date + 30d)
+ *     : effective_payment_deadline
+ */
+
+export interface EventDeadlineLike {
+  date: string; // ISO (UTC保管)
+  registration_deadline?: string | null;
+  payment_deadline?: string | null;
+}
+
+export interface FinalLimitOptions {
+  allow_payment_after_deadline?: boolean | null;
+  grace_period_days?: number | null; // 0-30
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * ISO文字列をDateに変換（不正値はInvalid Dateのまま返す）
+ */
+export function toDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * effective_registration_deadline / effective_payment_deadline を導出
+ */
+export function deriveEffectiveDeadlines(event: EventDeadlineLike): {
+  effectiveRegistrationDeadline: Date;
+  effectivePaymentDeadline: Date;
+  eventDate: Date;
+} {
+  const eventDate = new Date(event.date);
+  const reg = toDate(event.registration_deadline) ?? eventDate;
+  const pay = toDate(event.payment_deadline) ?? eventDate;
+  return {
+    effectiveRegistrationDeadline: reg,
+    effectivePaymentDeadline: pay,
+    eventDate,
+  };
+}
+
+/**
+ * 最終支払上限を導出
+ * - allow=false なら effectivePaymentDeadline のまま
+ * - allow=true なら min(effectivePaymentDeadline + graceDays, eventDate + 30d)
+ */
+export function deriveFinalPaymentLimit(
+  args: {
+    effectivePaymentDeadline: Date;
+    eventDate: Date;
+  } & FinalLimitOptions
+): Date {
+  const { effectivePaymentDeadline, eventDate } = args;
+  const allow = Boolean(args.allow_payment_after_deadline);
+  if (!allow) return effectivePaymentDeadline;
+
+  const graceDays = Math.max(0, Math.min(30, Number(args.grace_period_days ?? 0)));
+  const candidate = new Date(effectivePaymentDeadline.getTime() + graceDays * ONE_DAY_MS);
+  const eventPlus30d = new Date(eventDate.getTime() + 30 * ONE_DAY_MS);
+  return new Date(Math.min(candidate.getTime(), eventPlus30d.getTime()));
+}

--- a/core/utils/error-handler.ts
+++ b/core/utils/error-handler.ts
@@ -80,8 +80,8 @@ const ERROR_MAPPINGS: Record<string, Omit<ErrorDetails, "code">> = {
     shouldAlert: false,
     retryable: false,
   },
-  EVENT_CANCELLED: {
-    message: "Event has been cancelled",
+  EVENT_CANCELED: {
+    message: "Event has been canceled",
     userMessage: "このイベントはキャンセルされました。",
     severity: "low",
     shouldLog: false,

--- a/core/utils/form-data-extractors.ts
+++ b/core/utils/form-data-extractors.ts
@@ -119,6 +119,8 @@ interface EventCreateFormData {
   capacity?: string;
   registration_deadline?: string;
   payment_deadline?: string;
+  allow_payment_after_deadline?: boolean;
+  grace_period_days?: number;
 }
 
 export function extractEventCreateFormData(formData: FormData): EventCreateFormData {
@@ -134,6 +136,8 @@ export function extractEventCreateFormData(formData: FormData): EventCreateFormD
     capacity: extractor.extractOptionalValue("capacity"),
     registration_deadline: extractor.extractOptionalValue("registration_deadline"),
     payment_deadline: extractor.extractOptionalValue("payment_deadline"),
+    allow_payment_after_deadline: extractor.extractBooleanValue("allow_payment_after_deadline"),
+    grace_period_days: extractor.extractNumberValue("grace_period_days"),
   };
 }
 
@@ -155,5 +159,7 @@ export function extractEventUpdateFormData(formData: FormData): Partial<UpdateEv
     capacity: extractor.extractOptionalValue("capacity"),
     registration_deadline: extractor.extractOptionalValue("registration_deadline"),
     payment_deadline: extractor.extractOptionalValue("payment_deadline"),
+    allow_payment_after_deadline: extractor.extractBooleanValue("allow_payment_after_deadline"),
+    grace_period_days: extractor.extractNumberValue("grace_period_days"),
   };
 }

--- a/core/utils/guest-token.ts
+++ b/core/utils/guest-token.ts
@@ -36,6 +36,8 @@ export interface GuestAttendanceData {
     capacity: number | null;
     registration_deadline: string | null;
     payment_deadline: string | null;
+    allow_payment_after_deadline?: boolean;
+    grace_period_days?: number | null;
     status: Database["public"]["Enums"]["event_status_enum"];
     created_by: string;
   };

--- a/core/utils/invite-token.ts
+++ b/core/utils/invite-token.ts
@@ -57,7 +57,7 @@ export interface InviteValidationResult {
   errorCode?:
     | "INVALID_TOKEN"
     | "TOKEN_NOT_FOUND"
-    | "EVENT_CANCELLED"
+    | "EVENT_CANCELED"
     | "EVENT_ENDED"
     | "REGISTRATION_DEADLINE_PASSED"
     | "UNKNOWN_ERROR";
@@ -170,13 +170,13 @@ export async function validateInviteToken(token: string): Promise<InviteValidati
     };
 
     // イベントがキャンセルされているか確認
-    if (event.status === "cancelled") {
+    if (event.status === "canceled") {
       return {
         isValid: true,
         event: eventDetail,
         canRegister: false,
         errorMessage: "このイベントはキャンセルされました",
-        errorCode: "EVENT_CANCELLED",
+        errorCode: "EVENT_CANCELED",
       };
     }
 

--- a/core/validation/payment-eligibility.ts
+++ b/core/validation/payment-eligibility.ts
@@ -96,8 +96,8 @@ export function checkBasicPaymentEligibility(
     grace_period_days: event.grace_period_days,
   } as FinalLimitOptions & { effectivePaymentDeadline: Date; eventDate: Date });
 
-  // ステータスガード: cancelledのみ禁止。猶予ONの場合はpastも許可
-  const isEventActiveForPayment = event.status !== "cancelled";
+  // ステータスガード: canceledのみ禁止。猶予ONの場合はpastも許可
+  const isEventActiveForPayment = event.status !== "canceled";
 
   const checks = {
     isAttending: attendance.status === "attending",

--- a/features/events/actions/admin-add-attendance.ts
+++ b/features/events/actions/admin-add-attendance.ts
@@ -1,0 +1,181 @@
+"use server";
+
+import { z } from "zod";
+
+import { verifyEventAccess } from "@core/auth/event-authorization";
+import { logger } from "@core/logging/app-logger";
+import { SecureSupabaseClientFactory } from "@core/security/secure-client-factory.impl";
+import { AdminReason } from "@core/security/secure-client-factory.types";
+import {
+  createServerActionError,
+  createServerActionSuccess,
+  type ServerActionResult,
+} from "@core/types/server-actions";
+import { generateGuestToken } from "@core/utils/guest-token";
+import { canCreateStripeSession } from "@core/validation/payment-eligibility";
+
+// 入力検証
+const AddAttendanceInputSchema = z.object({
+  eventId: z.string().uuid(),
+  nickname: z.string().min(1, "ニックネームは必須です").max(50),
+  // MVPではメールを入力しない（将来の通知機能のためにschemaからは削除）
+  status: z.enum(["attending", "maybe", "not_attending"]).default("attending"),
+  bypassCapacity: z.boolean().optional().default(false),
+});
+
+export type AddAttendanceInput = z.infer<typeof AddAttendanceInputSchema>;
+
+export interface AddAttendanceResult {
+  attendanceId: string;
+  guestToken: string;
+  guestUrl: string;
+  canOnlinePay: boolean;
+  reason?: string;
+}
+
+/**
+ * 主催者が手動で参加者を追加する（締切制約なし、定員は上書き可能）
+ * - 既存のRPCの容量チェックを回避するため、Service Roleで直接INSERT
+ * - 定員超過時、bypassCapacity=false なら確認要求エラーを返す
+ * - 追加完了後、ゲストURLとオンライン決済可否を返す
+ */
+export async function adminAddAttendanceAction(
+  input: unknown
+): Promise<
+  ServerActionResult<
+    AddAttendanceResult | { confirmRequired: true; capacity?: number | null; current?: number }
+  >
+> {
+  try {
+    const { eventId, nickname, status, bypassCapacity } = AddAttendanceInputSchema.parse(input);
+
+    // 認証・主催者権限確認（イベント所有者）
+    const { user } = await verifyEventAccess(eventId);
+
+    // 認証済みクライアント（RLS）と管理クライアント（RLSバイパス）
+    const secureFactory = SecureSupabaseClientFactory.getInstance();
+    const adminClient = await secureFactory.createAuditedAdminClient(
+      AdminReason.EVENT_MANAGEMENT,
+      "admin_add_attendance",
+      { eventId, actorId: user.id }
+    );
+
+    // イベント情報取得（決済可否判定・定員チェック用）
+    const { data: eventRow, error: eventErr } = await adminClient
+      .from("events")
+      .select(
+        `id, created_by, status, date, fee, capacity, registration_deadline, payment_deadline, allow_payment_after_deadline, grace_period_days`
+      )
+      .eq("id", eventId)
+      .single();
+
+    if (eventErr || !eventRow) {
+      return createServerActionError("NOT_FOUND", "イベントが見つかりません");
+    }
+
+    // 重複メールチェック（同一イベント内）
+    // MVP: email は入力しないため重複チェックはスキップ
+
+    // 定員チェック（attending 追加時のみ）
+    if (status === "attending" && eventRow.capacity !== null) {
+      const { count: currentCount, error: cntErr } = await adminClient
+        .from("attendances")
+        .select("id", { count: "exact", head: true })
+        .eq("event_id", eventId)
+        .eq("status", "attending");
+      if (cntErr) {
+        return createServerActionError("DATABASE_ERROR", cntErr.message);
+      }
+      const isFull =
+        typeof currentCount === "number" && currentCount >= (eventRow.capacity as number);
+      if (isFull && !bypassCapacity) {
+        // 確認要求
+        return createServerActionSuccess({
+          confirmRequired: true,
+          capacity: eventRow.capacity,
+          current: currentCount,
+        });
+      }
+    }
+
+    // ゲストトークン生成
+    const guestToken = generateGuestToken();
+
+    // 参加者レコード挿入（MVP: emailは未収集のためプレースホルダを保存）
+    const placeholderEmail = `noemail+${guestToken.substring(4, 12)}.${eventId.substring(0, 8)}@guest.eventpay.local`;
+    const { data: inserted, error: insErr } = await adminClient
+      .from("attendances")
+      .insert({
+        event_id: eventId,
+        nickname,
+        email: placeholderEmail,
+        status,
+        guest_token: guestToken,
+      })
+      .select("id")
+      .single();
+
+    if (insErr || !inserted) {
+      return createServerActionError(
+        "DATABASE_ERROR",
+        insErr?.message || "参加者の追加に失敗しました"
+      );
+    }
+
+    const attendanceId = inserted.id as string;
+
+    // 決済可否（Stripe）を判定
+    const eventForEligibility = {
+      id: eventRow.id,
+      status: eventRow.status as any,
+      fee: eventRow.fee,
+      date: eventRow.date,
+      payment_deadline: eventRow.payment_deadline,
+      allow_payment_after_deadline: eventRow.allow_payment_after_deadline ?? false,
+      grace_period_days: eventRow.grace_period_days ?? 0,
+    };
+    const attendanceForEligibility = {
+      id: attendanceId,
+      status: status as any,
+      payment: null,
+    };
+    const eligibility = canCreateStripeSession(attendanceForEligibility, eventForEligibility);
+
+    // ゲストURL（/guest/gst_xxx）
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      process.env.NEXT_PUBLIC_SITE_URL ||
+      "http://localhost:3000";
+    const guestUrl = `${baseUrl}/guest/${guestToken}`;
+
+    // 監査ログ
+    logger.info("ADMIN_ADD_ATTENDANCE", {
+      eventId,
+      attendanceId,
+      actorId: user.id,
+      bypassCapacity,
+      nickname,
+      email: placeholderEmail.toLowerCase(),
+      canOnlinePay: eligibility.isEligible,
+    });
+
+    return createServerActionSuccess<AddAttendanceResult>({
+      attendanceId,
+      guestToken,
+      guestUrl,
+      canOnlinePay: eligibility.isEligible,
+      reason: eligibility.reason,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return createServerActionError(
+        "VALIDATION_ERROR",
+        error.errors?.[0]?.message || "入力が不正です",
+        {
+          details: { zodErrors: error.errors },
+        }
+      );
+    }
+    return createServerActionError("INTERNAL_ERROR", "参加者の追加処理でエラーが発生しました");
+  }
+}

--- a/features/events/actions/create-event.ts
+++ b/features/events/actions/create-event.ts
@@ -34,6 +34,8 @@ type FormDataFields = {
   capacity?: string;
   registration_deadline?: string;
   payment_deadline?: string;
+  allow_payment_after_deadline?: boolean;
+  grace_period_days?: number;
 };
 
 export async function createEventAction(formData: FormData): Promise<CreateEventResult> {
@@ -181,6 +183,8 @@ function buildEventData(
   capacity: number | null;
   registration_deadline: string | null;
   payment_deadline: string | null;
+  allow_payment_after_deadline: boolean;
+  grace_period_days: number;
   created_by: string;
   invite_token: string;
 } {
@@ -204,6 +208,8 @@ function buildEventData(
     payment_deadline: validatedData.payment_deadline
       ? convertDatetimeLocalToIso(validatedData.payment_deadline)
       : null,
+    allow_payment_after_deadline: Boolean(validatedData.allow_payment_after_deadline),
+    grace_period_days: Number(validatedData.grace_period_days ?? 0),
     created_by: userId,
     invite_token: inviteToken,
   };

--- a/features/events/actions/generate-guest-url.ts
+++ b/features/events/actions/generate-guest-url.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import { z } from "zod";
+
+import { verifyEventAccess } from "@core/auth/event-authorization";
+import { SecureSupabaseClientFactory } from "@core/security/secure-client-factory.impl";
+import { AdminReason } from "@core/security/secure-client-factory.types";
+import {
+  createServerActionError,
+  createServerActionSuccess,
+  type ServerActionResult,
+} from "@core/types/server-actions";
+import { canCreateStripeSession } from "@core/validation/payment-eligibility";
+
+const InputSchema = z.object({
+  eventId: z.string().uuid(),
+  attendanceId: z.string().uuid(),
+});
+
+export async function generateGuestUrlAction(input: unknown): Promise<
+  ServerActionResult<{
+    guestUrl: string;
+    canOnlinePay: boolean;
+    reason?: string;
+  }>
+> {
+  try {
+    const { eventId, attendanceId } = InputSchema.parse(input);
+
+    // 主催者権限確認
+    const { user } = await verifyEventAccess(eventId);
+
+    const factory = SecureSupabaseClientFactory.getInstance();
+    const admin = await factory.createAuditedAdminClient(
+      AdminReason.EVENT_MANAGEMENT,
+      "generate_guest_url",
+      { eventId, actorId: user.id, attendanceId }
+    );
+
+    // attendance と event を取得（guest_token, 決済可否判定用）
+    const { data: attendance, error: attErr } = await admin
+      .from("attendances")
+      .select(
+        "id, status, guest_token, event:events(id, status, date, fee, payment_deadline, allow_payment_after_deadline, grace_period_days)"
+      )
+      .eq("id", attendanceId)
+      .eq("event_id", eventId)
+      .single();
+
+    if (attErr || !attendance) {
+      return createServerActionError("NOT_FOUND", "参加レコードが見つかりません");
+    }
+
+    const guestToken: string | null = attendance.guest_token as unknown as string | null;
+    if (!guestToken) {
+      return createServerActionError("RESOURCE_CONFLICT", "ゲストトークンが未発行です");
+    }
+
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      process.env.NEXT_PUBLIC_SITE_URL ||
+      "http://localhost:3000";
+    const guestUrl = `${baseUrl}/guest/${guestToken}`;
+
+    const eventRel: unknown = (attendance as any).event;
+    const ev = Array.isArray(eventRel) ? (eventRel[0] as any) : (eventRel as any);
+
+    const eligibility = canCreateStripeSession(
+      { id: attendance.id, status: attendance.status as any, payment: null },
+      {
+        id: ev.id as string,
+        status: ev.status as any,
+        fee: ev.fee as number,
+        date: ev.date as string,
+        payment_deadline: (ev as any).payment_deadline ?? null,
+        allow_payment_after_deadline: (ev as any).allow_payment_after_deadline ?? false,
+        grace_period_days: (ev as any).grace_period_days ?? 0,
+      }
+    );
+
+    return createServerActionSuccess({
+      guestUrl,
+      canOnlinePay: eligibility.isEligible,
+      reason: eligibility.reason,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return createServerActionError(
+        "VALIDATION_ERROR",
+        error.errors?.[0]?.message || "入力が不正です",
+        {
+          details: { zodErrors: error.errors },
+        }
+      );
+    }
+    return createServerActionError("INTERNAL_ERROR", "ゲストURLの生成でエラーが発生しました");
+  }
+}

--- a/features/events/actions/get-events.ts
+++ b/features/events/actions/get-events.ts
@@ -106,12 +106,12 @@ export async function getEventsAction(options: GetEventsOptions = {}): Promise<G
 
     if (
       statusFilter &&
-      !["all", "upcoming", "ongoing", "past", "cancelled"].includes(statusFilter)
+      !["all", "upcoming", "ongoing", "past", "canceled"].includes(statusFilter)
     ) {
       return {
         success: false,
         error:
-          "statusFilterは'all', 'upcoming', 'ongoing', 'past', 'cancelled'のいずれかである必要があります",
+          "statusFilterは'all', 'upcoming', 'ongoing', 'past', 'canceled'のいずれかである必要があります",
       };
     }
 

--- a/features/events/actions/update-event.ts
+++ b/features/events/actions/update-event.ts
@@ -329,5 +329,22 @@ function buildUpdateData(
     }
   }
 
+  // 締切後決済許可
+  if (validatedData.allow_payment_after_deadline !== undefined) {
+    const next = Boolean(validatedData.allow_payment_after_deadline);
+    if (next !== (existingEvent as any).allow_payment_after_deadline) {
+      (updateData as any).allow_payment_after_deadline = next;
+    }
+  }
+
+  // 猶予日数
+  if (validatedData.grace_period_days !== undefined) {
+    const raw = validatedData.grace_period_days as number;
+    const next = Number.isFinite(raw) ? Number(raw) : 0;
+    if (next !== (existingEvent as any).grace_period_days) {
+      (updateData as any).grace_period_days = next;
+    }
+  }
+
   return updateData;
 }

--- a/features/events/components/event-card.tsx
+++ b/features/events/components/event-card.tsx
@@ -19,7 +19,7 @@ const STATUS_CONFIG = {
   upcoming: { text: EVENT_STATUS_LABELS.upcoming, styles: "bg-green-100 text-green-800" },
   ongoing: { text: EVENT_STATUS_LABELS.ongoing, styles: "bg-blue-100 text-blue-800" },
   past: { text: EVENT_STATUS_LABELS.past, styles: "bg-gray-100 text-gray-800" },
-  cancelled: { text: EVENT_STATUS_LABELS.cancelled, styles: "bg-red-100 text-red-800" },
+  canceled: { text: EVENT_STATUS_LABELS.canceled, styles: "bg-red-100 text-red-800" },
 } as const;
 
 export const EventCard = memo(function EventCard({ event }: EventCardProps) {

--- a/features/events/components/event-detail.tsx
+++ b/features/events/components/event-detail.tsx
@@ -13,7 +13,7 @@ interface EventDetailProps {
     location: any;
     fee: number;
     capacity: any;
-    status: "upcoming" | "ongoing" | "past" | "cancelled";
+    status: "upcoming" | "ongoing" | "past" | "canceled";
     description?: any;
     registration_deadline?: any;
     payment_deadline?: any;

--- a/features/events/components/event-detail.tsx
+++ b/features/events/components/event-detail.tsx
@@ -84,7 +84,7 @@ export function EventDetail({ event }: EventDetailProps) {
 
           {event.payment_deadline && (
             <div>
-              <h3 className="text-sm font-medium text-gray-700">決済締切</h3>
+              <h3 className="text-sm font-medium text-gray-700">オンライン決済締切</h3>
               <p className="mt-1 text-sm text-gray-900">
                 {formatUtcToJstByType(event.payment_deadline, "japanese")}
               </p>

--- a/features/events/components/event-edit-form.tsx
+++ b/features/events/components/event-edit-form.tsx
@@ -19,6 +19,7 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  FormDescription,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -349,7 +350,7 @@ export function EventEditForm({ event, attendeeCount, onSubmit, serverError }: E
                 <div>
                   <h3 className="text-lg font-medium text-gray-900">締切設定</h3>
                   <p className="text-sm text-gray-500">
-                    参加申込と支払いの締切日時を設定してください
+                    参加申込とオンライン決済の締切日時を設定してください
                   </p>
                 </div>
 
@@ -375,7 +376,7 @@ export function EventEditForm({ event, attendeeCount, onSubmit, serverError }: E
                     name="payment_deadline"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>支払い締切</FormLabel>
+                        <FormLabel>オンライン決済締切</FormLabel>
                         <FormControl>
                           <Input {...field} type="datetime-local" disabled={isPending} />
                         </FormControl>
@@ -384,6 +385,70 @@ export function EventEditForm({ event, attendeeCount, onSubmit, serverError }: E
                     )}
                   />
                 </div>
+
+                {/* 締切後もオンライン決済を許可 + 猶予（日） */}
+                {!isFreeEvent && form.watch("payment_deadline") && (
+                  <div className="space-y-3">
+                    <FormField
+                      control={form.control}
+                      name="allow_payment_after_deadline"
+                      as={undefined as never}
+                      render={() => (
+                        <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                          <FormControl>
+                            <Checkbox
+                              checked={Boolean(form.watch("allow_payment_after_deadline"))}
+                              onCheckedChange={(checked) => {
+                                form.setValue("allow_payment_after_deadline", checked === true);
+                                void form.trigger();
+                              }}
+                              disabled={isPending}
+                            />
+                          </FormControl>
+                          <div className="space-y-1 leading-none">
+                            <FormLabel>締切後もオンライン決済を許可</FormLabel>
+                            <FormDescription>
+                              終了後も支払いを受け付けます（最長30日まで）。
+                            </FormDescription>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+
+                    {form.watch("allow_payment_after_deadline") && (
+                      <FormField
+                        control={form.control}
+                        name="grace_period_days"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>猶予（日）</FormLabel>
+                            <FormControl>
+                              <Input
+                                {...field}
+                                type="number"
+                                inputMode="numeric"
+                                min="0"
+                                max="30"
+                                step="1"
+                                placeholder="例：7"
+                                disabled={isPending}
+                                onChange={(e) => {
+                                  const v = e.target.value;
+                                  field.onChange(v);
+                                  void form.trigger();
+                                }}
+                              />
+                            </FormControl>
+                            <FormDescription>
+                              オンライン決済締切からの猶予日数（最大30日）。
+                            </FormDescription>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+                  </div>
+                )}
               </div>
 
               {/* アクションボタン */}

--- a/features/events/components/event-edit-form.tsx
+++ b/features/events/components/event-edit-form.tsx
@@ -392,7 +392,6 @@ export function EventEditForm({ event, attendeeCount, onSubmit, serverError }: E
                     <FormField
                       control={form.control}
                       name="allow_payment_after_deadline"
-                      as={undefined as never}
                       render={() => (
                         <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                           <FormControl>

--- a/features/events/components/event-form.tsx
+++ b/features/events/components/event-form.tsx
@@ -170,7 +170,7 @@ function EventCreateForm(): JSX.Element {
               <div>
                 <h3 className="text-lg font-medium text-gray-900">締切設定</h3>
                 <p className="text-sm text-gray-500">
-                  参加申込と決済の締切を設定してください (任意)
+                  参加申込とオンライン決済の締切を設定してください (任意)
                 </p>
               </div>
 
@@ -195,13 +195,13 @@ function EventCreateForm(): JSX.Element {
                 )}
               />
 
-              {/* 決済締切 */}
+              {/* オンライン決済締切 */}
               <FormField
                 control={form.control}
                 name="payment_deadline"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>決済締切</FormLabel>
+                    <FormLabel>オンライン決済締切</FormLabel>
                     <FormControl>
                       <Input
                         {...field}
@@ -210,11 +210,77 @@ function EventCreateForm(): JSX.Element {
                         min={minDatetimeLocal}
                       />
                     </FormControl>
-                    <FormDescription>決済の締切日時を設定してください (任意)</FormDescription>
+                    <FormDescription>
+                      オンライン決済の締切日時を設定してください (任意)
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
               />
+
+              {/* 締切後もオンライン決済を許可 + 猶予（日） */}
+              {!isFreeEvent && form.watch("payment_deadline") && (
+                <div className="space-y-3">
+                  <FormField
+                    control={form.control}
+                    name="allow_payment_after_deadline"
+                    render={() => (
+                      <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                        <FormControl>
+                          <Checkbox
+                            checked={Boolean(form.watch("allow_payment_after_deadline"))}
+                            onCheckedChange={(checked) => {
+                              form.setValue("allow_payment_after_deadline", checked === true);
+                              // 相関バリデーション再評価
+                              void form.trigger();
+                            }}
+                            disabled={isPending}
+                          />
+                        </FormControl>
+                        <div className="space-y-1 leading-none">
+                          <FormLabel>締切後もオンライン決済を許可</FormLabel>
+                          <FormDescription>
+                            終了後も支払いを受け付けます（最長30日まで）。
+                          </FormDescription>
+                        </div>
+                      </FormItem>
+                    )}
+                  />
+
+                  {form.watch("allow_payment_after_deadline") && (
+                    <FormField
+                      control={form.control}
+                      name="grace_period_days"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>猶予（日）</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              type="number"
+                              inputMode="numeric"
+                              min="0"
+                              max="30"
+                              step="1"
+                              placeholder="例：7"
+                              disabled={isPending}
+                              onChange={(e) => {
+                                const v = e.target.value;
+                                field.onChange(v);
+                                void form.trigger();
+                              }}
+                            />
+                          </FormControl>
+                          <FormDescription>
+                            オンライン決済締切からの猶予日数（最大30日）。
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
+                </div>
+              )}
             </div>
 
             {/* 決済方法セクション */}

--- a/features/events/components/participants-management.tsx
+++ b/features/events/components/participants-management.tsx
@@ -10,6 +10,17 @@ import type {
   GetEventPaymentsResponse,
 } from "@core/validation/participant-management";
 
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+import { adminAddAttendanceAction } from "../actions/admin-add-attendance";
 import { getEventParticipantsAction } from "../actions/get-event-participants";
 import { getEventPaymentsAction } from "../actions/get-event-payments";
 
@@ -38,6 +49,59 @@ export function ParticipantsManagement({
   const [isLoading, setIsLoading] = useState(false);
   const [isPaymentsLoading, setIsPaymentsLoading] = useState(false);
   const { toast } = useToast();
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [addNickname, setAddNickname] = useState("");
+  // const [addEmail, setAddEmail] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [confirmOverCapacity, setConfirmOverCapacity] = useState<null | {
+    capacity?: number | null;
+    current?: number;
+  }>(null);
+
+  const handleOpenAdd = () => {
+    setAddNickname("");
+    setConfirmOverCapacity(null);
+    setShowAddDialog(true);
+  };
+
+  const handleSubmitAdd = async (forceBypass = false) => {
+    if (isAdding) return;
+    setIsAdding(true);
+    try {
+      const result = await adminAddAttendanceAction({
+        eventId,
+        nickname: addNickname,
+        status: "attending",
+        bypassCapacity: forceBypass,
+      });
+      if (!result.success) {
+        if ((result as any).data?.confirmRequired || (result as any).confirmRequired) {
+          const payload = (result as any).data || result;
+          setConfirmOverCapacity({ capacity: payload.capacity, current: payload.current });
+          return;
+        }
+        toast({
+          title: "追加に失敗しました",
+          description: result.error || "参加者の追加に失敗しました",
+          variant: "destructive",
+        });
+        return;
+      }
+      const data = result.data as import("../actions/admin-add-attendance").AddAttendanceResult;
+      await navigator.clipboard.writeText((data as any).guestUrl);
+      toast({
+        title: "参加者を追加しました",
+        description: (data as any).canOnlinePay
+          ? "ゲストURLをコピーしました（現在オンライン決済が可能です）"
+          : "ゲストURLをコピーしました（オンライン決済は現在できません）",
+      });
+      setShowAddDialog(false);
+      setConfirmOverCapacity(null);
+      await refreshAllData();
+    } finally {
+      setIsAdding(false);
+    }
+  };
 
   // 決済データ更新ハンドラー
   const refreshPaymentsData = useCallback(async () => {
@@ -111,8 +175,15 @@ export function ParticipantsManagement({
         payments={paymentsData.payments}
       />
 
-      {/* 決済状況サマリー（MANAGE-002新機能） */}
+      {/* 決済状況サマリー */}
       <PaymentSummary summary={paymentsData.summary} isLoading={isPaymentsLoading} />
+
+      {/* 参加者追加ボタン */}
+      <div className="flex justify-end">
+        <Button onClick={handleOpenAdd} variant="default">
+          参加者を追加
+        </Button>
+      </div>
 
       {/* 参加者一覧テーブル */}
       <ParticipantsTable
@@ -122,6 +193,52 @@ export function ParticipantsManagement({
         isLoading={isLoading}
         onPaymentStatusUpdate={refreshAllData}
       />
+
+      {/* 追加ダイアログ */}
+      <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>参加者を追加</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input
+              placeholder="ニックネーム"
+              value={addNickname}
+              onChange={(e) => setAddNickname(e.target.value)}
+            />
+            {/* MVPではメールは収集しない */}
+            {confirmOverCapacity && (
+              <div className="text-sm text-orange-700 bg-orange-50 border border-orange-200 rounded p-2">
+                定員（{confirmOverCapacity.capacity ?? "-"}）を超過します。本当に追加しますか？
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            {!confirmOverCapacity ? (
+              <Button onClick={() => void handleSubmitAdd(false)} disabled={isAdding}>
+                追加
+              </Button>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => setConfirmOverCapacity(null)}
+                  disabled={isAdding}
+                >
+                  戻る
+                </Button>
+                <Button
+                  onClick={() => void handleSubmitAdd(true)}
+                  disabled={isAdding}
+                  className="bg-red-600 hover:bg-red-700"
+                >
+                  定員超過で追加
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/features/events/components/payment-status-alert.tsx
+++ b/features/events/components/payment-status-alert.tsx
@@ -21,7 +21,7 @@ interface PaymentStatusAlertProps {
 }
 
 interface VerificationSuccessResult {
-  payment_status: "success" | "failed" | "cancelled" | "processing" | "pending";
+  payment_status: "success" | "failed" | "canceled" | "processing" | "pending";
   payment_required: boolean;
 }
 
@@ -160,7 +160,7 @@ export function PaymentStatusAlert({
 
   // paymentStatus と verifiedStatus からの派生状態を単一点に集約
   const derivedStatus = useMemo(() => {
-    return paymentStatus === "cancelled" ? "cancelled" : verifiedStatus || paymentStatus;
+    return paymentStatus === "canceled" ? "canceled" : verifiedStatus || paymentStatus;
   }, [paymentStatus, verifiedStatus]);
 
   // ポーリング打ち切り後に手動再確認する関数
@@ -180,7 +180,7 @@ export function PaymentStatusAlert({
   // セッション検証を実行（sessionIdがある場合）
   useEffect(() => {
     // キャンセル導線では検証を行わず、UIのキャンセル表示を優先する
-    if (derivedStatus === "cancelled") return;
+    if (derivedStatus === "canceled") return;
 
     if (sessionId && !verifiedStatus && !isVerifying) {
       verifySession();
@@ -190,7 +190,7 @@ export function PaymentStatusAlert({
   // 決済ステータスが processing/pending の間は指数バックオフで再検証
   useEffect(() => {
     if (
-      derivedStatus !== "cancelled" &&
+      derivedStatus !== "canceled" &&
       sessionId &&
       ["processing", "pending"].includes(derivedStatus) &&
       retryCount < maxRetries
@@ -206,7 +206,7 @@ export function PaymentStatusAlert({
 
   // ステータス確定後はリトライ回数をリセット
   useEffect(() => {
-    const finalStatuses = ["success", "failed", "cancelled"];
+    const finalStatuses = ["success", "failed", "canceled"];
     if (finalStatuses.includes(derivedStatus)) {
       setRetryCount(0);
     }
@@ -226,7 +226,7 @@ export function PaymentStatusAlert({
   const getAlertContent = () => {
     // 検証中はローディング状態を表示
     // キャンセル時は検証ローディングを表示しない
-    if (sessionId && isVerifying && derivedStatus !== "cancelled") {
+    if (sessionId && isVerifying && derivedStatus !== "canceled") {
       return {
         variant: "default" as const,
         icon: <Loader2 className="h-5 w-5 text-blue-600 animate-spin" />,
@@ -272,7 +272,7 @@ export function PaymentStatusAlert({
           title: verifiedStatus ? "決済が完了しました（検証済み）" : "決済が完了しました",
           description: `${sanitizeForEventPay(eventTitle)}の参加費の決済が正常に完了しました。参加登録が確定されました。`,
         };
-      case "cancelled":
+      case "canceled":
         return {
           variant: "default" as const,
           icon: <XCircle className="h-5 w-5 text-orange-600" />,

--- a/features/events/hooks/use-event-changes.ts
+++ b/features/events/hooks/use-event-changes.ts
@@ -76,7 +76,19 @@ export function useEventChanges({
         field: "payment_deadline",
         oldValue: formatUtcToDatetimeLocal(event.payment_deadline || ""),
         newValue: formData.payment_deadline || "",
-        fieldName: "支払い締切",
+        fieldName: "オンライン決済締切",
+      },
+      {
+        field: "allow_payment_after_deadline",
+        oldValue: ((event as any).allow_payment_after_deadline ?? false).toString(),
+        newValue: ((formData as any).allow_payment_after_deadline ?? false).toString(),
+        fieldName: "締切後もオンライン決済を許可",
+      },
+      {
+        field: "grace_period_days",
+        oldValue: (((event as any).grace_period_days ?? 0) as number).toString(),
+        newValue: ((formData as any).grace_period_days ?? "0") as string,
+        fieldName: "猶予（日）",
       },
     ];
 
@@ -141,7 +153,13 @@ export function useEventChanges({
       const fieldTypes = {
         basic: ["title", "description", "location"],
         datetime: ["date", "registration_deadline", "payment_deadline"],
-        payment: ["fee", "payment_methods", "capacity"],
+        payment: [
+          "fee",
+          "payment_methods",
+          "capacity",
+          "allow_payment_after_deadline",
+          "grace_period_days",
+        ],
       };
 
       return changes.filter((change) => fieldTypes[fieldType].includes(change.field));

--- a/features/events/hooks/use-event-submission.ts
+++ b/features/events/hooks/use-event-submission.ts
@@ -33,6 +33,8 @@ interface FormErrors {
   payment_methods?: string;
   registration_deadline?: string;
   payment_deadline?: string;
+  allow_payment_after_deadline?: string;
+  grace_period_days?: string;
   general?: string;
 }
 
@@ -53,6 +55,8 @@ export function useEventSubmission({ eventId, onSubmit }: UseEventSubmissionProp
         Object.entries(formData).forEach(([key, value]) => {
           if (Array.isArray(value)) {
             value.forEach((v) => formDataObj.append(key, v));
+          } else if (typeof value === "boolean") {
+            formDataObj.append(key, String(value));
           } else if (value !== "") {
             formDataObj.append(key, value);
           }
@@ -128,6 +132,12 @@ export function useEventSubmission({ eventId, onSubmit }: UseEventSubmissionProp
         case "payment_deadline":
           submissionData.payment_deadline = value as string;
           break;
+        case "allow_payment_after_deadline":
+          submissionData.allow_payment_after_deadline = value as boolean;
+          break;
+        case "grace_period_days":
+          submissionData.grace_period_days = value as string;
+          break;
       }
     });
 
@@ -141,6 +151,8 @@ export function useEventSubmission({ eventId, onSubmit }: UseEventSubmissionProp
     Object.entries(data).forEach(([key, value]) => {
       if (Array.isArray(value)) {
         value.forEach((v) => formDataObj.append(key, v));
+      } else if (typeof value === "boolean") {
+        formDataObj.append(key, String(value));
       } else if (value !== "") {
         formDataObj.append(key, value);
       }

--- a/features/events/validation.ts
+++ b/features/events/validation.ts
@@ -52,7 +52,7 @@ export const inviteGenerationSchema = z.object({
 
 // 参加者検索・フィルタ用バリデーション
 export const participantFilterSchema = z.object({
-  status: z.enum(["confirmed", "pending", "cancelled"]).optional(),
+  status: z.enum(["confirmed", "pending", "canceled"]).optional(),
   payment_status: z
     .enum(["pending", "paid", "received", "failed", "completed", "refunded", "waived"])
     .optional(),

--- a/features/guest/actions/create-stripe-session.ts
+++ b/features/guest/actions/create-stripe-session.ts
@@ -60,7 +60,16 @@ export async function createGuestStripeSessionAction(
   const event = attendance.event;
 
   // 決済許可条件の統一チェック
-  const eligibilityResult = canCreateStripeSession(attendance, event);
+  const eligibilityResult = canCreateStripeSession(attendance, {
+    id: event.id,
+    status: event.status,
+    fee: event.fee,
+    date: event.date,
+    payment_deadline: event.payment_deadline,
+    // 新フィールド（存在しない場合は既定値で解釈）
+    allow_payment_after_deadline: event.allow_payment_after_deadline ?? false,
+    grace_period_days: event.grace_period_days ?? 0,
+  });
   if (!eligibilityResult.isEligible) {
     return createServerActionError(
       "RESOURCE_CONFLICT",

--- a/features/guest/components/guest-event-details.tsx
+++ b/features/guest/components/guest-event-details.tsx
@@ -62,7 +62,7 @@ export function GuestEventDetails({ attendance }: GuestEventDetailsProps) {
           <div className="flex items-center space-x-3">
             <Clock className="h-5 w-5 text-gray-500 flex-shrink-0" />
             <div className="text-gray-900">
-              決済締切:{" "}
+              オンライン決済締切:{" "}
               <span className="font-medium">
                 {formatUtcToJstByType(event.payment_deadline, "japanese")}
               </span>

--- a/features/guest/components/guest-management-form.tsx
+++ b/features/guest/components/guest-management-form.tsx
@@ -472,7 +472,7 @@ export function GuestManagementForm({ attendance, canModify }: GuestManagementFo
 
             {attendance.event.payment_deadline && (
               <div>
-                <h4 className="text-sm font-medium text-gray-700">決済締切</h4>
+                <h4 className="text-sm font-medium text-gray-700">オンライン決済締切</h4>
                 <p className="mt-1 text-sm text-gray-900 break-words">
                   {formatUtcToJstByType(attendance.event.payment_deadline, "japanese")}
                 </p>

--- a/features/invite/components/invite-event-detail.tsx
+++ b/features/invite/components/invite-event-detail.tsx
@@ -174,7 +174,7 @@ export function InviteEventDetail({ event, inviteToken }: InviteEventDetailProps
 
               {event.payment_deadline && (
                 <div>
-                  <h3 className="text-sm font-medium text-gray-700">決済締切</h3>
+                  <h3 className="text-sm font-medium text-gray-700">オンライン決済締切</h3>
                   <p className="mt-1 text-sm text-gray-900 break-words">
                     {formatUtcToJstByType(event.payment_deadline, "japanese")}
                   </p>

--- a/local_schema.sql
+++ b/local_schema.sql
@@ -1,5 +1,5 @@
 
-\restrict BgHiOnvJ6EilTMPbhSlyCgkxvt4PANohs8wPyghp4eYU49clAcr9ZrYh0KzapHl
+\restrict 4Q0hJglQdc65MdGlpQpwMgyfsPBfj1dbmX73CxRkvgiYqbQpw3r3Mldzl6lKfYj
 
 
 SET statement_timeout = 0;
@@ -2228,11 +2228,14 @@ CREATE TABLE IF NOT EXISTS "public"."events" (
     "status" "public"."event_status_enum" DEFAULT 'upcoming'::"public"."event_status_enum" NOT NULL,
     "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "allow_payment_after_deadline" boolean DEFAULT false NOT NULL,
+    "grace_period_days" smallint DEFAULT 0 NOT NULL,
     CONSTRAINT "events_capacity_check" CHECK ((("capacity" IS NULL) OR ("capacity" > 0))),
     CONSTRAINT "events_date_after_creation" CHECK (("date" > "created_at")),
     CONSTRAINT "events_fee_check" CHECK (("fee" >= 0)),
+    CONSTRAINT "events_grace_period_days_check" CHECK ((("grace_period_days" >= 0) AND ("grace_period_days" <= 30))),
     CONSTRAINT "events_payment_deadline_after_registration" CHECK ((("payment_deadline" IS NULL) OR ("registration_deadline" IS NULL) OR ("payment_deadline" >= "registration_deadline"))),
-    CONSTRAINT "events_payment_deadline_before_event" CHECK ((("payment_deadline" IS NULL) OR ("payment_deadline" < "date"))),
+    CONSTRAINT "events_payment_deadline_within_30d_after_date" CHECK ((("payment_deadline" IS NULL) OR ("payment_deadline" <= ("date" + '30 days'::interval)))),
     CONSTRAINT "events_payment_methods_check" CHECK (("array_length"("payment_methods", 1) > 0)),
     CONSTRAINT "events_registration_deadline_before_event" CHECK ((("registration_deadline" IS NULL) OR ("registration_deadline" < "date")))
 );
@@ -4117,6 +4120,6 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TAB
 
 
 
-\unrestrict BgHiOnvJ6EilTMPbhSlyCgkxvt4PANohs8wPyghp4eYU49clAcr9ZrYh0KzapHl
+\unrestrict 4Q0hJglQdc65MdGlpQpwMgyfsPBfj1dbmX73CxRkvgiYqbQpw3r3Mldzl6lKfYj
 
 RESET ALL;

--- a/local_schema.sql
+++ b/local_schema.sql
@@ -1,5 +1,5 @@
 
-\restrict 4Q0hJglQdc65MdGlpQpwMgyfsPBfj1dbmX73CxRkvgiYqbQpw3r3Mldzl6lKfYj
+\restrict lC996H0E5gTHut9t753KIv0d20RtMF3UYZDlr08acMQci5sgi18oRtyvbpgGwaW
 
 
 SET statement_timeout = 0;
@@ -87,7 +87,7 @@ CREATE TYPE "public"."event_status_enum" AS ENUM (
     'upcoming',
     'ongoing',
     'past',
-    'cancelled'
+    'canceled'
 );
 
 
@@ -4120,6 +4120,6 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TAB
 
 
 
-\unrestrict 4Q0hJglQdc65MdGlpQpwMgyfsPBfj1dbmX73CxRkvgiYqbQpw3r3Mldzl6lKfYj
+\unrestrict lC996H0E5gTHut9t753KIv0d20RtMF3UYZDlr08acMQci5sgi18oRtyvbpgGwaW
 
 RESET ALL;

--- a/supabase/migrations/20250101000000_initial_schema.sql
+++ b/supabase/migrations/20250101000000_initial_schema.sql
@@ -8,7 +8,7 @@ BEGIN;
 -- ====================================================================
 -- 1. ENUM型定義
 -- ====================================================================
-CREATE TYPE public.event_status_enum AS ENUM ('upcoming', 'ongoing', 'past', 'cancelled');
+CREATE TYPE public.event_status_enum AS ENUM ('upcoming', 'ongoing', 'past', 'canceled');
 CREATE TYPE public.payment_method_enum AS ENUM ('stripe', 'cash');
 CREATE TYPE public.payment_status_enum AS ENUM ('pending', 'paid', 'failed', 'received', 'completed', 'refunded', 'waived');
 CREATE TYPE public.attendance_status_enum AS ENUM ('attending', 'not_attending', 'maybe');

--- a/supabase/migrations/20250914000100_deadline_management_p1.sql
+++ b/supabase/migrations/20250914000100_deadline_management_p1.sql
@@ -1,0 +1,66 @@
+-- P1: 締切管理 仕様反映（allow_payment_after_deadline / grace_period_days / CHECK見直し）
+-- 破壊的変更を含むが、本番未運用前提（docs/spec/deadline-management/required.md 参照）
+
+BEGIN;
+
+-- 1) 新カラム追加
+ALTER TABLE public.events
+  ADD COLUMN IF NOT EXISTS allow_payment_after_deadline boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS grace_period_days smallint NOT NULL DEFAULT 0;
+
+-- 1-1) 新カラムCHECK（0〜30日）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'events_grace_period_days_check'
+  ) THEN
+    ALTER TABLE public.events
+      ADD CONSTRAINT events_grace_period_days_check
+      CHECK (grace_period_days >= 0 AND grace_period_days <= 30);
+  END IF;
+END $$;
+
+-- 2) 旧CHECKの削除（"payment_deadline < date" を撤廃）
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'events_payment_deadline_before_event'
+  ) THEN
+    ALTER TABLE public.events DROP CONSTRAINT events_payment_deadline_before_event;
+  END IF;
+END $$;
+
+-- 3) 支払締切 上限: payment_deadline <= date + 30 days（nullセーフ）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'events_payment_deadline_within_30d_after_date'
+  ) THEN
+    ALTER TABLE public.events
+      ADD CONSTRAINT events_payment_deadline_within_30d_after_date
+      CHECK (
+        payment_deadline IS NULL OR payment_deadline <= ("date" + INTERVAL '30 days')
+      );
+  END IF;
+END $$;
+
+-- 4) 支払締切 下限（既存の registration 以降 制約はinclusiveのため流用/存在確認）
+-- 既存: events_payment_deadline_after_registration
+-- 形式: (payment_deadline IS NULL) OR (registration_deadline IS NULL) OR (payment_deadline >= registration_deadline)
+-- なければ追加しておく
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'events_payment_deadline_after_registration'
+  ) THEN
+    ALTER TABLE public.events
+      ADD CONSTRAINT events_payment_deadline_after_registration
+      CHECK (
+        payment_deadline IS NULL OR registration_deadline IS NULL OR payment_deadline >= registration_deadline
+      );
+  END IF;
+END $$;
+
+COMMIT;

--- a/tests/e2e/event-creation.spec.ts
+++ b/tests/e2e/event-creation.spec.ts
@@ -200,13 +200,15 @@ test.describe("イベント作成（E2E）", () => {
     await page.getByLabel("イベント *").fill("テストイベント");
     await page.getByLabel("開催日時 *").fill(eventDateString);
     await page.getByLabel("参加費 *").fill("0");
-    await page.getByLabel("決済締切").fill(paymentDeadlineString);
+    await page.getByLabel("オンライン決済締切").fill(paymentDeadlineString);
 
     // 他のフィールドをクリックしてバリデーションをトリガー
     await page.getByLabel("説明").click();
 
     // エラーメッセージが表示されることを確認
-    await expect(page.getByText("決済締切は開催日時より前に設定してください")).toBeVisible();
+    await expect(
+      page.getByText("オンライン決済締切は開催日時より前に設定してください")
+    ).toBeVisible();
 
     // 作成ボタンが無効化されていることを確認
     await expect(page.getByRole("button", { name: "イベントを作成" })).toBeDisabled();
@@ -227,7 +229,7 @@ test.describe("イベント作成（E2E）", () => {
     await page.getByLabel("開催日時 *").fill(eventDateString);
     await page.getByLabel("参加費 *").fill("0");
     await page.getByLabel("参加申込締切").fill(registrationDeadlineString);
-    await page.getByLabel("決済締切").fill(paymentDeadlineString);
+    await page.getByLabel("オンライン決済締切").fill(paymentDeadlineString);
 
     // 他のフィールドをクリックしてバリデーションをトリガー
     await page.getByLabel("説明").click();

--- a/tests/e2e/payment-flow.grace.spec.ts
+++ b/tests/e2e/payment-flow.grace.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * 決済フロー E2E - 猶予ON/OFFと最終上限
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+import { TestDataManager, FIXED_TIME } from "./helpers/test-data-setup";
+
+class PageHelper {
+  static async navigateToGuestPage(page: Page, guestToken: string): Promise<void> {
+    await page.goto(`/guest/${guestToken}`);
+    await page.waitForLoadState("networkidle");
+  }
+}
+
+test.describe("決済フロー - 猶予と最終上限", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.clock.setFixedTime(FIXED_TIME);
+    await TestDataManager.createUserWithConnect();
+    await TestDataManager.createPaidEvent();
+  });
+
+  test.afterEach(async () => {
+    await TestDataManager.cleanup();
+  });
+
+  test("猶予OFF: 締切超過で決済ボタンが出ない", async ({ page }) => {
+    const attendance = await TestDataManager.createAttendance();
+    // event.date = FIXED_TIME + 48h, registration_deadline = +24h
+    // payment_deadline を過去日へ（常に期限超過）
+    await TestDataManager.updateEventPaymentSettings({
+      payment_deadline: "2000-01-01T00:00:00.000Z",
+      allow_payment_after_deadline: false,
+      grace_period_days: 0,
+      status: "upcoming",
+    });
+
+    await PageHelper.navigateToGuestPage(page, attendance.guest_token);
+    // await expect(page.getByRole("button", { name: "決済を完了する" })).toHaveCount(0);
+    const payBtn = page.getByRole("button", { name: "決済を完了する" });
+    await expect(payBtn).toBeVisible();
+    await expect(payBtn).toBeDisabled();
+    await expect(page.getByText(/期限|締切|決済不可|決済は現在できません/)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("猶予ON: 締切超過でもfinal内なら決済可能", async ({ page }) => {
+    const attendance = await TestDataManager.createAttendance();
+    // payment_deadline を過去、ただし final = min(deadline+grace, date+30d) 内にする
+    // 例: deadline = FIXED_TIME + 1h (過去基準にするため2000年に), grace = 30d として、date+30d まで許可
+    await TestDataManager.updateEventPaymentSettings({
+      payment_deadline: new Date(FIXED_TIME.getTime() + 1 * 60 * 60 * 1000).toISOString(),
+      allow_payment_after_deadline: true,
+      grace_period_days: 30,
+      status: "past", // 終了後でも許可（仕様）
+    });
+
+    await PageHelper.navigateToGuestPage(page, attendance.guest_token);
+    const payButton = page.getByRole("button", { name: "決済を完了する" });
+    await expect(payButton).toBeVisible();
+    await expect(payButton).toBeEnabled();
+  });
+
+  test("最終上限超過: date+30d を超えると決済不可", async ({ page }) => {
+    const attendance = await TestDataManager.createAttendance();
+
+    // event.date = FIXED_TIME + 48h
+    const eventDatePlus30d = new Date(
+      FIXED_TIME.getTime() + 48 * 60 * 60 * 1000 + 30 * 24 * 60 * 60 * 1000
+    );
+    // const afterFinal = new Date(eventDatePlus30d.getTime() + 1 * 60 * 60 * 1000).toISOString();
+
+    // final を超える状態を作る: deadline を date にし、grace 30d で final = date+30d
+    // その後、現在時刻を final より後に固定して検証
+    await TestDataManager.updateEventPaymentSettings({
+      payment_deadline: new Date(FIXED_TIME.getTime() + 48 * 60 * 60 * 1000).toISOString(), // = date
+      allow_payment_after_deadline: true,
+      grace_period_days: 30,
+      status: "past",
+    });
+
+    // 現在時刻を final + 1h にセット
+    await page.clock.setFixedTime(new Date(eventDatePlus30d.getTime() + 60 * 60 * 1000));
+
+    await PageHelper.navigateToGuestPage(page, attendance.guest_token);
+    // await expect(page.getByRole("button", { name: "決済を完了する" })).toHaveCount(0);
+    const payBtn = page.getByRole("button", { name: "決済を完了する" });
+    await expect(payBtn).toBeVisible();
+    await expect(payBtn).toBeDisabled();
+  });
+});

--- a/tests/unit/deadlines.utils.test.ts
+++ b/tests/unit/deadlines.utils.test.ts
@@ -1,0 +1,61 @@
+import { deriveEffectiveDeadlines, deriveFinalPaymentLimit } from "../../core/utils/deadlines";
+
+describe("deadlines utils", () => {
+  const date = "2025-01-01T10:00:00.000Z"; // event date (UTC)
+
+  test("effective deadlines fallback to event date when null", () => {
+    const { effectiveRegistrationDeadline, effectivePaymentDeadline, eventDate } =
+      deriveEffectiveDeadlines({ date, registration_deadline: null, payment_deadline: null });
+
+    expect(effectiveRegistrationDeadline.toISOString()).toBe(eventDate.toISOString());
+    expect(effectivePaymentDeadline.toISOString()).toBe(eventDate.toISOString());
+  });
+
+  test("final limit without allow == effectivePaymentDeadline", () => {
+    const { effectivePaymentDeadline, eventDate } = deriveEffectiveDeadlines({
+      date,
+      registration_deadline: null,
+      payment_deadline: "2025-01-01T05:00:00.000Z",
+    });
+
+    const finalLimit = deriveFinalPaymentLimit({
+      effectivePaymentDeadline,
+      eventDate,
+      allow_payment_after_deadline: false,
+      grace_period_days: 10,
+    });
+
+    expect(finalLimit.toISOString()).toBe(effectivePaymentDeadline.toISOString());
+  });
+
+  test("final limit with allow == min(effective + grace, date + 30d)", () => {
+    const { effectivePaymentDeadline, eventDate } = deriveEffectiveDeadlines({
+      date,
+      registration_deadline: null,
+      payment_deadline: "2025-01-01T05:00:00.000Z",
+    });
+
+    // grace smaller than 30d anchor
+    const final1 = deriveFinalPaymentLimit({
+      effectivePaymentDeadline,
+      eventDate,
+      allow_payment_after_deadline: true,
+      grace_period_days: 3,
+    });
+    const expected1 = new Date(effectivePaymentDeadline.getTime() + 3 * 24 * 60 * 60 * 1000);
+    expect(final1.toISOString()).toBe(expected1.toISOString());
+
+    // grace larger than anchor -> capped at date+30d
+    const final2 = deriveFinalPaymentLimit({
+      effectivePaymentDeadline,
+      eventDate,
+      allow_payment_after_deadline: true,
+      grace_period_days: 60,
+    });
+    // grace は 30日にクランプされるため、候補は (deadline + 30d)
+    const candidate = new Date(effectivePaymentDeadline.getTime() + 30 * 24 * 60 * 60 * 1000);
+    const anchor = new Date(new Date(date).getTime() + 30 * 24 * 60 * 60 * 1000);
+    const expected2 = new Date(Math.min(candidate.getTime(), anchor.getTime()));
+    expect(final2.toISOString()).toBe(expected2.toISOString());
+  });
+});

--- a/tests/unit/events/event-schema-deadlines.test.ts
+++ b/tests/unit/events/event-schema-deadlines.test.ts
@@ -1,0 +1,64 @@
+// import { z } from "zod";
+
+import { createEventSchema, updateEventSchema } from "../../../core/validation/event";
+
+// datetime-local 文字列は JST として convertDatetimeLocalToUtc で扱われる前提
+describe("event schema - deadline correlations", () => {
+  const base = {
+    title: "締切検証イベント",
+    date: "2025-01-10T10:00", // JST datetime-local
+    fee: "1000",
+    payment_methods: ["stripe"],
+  };
+
+  test("payment_deadline <= date + 30日 (包括) を満たさないとエラー", () => {
+    const bad = {
+      ...base,
+      registration_deadline: "2025-01-05T10:00",
+      // 31日後相当（JST想定）
+      payment_deadline: "2025-02-10T10:01",
+    };
+    const parsed = createEventSchema.safeParse(bad);
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.errors.map((e) => e.path.join("."))).toContain("payment_deadline");
+    }
+  });
+
+  test("registration_deadline <= payment_deadline を満たさないとエラー", () => {
+    const bad = {
+      ...base,
+      registration_deadline: "2025-01-08T10:00",
+      payment_deadline: "2025-01-07T10:00",
+    };
+    const parsed = createEventSchema.safeParse(bad);
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.errors.map((e) => e.path.join("."))).toContain("payment_deadline");
+    }
+  });
+
+  test("猶予ON時: final_payment_limit <= date + 30日 を超えるgraceはエラー", () => {
+    const bad = {
+      ...base,
+      payment_deadline: "2025-01-10T10:00",
+      allow_payment_after_deadline: true,
+      grace_period_days: 999, // 上限超
+    } as any;
+    const parsed = createEventSchema.safeParse(bad);
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      // grace_period_days にエラーが紐付く
+      expect(parsed.error.errors.map((e) => e.path.join("."))).toContain("grace_period_days");
+    }
+  });
+
+  test("updateEventSchemaでも同様の相関が働く", () => {
+    const badUpdate = {
+      date: "2025-01-10T10:00",
+      payment_deadline: "2025-02-15T10:00", // 30日超
+    } as any;
+    const parsed = updateEventSchema.safeParse(badUpdate);
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/tests/unit/payments/payment-eligibility.test.ts
+++ b/tests/unit/payments/payment-eligibility.test.ts
@@ -1,0 +1,90 @@
+import {
+  checkBasicPaymentEligibility,
+  canCreateStripeSession,
+  canGuestRepay,
+} from "../../../core/validation/payment-eligibility";
+
+describe("payment eligibility", () => {
+  const baseEvent = {
+    id: "e1",
+    status: "upcoming" as const,
+    fee: 1000,
+    date: "2025-01-01T10:00:00.000Z",
+    payment_deadline: "2025-01-01T08:00:00.000Z",
+    allow_payment_after_deadline: false,
+    grace_period_days: 0,
+  };
+  const attendee = { id: "a1", status: "attending" as const };
+
+  test("締切前は許可、締切後は不許可（猶予OFF）", () => {
+    const before = checkBasicPaymentEligibility(
+      attendee,
+      baseEvent,
+      new Date("2025-01-01T07:00:00.000Z")
+    );
+    expect(before.isEligible).toBe(true);
+
+    const after = checkBasicPaymentEligibility(
+      attendee,
+      baseEvent,
+      new Date("2025-01-01T09:00:00.000Z")
+    );
+    expect(after.isEligible).toBe(false);
+    expect(after.reason).toContain("決済期限");
+  });
+
+  test("猶予ON: 締切超過でもfinal内は許可、final超過は不許可", () => {
+    const event = { ...baseEvent, allow_payment_after_deadline: true, grace_period_days: 2 };
+    // base payment_deadline 08:00, grace 2d => final = min(08:00+2d, date+30d) = 2d延長
+    const within = checkBasicPaymentEligibility(
+      attendee,
+      event,
+      new Date("2025-01-02T09:00:00.000Z")
+    );
+    expect(within.isEligible).toBe(true);
+
+    const over = checkBasicPaymentEligibility(
+      attendee,
+      event,
+      new Date("2025-01-05T00:00:00.000Z")
+    );
+    expect(over.isEligible).toBe(false);
+  });
+
+  test("キャンセルイベントは常に不許可", () => {
+    const event = { ...baseEvent, status: "canceled" as const, allow_payment_after_deadline: true };
+    const res = checkBasicPaymentEligibility(attendee, event, new Date("2025-01-01T07:00:00.000Z"));
+    expect(res.isEligible).toBe(false);
+    expect(res.reason).toContain("キャンセル");
+  });
+
+  test("canCreateStripeSession excludes finalized statuses", () => {
+    const event = { ...baseEvent, allow_payment_after_deadline: true, grace_period_days: 30 };
+    const paidAttendee = {
+      id: "a1",
+      status: "attending" as const,
+      payment: { method: "stripe", status: "paid" as const },
+    };
+    const res = canCreateStripeSession(paidAttendee, event, new Date("2025-01-01T07:00:00.000Z"));
+    expect(res.isEligible).toBe(false);
+  });
+
+  test("canGuestRepay requires stripe method and allowed statuses", () => {
+    const event = { ...baseEvent, allow_payment_after_deadline: true, grace_period_days: 30 };
+    const failedStripe = {
+      id: "a1",
+      status: "attending" as const,
+      payment: { method: "stripe", status: "failed" as const },
+    };
+    const ok = canGuestRepay(failedStripe, event, new Date("2025-01-01T07:00:00.000Z"));
+    expect(ok.isEligible).toBe(true);
+
+    const receivedCash = {
+      id: "a1",
+      status: "attending" as const,
+      payment: { method: "cash", status: "failed" as const },
+    };
+    const ng = canGuestRepay(receivedCash, event, new Date("2025-01-01T07:00:00.000Z"));
+    expect(ng.isEligible).toBe(false);
+  });
+});

--- a/types/database.ts
+++ b/types/database.ts
@@ -1283,7 +1283,7 @@ export type Database = {
         | "data_migration"
         | "security_investigation";
       attendance_status_enum: "attending" | "not_attending" | "maybe";
-      event_status_enum: "upcoming" | "ongoing" | "past" | "cancelled";
+      event_status_enum: "upcoming" | "ongoing" | "past" | "canceled";
       payment_method_enum: "stripe" | "cash";
       payment_status_enum:
         | "pending"
@@ -1442,7 +1442,7 @@ export const Constants = {
         "security_investigation",
       ],
       attendance_status_enum: ["attending", "not_attending", "maybe"],
-      event_status_enum: ["upcoming", "ongoing", "past", "cancelled"],
+      event_status_enum: ["upcoming", "ongoing", "past", "canceled"],
       payment_method_enum: ["stripe", "cash"],
       payment_status_enum: [
         "pending",

--- a/types/database.ts
+++ b/types/database.ts
@@ -119,12 +119,14 @@ export type Database = {
       };
       events: {
         Row: {
+          allow_payment_after_deadline: boolean;
           capacity: number | null;
           created_at: string;
           created_by: string;
           date: string;
           description: string | null;
           fee: number;
+          grace_period_days: number;
           id: string;
           invite_token: string | null;
           location: string | null;
@@ -136,12 +138,14 @@ export type Database = {
           updated_at: string;
         };
         Insert: {
+          allow_payment_after_deadline?: boolean;
           capacity?: number | null;
           created_at?: string;
           created_by: string;
           date: string;
           description?: string | null;
           fee?: number;
+          grace_period_days?: number;
           id?: string;
           invite_token?: string | null;
           location?: string | null;
@@ -153,12 +157,14 @@ export type Database = {
           updated_at?: string;
         };
         Update: {
+          allow_payment_after_deadline?: boolean;
           capacity?: number | null;
           created_at?: string;
           created_by?: string;
           date?: string;
           description?: string | null;
           fee?: number;
+          grace_period_days?: number;
           id?: string;
           invite_token?: string | null;
           location?: string | null;


### PR DESCRIPTION
目的
- docs/spec/deadline-management の要件実装（P1/P2）
- 決済期限の猶予（grace）と最終上限、主催者の例外操作（手動追加）を導入

主な変更点
- DB（Supabase）
  - 新規カラム: `events.allow_payment_after_deadline` (boolean, default false)
  - 新規カラム: `events.grace_period_days` (smallint, 0〜30, default 0)
  - CHECK制約: `grace_period_days` を 0〜30 に制限
  - 旧制約（`payment_deadline < date`）を撤廃し、新仕様に整合
  - マイグレーション: `supabase/migrations/20250914000100_deadline_management_p1.sql`
- ドメインロジック/バリデーション
  - `core/utils/deadlines.ts` 追加
    - effective/最終期限を導出
    - final_payment_limit = allow ? min(effective_payment_deadline + grace_days, date + 30d) : effective_payment_deadline
  - `core/validation/event.ts` 更新
    - `payment_deadline <= date + 30日（包括）`
    - `registration_deadline <= payment_deadline`
    - 猶予ON時、`final_payment_limit <= date + 30日` を満たすよう `grace_period_days` を検証
  - `core/validation/payment-eligibility.ts` 更新
    - 締切/最終上限に基づく支払い可否判定を実装・整理
- UI/フロー
  - `features/events/components/event-form.tsx`, `event-edit-form.tsx` に猶与ON/OFF・日数入力を追加、相関バリデーション/エラーメッセージを表示
  - `participants-management.tsx`, `participants-table.tsx` など関連UIの状態・操作を更新
- 例外操作（主催者手動追加）
  - `features/events/actions/admin-add-attendance.ts` 追加（締切を越えても主催者が手動で参加者を追加可能な管理用アクション）
- リファクタ
  - "canceled" 表記揺れの統一

テスト
- E2E: `tests/e2e/payment-flow.grace.spec.ts`
  - 猶予OFF: 締切超過で決済不可（ボタン不可/警告表示）
  - 猶予ON: `final_payment_limit` 内は決済可能
  - 最終上限超過（`date + 30d`）で決済不可
- Unit:
  - `tests/unit/deadlines.utils.test.ts`（導出/上限計算）
  - `tests/unit/events/event-schema-deadlines.test.ts`（相関バリデーション）
  - `tests/unit/payments/payment-eligibility.test.ts`（可否判定）

移行/互換性
- マイグレーションは破壊的変更を含む可能性がありますが、本番未運用前提で作成しています（コメント参照）。
- 既存イベントデータには `allow_payment_after_deadline=false`, `grace_period_days=0` が適用されます。

動作確認観点（抜粋）
- 猶予OFF: `payment_deadline` を過去に設定し、決済不可表示になること
- 猶予ON: `payment_deadline` を過去、`grace_period_days` を設定し、`final_payment_limit` 内で決済可能になること
- `final_payment_limit` を超えたら決済不可になること（`date + 30d` のキャップが効く）

リリース手順（提案）
1) Supabase マイグレーション適用（例）
   - `supabase/migrations/20250914000100_deadline_management_p1.sql` を適用
2) フロントの環境変数/設定に変更はありません
3) 最低限の回帰確認: 新規イベント作成/編集、ゲスト決済フロー

関連ドキュメント
- `docs/spec/deadline-management/required.md`
- `docs/spec/deadline-management/design.md`

変更規模
- 50 files changed, 約 1.5k insertions / 126 deletions（参考レポートより）

レビュー観点
- バリデーションの境界条件（タイムゾーン/包括比較）
- 例外操作の権限/トレーサビリティ
- UI の文言/エラーメッセージの明確さ

以上、ご確認お願いします。