### PR TITLE
Refactor: CSP違反解消のためNode.js cryptoをWeb Crypto APIに置き換え

### DIFF
--- a/core/logging/deduplication.ts
+++ b/core/logging/deduplication.ts
@@ -31,7 +31,7 @@ export async function shouldLogError(
     // 行番号の変更でハッシュが変わるのを防ぐ
     const stackLines = stack?.split("\n").slice(0, 3).join("\n") || "";
 
-    const hash = hashToken(message + stackLines);
+    const hash = await hashToken(message + stackLines);
 
     const key = `error_dedupe:${hash}`;
 


### PR DESCRIPTION
### 概要
このPRでは、ブラウザ向けのビルドにおいてNode.jsの `crypto` モジュールのポリフィル（`crypto-browserify` や `vm-browserify`）に含まれる `eval` ステートメントが Content Security Policy (CSP) 違反を引き起こす問題を解決するため、`core/security/crypto.ts` モジュールをブラウザネイティブな Web Crypto API を使用するようにリファクタリングしました。

### 変更点
- **core/security/crypto.ts**:
  - `import { ... } from "crypto"` を削除。
  - `generateRandomBytes` をネイティブの `crypto.getRandomValues` を使用するように更新。
  - `hashToken` を `crypto.subtle.digest("SHA-256")` を使用するように変更。これに伴い、関数を非同期（Async）化。
  - `constantTimeCompare` を `Buffer` ポリフィルに依存せず、ビット演算（XOR）を用いて定数時間で動作するように独自実装。
- **core/logging/deduplication.ts**:
  - `hashToken` の非同期化に合わせて `shouldLogError` で `await` を追加。
- **tests/unit/core/logging/deduplication.test.ts**:
  - 非同期化した `hashToken` に対応するようにモックを更新。

### 検証結果
- `npm run build` が成功し、生成されたビルドチャンク内に Node.js の crypto ポリフィルが含まれていないことを確認。
- ユニットテストが正常に通過することを確認。
- 独自の暗号化関数が期待通りに動作することを検証済み。