### PR TITLE
refactor: 監査付きAdminクライアント統一 (webhook/demo/errors)

### DIFF
--- a/core/logging/app-logger.ts
+++ b/core/logging/app-logger.ts
@@ -79,6 +79,7 @@ function createSupabaseClient(): SupabaseClient<Database> | null {
     return null;
   }
 
+  // 循環依存回避のため、監査なしの直接クライアントを使用
   return createClient<Database>(supabaseUrl, supabaseKey, {
     auth: { persistSession: false },
   });

--- a/core/logging/system-logger.ts
+++ b/core/logging/system-logger.ts
@@ -1,8 +1,6 @@
 /**
  * system_logs テーブルへのログ記録ヘルパー
  *
- * 業界標準（ECS、OpenTelemetry、OWASP）に準拠した監査ログを記録します。
- *
  * @module core/logging/system-logger
  */
 

--- a/core/security/secure-client-factory.types.ts
+++ b/core/security/secure-client-factory.types.ts
@@ -17,6 +17,8 @@ export enum AdminReason {
   LOGGING = "logging",
   ACCOUNT_DELETION = "account_deletion",
   LINE_LOGIN = "line_login",
+  DEMO_SETUP = "demo_setup",
+  ERROR_COLLECTION = "error_collection",
 }
 
 // エラーハンドリングは専用ファイルから再エクスポート

--- a/tests/integration/api/errors/error-collection.integration.test.ts
+++ b/tests/integration/api/errors/error-collection.integration.test.ts
@@ -26,6 +26,18 @@ jest.mock("@supabase/supabase-js", () => ({
   })),
 }));
 
+// @core/security をモック化
+jest.mock("@core/security", () => ({
+  AdminReason: {
+    ERROR_COLLECTION: "error_collection",
+  },
+  createSecureSupabaseClient: jest.fn(() => ({
+    createAuditedAdminClient: jest.fn().mockResolvedValue({
+      from: mockSupabaseFrom,
+    }),
+  })),
+}));
+
 describe("エラー収集API統合テスト (/api/errors)", () => {
   // モック関数をテストスコープで定義
   let mockLimit: jest.MockedFunction<any>;


### PR DESCRIPTION
## 概要
#274 に基づき、プロダクションコードにおける `service_role` 直生成クライアントを排除し、監査ログ対応の `SecureSupabaseClientFactory.createAuditedAdminClient` への統一を行いました。

## 変更内容
- **AdminReasonの追加**: `AdminReason` に `DEMO_SETUP` と `ERROR_COLLECTION` を追加しました。
- **クライアントの移行**:
  - `app/api/errors/route.ts`: エラー収集時に `AdminReason.ERROR_COLLECTION` を使用するように変更。
  - `features/payments/services/webhook/webhook-event-handler.ts`: Webhook処理時に `AdminReason.PAYMENT_PROCESSING` を使用し、非同期初期化パターンを採用。
  - `features/demo/actions/start-demo.ts`: デモ環境構築時に `AdminReason.DEMO_SETUP` を使用。
- **例外箇所の明文化**:
  - `core/logging/app-logger.ts` および `core/logging/system-logger.ts` において、循環参照を回避するために直生成クライアントを維持している理由をコメントとして追記しました。
- **テスト修正**:
  - `tests/integration/api/errors/error-collection.integration.test.ts` において、`createSecureSupabaseClient` のモックを追加し、テストが通るように修正しました。

## 確認事項
- [x] `npm run lint` が通ること
- [x] `npm run typecheck` が通ること
- [x] `npx jest tests/integration/api/errors/error-collection.integration.test.ts` がパスすること

## 関連Issue
Fixes #274