### PR TITLE
fix(security): ゲストページのCSPエラー修正 (Vaulハッシュの許可)

### DIFF
--- a/core/security/csp.ts
+++ b/core/security/csp.ts
@@ -64,6 +64,15 @@ export const ALLOWED_ORIGINS = {
 } as const;
 
 /**
+ * 許可するインラインスタイルのHash
+ * ライブラリ（vaulなど）が注入するCSSを許可するために使用
+ */
+export const ALLOWED_HASHES = [
+  "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='", // vaul (Drawer)
+  "'sha256-YIjArHm2rkb5J7hX9lUM1bnQ3Kp61MTfluMGkuyKwDw='", // vaul (Drawer)
+];
+
+/**
  * スペース区切りで結合
  */
 function joinSrc(list: readonly string[]): string {
@@ -129,9 +138,10 @@ export function buildCsp(params: BuildCspParams): string {
   )}`;
 
   // style-src-elem: 動的ページはnonce、静的ページは'unsafe-inline'を許可（Next.jsハイドレーション用）
+  // 特定のライブラリ（vaul等）のためにハッシュも許可
   const styleElem =
     mode === "dynamic" && nonce
-      ? `style-src-elem 'self' 'nonce-${nonce}' ${ALLOWED_ORIGINS.fonts[0]}`
+      ? `style-src-elem 'self' 'nonce-${nonce}' ${ALLOWED_ORIGINS.fonts[0]} ${joinSrc(ALLOWED_HASHES)}`
       : `style-src-elem 'self' 'unsafe-inline' ${ALLOWED_ORIGINS.fonts[0]}`;
 
   // img-src: 画像ソース


### PR DESCRIPTION
### 概要
ゲストページ（`/guest/[token]`）で発生していたCSP（Content Security Policy）エラーを修正しました。

### 変更内容
- ゲストページの「ステータス変更」ダイアログ（`vaul`ライブラリ仕様のDrawer）が注入するインラインスタイルのハッシュを、`core/security/csp.ts`の`style-src-elem`ディレクティブに追加しました。
- これにより、厳格なCSPを維持したまま、ライブラリによる正当なスタイル注入を許可し、表示崩れやエラーログ出力を解消しました。

### 確認事項
- [x] `/guest/[token]` アクセス時に開発者ツールのコンソールでCSPエラーが表示されないこと。
- [x] ステータス変更ダイアログが正常に動作し、スタイルが適用されていること。