### PR TITLE
fix: resolve CSP violations by passing nonce to inline scripts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Noto_Sans_JP } from "next/font/google";
 import localFont from "next/font/local";
+import { headers } from "next/headers";
 
 import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata } from "next";
@@ -95,6 +96,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>): JSX.Element {
   const ga4Config = getGA4Config();
+  const nonce = headers().get("x-nonce") ?? undefined;
 
   // 構造化データ（JSON-LD）を生成
   const organizationSchema = generateOrganizationSchema();
@@ -106,11 +108,11 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} ${notoSansJp.className} antialiased`}
         suppressHydrationWarning={true}
       >
-        <JsonLd data={[organizationSchema, webSiteSchema]} />
+        <JsonLd data={[organizationSchema, webSiteSchema]} nonce={nonce} />
         <TooltipProvider>
           <ToastProvider ToasterComponent={Toaster}>{children}</ToastProvider>
         </TooltipProvider>
-        {ga4Config.enabled && <GoogleAnalytics gaId={ga4Config.measurementId} />}
+        {ga4Config.enabled && <GoogleAnalytics gaId={ga4Config.measurementId} nonce={nonce} />}
       </body>
     </html>
   );

--- a/components/seo/JsonLd.tsx
+++ b/components/seo/JsonLd.tsx
@@ -8,9 +8,17 @@ import type { WithContext } from "schema-dts";
  *
  * @param data - WithContext型のスキーマオブジェクトまたはその配列
  */
-export function JsonLd<T extends WithContext<any>>({ data }: { data: T | T[] }): JSX.Element {
+export function JsonLd<T extends WithContext<any>>({
+  data,
+  nonce,
+}: {
+  data: T | T[];
+  nonce?: string;
+}): JSX.Element {
   // JSON-LDを文字列化し、XSS対策として "<" をエスケープ
   const jsonLd = JSON.stringify(data).replace(/</g, "\\u003c");
 
-  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} />;
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} nonce={nonce} />
+  );
 }


### PR DESCRIPTION
## 概要
CSP (Content Security Policy) 違反を解決するため、インラインスクリプトに `nonce` 属性を付与するように修正しました。

## 変更点
- `app/layout.tsx`: ヘッダーから `x-nonce` を取得し、`JsonLd` および `GoogleAnalytics` コンポーネントに渡すように変更。
- `components/seo/JsonLd.tsx`: `nonce` プロパティを受け取り、`<script>` タグに適用するように変更。

## 関連Issue
- CSP違反の修正

## 確認事項
- [x] `npm run typecheck` が通ることを確認
- [x] ビルドが通ることを確認