### PR TITLE
refactor: メール送信基盤を整理し、Resend連携と再試行制御を改善

### DIFF
--- a/core/notification/email-config.ts
+++ b/core/notification/email-config.ts
@@ -1,0 +1,68 @@
+import { logger } from "@core/logging/app-logger";
+
+export interface EmailServiceConfig {
+  fromEmail: string;
+  fromName: string;
+  adminEmail: string;
+}
+
+function isDevelopmentEnv(env: NodeJS.ProcessEnv): boolean {
+  return env.NODE_ENV === "development";
+}
+
+function resolveEnvValue(options: {
+  value: string | undefined;
+  envName: "FROM_EMAIL" | "FROM_NAME" | "ADMIN_EMAIL";
+  defaultValue: string;
+}): string {
+  if (options.value) {
+    return options.value;
+  }
+
+  logger.warn(`${options.envName} not set, using default`, {
+    category: "email",
+    action: "email_config_validation",
+    default_value: options.defaultValue,
+    outcome: "success",
+  });
+
+  return options.defaultValue;
+}
+
+export function resolveEmailConfig(env: NodeJS.ProcessEnv = process.env): EmailServiceConfig {
+  const fromEmail = env.FROM_EMAIL;
+  const fromName = env.FROM_NAME;
+  const adminEmail = env.ADMIN_EMAIL;
+
+  if (!isDevelopmentEnv(env)) {
+    if (!fromEmail) {
+      throw new Error(
+        "FROM_EMAIL environment variable is required in production. Please set it in your environment variables."
+      );
+    }
+
+    if (!adminEmail) {
+      throw new Error(
+        "ADMIN_EMAIL environment variable is required in production. Please set it in your environment variables."
+      );
+    }
+  }
+
+  return {
+    fromEmail: resolveEnvValue({
+      value: fromEmail,
+      envName: "FROM_EMAIL",
+      defaultValue: "noreply@eventpay.jp",
+    }),
+    fromName: resolveEnvValue({
+      value: fromName,
+      envName: "FROM_NAME",
+      defaultValue: "みんなの集金",
+    }),
+    adminEmail: resolveEnvValue({
+      value: adminEmail,
+      envName: "ADMIN_EMAIL",
+      defaultValue: "admin@eventpay.jp",
+    }),
+  };
+}

--- a/core/notification/email-error-policy.ts
+++ b/core/notification/email-error-policy.ts
@@ -1,0 +1,111 @@
+import { getFiniteNumberProp, getStringProp, isRecord } from "@core/utils/type-guards";
+
+import type { EmailErrorInfo, EmailErrorType } from "./types";
+
+const PERMANENT_ERROR_NAMES = new Set<string>([
+  "missing_required_field",
+  "invalid_idempotency_key",
+  "invalid_idempotent_request",
+  "invalid_access",
+  "invalid_parameter",
+  "invalid_region",
+  "monthly_quota_exceeded",
+  "daily_quota_exceeded",
+  "missing_api_key",
+  "invalid_api_key",
+  "invalid_from_address",
+  "validation_error",
+  "not_found",
+  "method_not_allowed",
+  "restricted_api_key",
+  "invalid_attachment",
+  "security_error",
+]);
+
+const TRANSIENT_ERROR_NAMES = new Set<string>([
+  "rate_limit_exceeded",
+  "concurrent_idempotent_requests",
+  "application_error",
+  "internal_server_error",
+]);
+
+const TRANSIENT_ERROR_MESSAGE_PATTERNS = [
+  "network",
+  "timeout",
+  "econnrefused",
+  "enotfound",
+  "etimedout",
+  "fetch failed",
+];
+
+function resolveTypeFromErrorName(name: string): EmailErrorType | null {
+  if (TRANSIENT_ERROR_NAMES.has(name)) {
+    return "transient";
+  }
+
+  if (PERMANENT_ERROR_NAMES.has(name)) {
+    return "permanent";
+  }
+
+  return null;
+}
+
+export function classifyEmailProviderError(error: unknown): EmailErrorInfo {
+  if (isRecord(error)) {
+    const statusCode = getFiniteNumberProp(error, "statusCode");
+    const name = getStringProp(error, "name");
+    const message = getStringProp(error, "message") ?? "不明なエラー";
+
+    if (name) {
+      const typeFromName = resolveTypeFromErrorName(name);
+      if (typeFromName) {
+        return { type: typeFromName, message, name, statusCode };
+      }
+    }
+
+    if (typeof statusCode === "number") {
+      if (statusCode >= 500 || statusCode === 429 || statusCode === 408) {
+        return { type: "transient", message, name, statusCode };
+      }
+
+      if (statusCode >= 400 && statusCode < 500) {
+        return { type: "permanent", message, name, statusCode };
+      }
+
+      return { type: "transient", message, name, statusCode };
+    }
+
+    if (!(error instanceof Error)) {
+      const typeFromName = name ? resolveTypeFromErrorName(name) : null;
+      return {
+        type: typeFromName ?? "transient",
+        message,
+        name,
+        statusCode,
+      };
+    }
+  }
+
+  if (error instanceof Error) {
+    const lowerMessage = error.message.toLowerCase();
+
+    if (TRANSIENT_ERROR_MESSAGE_PATTERNS.some((pattern) => lowerMessage.includes(pattern))) {
+      return {
+        type: "transient",
+        message: "ネットワークエラー",
+        name: error.name,
+      };
+    }
+
+    return {
+      type: "transient",
+      message: error.message || "不明なエラー",
+      name: error.name,
+    };
+  }
+
+  return {
+    type: "transient",
+    message: String(error) || "不明なエラー",
+  };
+}

--- a/core/notification/email-retry-policy.ts
+++ b/core/notification/email-retry-policy.ts
@@ -1,0 +1,44 @@
+import type { EmailErrorInfo } from "./types";
+
+export const DEFAULT_MAX_ATTEMPTS = 2;
+export const INITIAL_RETRY_DELAY_MS = 1000;
+export const RATE_LIMIT_RETRY_DELAY_MS = 5000;
+export const RETRY_JITTER_RATIO = 0.2;
+
+function withJitter(
+  baseDelayMs: number,
+  randomFn: () => number,
+  jitterRatio: number = RETRY_JITTER_RATIO
+): number {
+  const jitterFactor = 1 + (randomFn() * 2 - 1) * jitterRatio;
+  return Math.max(0, Math.round(baseDelayMs * jitterFactor));
+}
+
+export function shouldRetry(options: {
+  errorInfo: EmailErrorInfo;
+  attempt: number;
+  maxAttempts?: number;
+}): boolean {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  return options.errorInfo.type === "transient" && options.attempt < maxAttempts;
+}
+
+export function computeRetryDelayMs(options: {
+  attempt: number;
+  statusCode?: number;
+  errorName?: string;
+  retryAfterSeconds?: number;
+  randomFn?: () => number;
+}): number {
+  const randomFn = options.randomFn ?? Math.random;
+
+  if (options.statusCode === 429 && typeof options.retryAfterSeconds === "number") {
+    return Math.max(0, Math.round(options.retryAfterSeconds * 1000));
+  }
+
+  if (options.statusCode === 429 || options.errorName === "rate_limit_exceeded") {
+    return withJitter(RATE_LIMIT_RETRY_DELAY_MS, randomFn);
+  }
+
+  return withJitter(INITIAL_RETRY_DELAY_MS * Math.pow(2, options.attempt), randomFn);
+}

--- a/core/notification/types.ts
+++ b/core/notification/types.ts
@@ -6,9 +6,9 @@ import type { AppResult } from "@core/errors";
 import type { StripeAccountStatus } from "@core/types/statuses";
 
 /**
- * Resendエラータイプ
+ * メール送信エラータイプ
  */
-export type ResendErrorType = "transient" | "permanent";
+export type EmailErrorType = "transient" | "permanent";
 
 /**
  * 通知結果メタデータ
@@ -16,13 +16,13 @@ export type ResendErrorType = "transient" | "permanent";
 export interface NotificationMeta {
   providerMessageId?: string;
   /** エラータイプ（一時的または恒久的） */
-  errorType?: ResendErrorType;
+  errorType?: EmailErrorType;
   /** リトライ回数 */
   retryCount?: number;
   /** ResendやWebhook先のステータスコード */
   statusCode?: number;
-  /** 再試行までの推奨待機秒数（Retry-After） */
-  retryAfterSeconds?: number;
+  /** プロバイダのエラー名 */
+  providerErrorName?: string;
   /** 通知処理をスキップしたか */
   skipped?: boolean;
 }
@@ -160,11 +160,11 @@ export interface IEmailNotificationService {
 }
 
 /**
- * Resendエラー情報
+ * メール送信エラー情報
  */
-export interface ResendErrorInfo {
-  type: ResendErrorType;
+export interface EmailErrorInfo {
+  type: EmailErrorType;
   message: string;
-  statusCode?: number;
   name?: string;
+  statusCode?: number;
 }

--- a/core/utils/type-guards.ts
+++ b/core/utils/type-guards.ts
@@ -28,6 +28,11 @@ export function getNumberProp(value: unknown, key: string): number | undefined {
   return typeof prop === "number" ? prop : undefined;
 }
 
+export function getFiniteNumberProp(value: unknown, key: string): number | undefined {
+  const prop = getNumberProp(value, key);
+  return typeof prop === "number" && Number.isFinite(prop) ? prop : undefined;
+}
+
 export function getRecordProp(value: unknown, key: string): UnknownRecord | undefined {
   if (!isRecord(value)) return undefined;
   const prop = value[key];

--- a/tests/unit/core/notification/email-config.test.ts
+++ b/tests/unit/core/notification/email-config.test.ts
@@ -1,0 +1,59 @@
+const mockRootLoggerWarn = jest.fn();
+
+jest.mock("@core/logging/app-logger", () => ({
+  logger: {
+    warn: mockRootLoggerWarn,
+  },
+}));
+
+import { resolveEmailConfig } from "@core/notification/email-config";
+
+describe("core/notification/email-config", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("development では未設定値をデフォルトで補完する", () => {
+    const config = resolveEmailConfig({
+      NODE_ENV: "development",
+    });
+
+    expect(config).toEqual({
+      fromEmail: "noreply@eventpay.jp",
+      fromName: "みんなの集金",
+      adminEmail: "admin@eventpay.jp",
+    });
+    expect(mockRootLoggerWarn).toHaveBeenCalledTimes(3);
+  });
+
+  it("production で FROM_EMAIL 未設定の場合は例外", () => {
+    expect(() =>
+      resolveEmailConfig({
+        NODE_ENV: "production",
+        ADMIN_EMAIL: "admin@example.com",
+      })
+    ).toThrow("FROM_EMAIL environment variable is required in production");
+  });
+
+  it("production で ADMIN_EMAIL 未設定の場合は例外", () => {
+    expect(() =>
+      resolveEmailConfig({
+        NODE_ENV: "production",
+        FROM_EMAIL: "noreply@example.com",
+      })
+    ).toThrow("ADMIN_EMAIL environment variable is required in production");
+  });
+
+  it("production で FROM_NAME 未設定の場合はデフォルトを利用する", () => {
+    const config = resolveEmailConfig({
+      NODE_ENV: "production",
+      FROM_EMAIL: "noreply@example.com",
+      ADMIN_EMAIL: "admin@example.com",
+    });
+
+    expect(config.fromEmail).toBe("noreply@example.com");
+    expect(config.adminEmail).toBe("admin@example.com");
+    expect(config.fromName).toBe("みんなの集金");
+    expect(mockRootLoggerWarn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/core/notification/email-error-policy.test.ts
+++ b/tests/unit/core/notification/email-error-policy.test.ts
@@ -1,0 +1,84 @@
+import { classifyEmailProviderError } from "@core/notification/email-error-policy";
+
+describe("core/notification/email-error-policy", () => {
+  it("statusCode 503 は transient になる", () => {
+    const result = classifyEmailProviderError({
+      statusCode: 503,
+      name: "application_error",
+      message: "server error",
+    });
+
+    expect(result).toEqual({
+      type: "transient",
+      name: "application_error",
+      message: "server error",
+      statusCode: 503,
+    });
+  });
+
+  it("statusCode 403 は permanent になる", () => {
+    const result = classifyEmailProviderError({
+      statusCode: 403,
+      name: "validation_error",
+      message: "forbidden",
+    });
+
+    expect(result.type).toBe("permanent");
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("name が rate_limit_exceeded の場合は transient になる", () => {
+    const result = classifyEmailProviderError({
+      name: "rate_limit_exceeded",
+      message: "too many requests",
+    });
+
+    expect(result.type).toBe("transient");
+  });
+
+  it("statusCode 409 でも concurrent_idempotent_requests は transient になる", () => {
+    const result = classifyEmailProviderError({
+      statusCode: 409,
+      name: "concurrent_idempotent_requests",
+      message: "Same idempotency key used while request is in progress",
+    });
+
+    expect(result.type).toBe("transient");
+    expect(result.statusCode).toBe(409);
+  });
+
+  it("name が monthly_quota_exceeded の場合は permanent になる", () => {
+    const result = classifyEmailProviderError({
+      name: "monthly_quota_exceeded",
+      message: "quota exceeded",
+    });
+
+    expect(result.type).toBe("permanent");
+  });
+
+  it("ネイティブ timeout エラーはネットワークエラーとして分類される", () => {
+    const result = classifyEmailProviderError(new Error("socket timeout"));
+
+    expect(result.type).toBe("transient");
+    expect(result.message).toBe("ネットワークエラー");
+  });
+
+  it("未知の入力は transient fallback になる", () => {
+    const result = classifyEmailProviderError({});
+
+    expect(result.type).toBe("transient");
+  });
+
+  it("message のみを持つ plain object の message を保持する", () => {
+    const result = classifyEmailProviderError({
+      message: "something went wrong",
+    });
+
+    expect(result).toEqual({
+      type: "transient",
+      message: "something went wrong",
+      name: undefined,
+      statusCode: undefined,
+    });
+  });
+});

--- a/tests/unit/core/notification/email-retry-policy.test.ts
+++ b/tests/unit/core/notification/email-retry-policy.test.ts
@@ -1,0 +1,79 @@
+import {
+  computeRetryDelayMs,
+  DEFAULT_MAX_ATTEMPTS,
+  INITIAL_RETRY_DELAY_MS,
+  RATE_LIMIT_RETRY_DELAY_MS,
+  shouldRetry,
+} from "@core/notification/email-retry-policy";
+
+describe("core/notification/email-retry-policy", () => {
+  it("transient error は最大回数まで再試行する", () => {
+    const result = shouldRetry({
+      errorInfo: { type: "transient", message: "temporary" },
+      attempt: 1,
+      maxAttempts: DEFAULT_MAX_ATTEMPTS,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("最大回数到達時は再試行しない", () => {
+    const result = shouldRetry({
+      errorInfo: { type: "transient", message: "temporary" },
+      attempt: DEFAULT_MAX_ATTEMPTS,
+      maxAttempts: DEFAULT_MAX_ATTEMPTS,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("permanent error は再試行しない", () => {
+    const result = shouldRetry({
+      errorInfo: { type: "permanent", message: "permanent" },
+      attempt: 1,
+      maxAttempts: DEFAULT_MAX_ATTEMPTS,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("rate_limit_exceeded は 5000ms 遅延になる", () => {
+    const delay = computeRetryDelayMs({
+      attempt: 0,
+      errorName: "rate_limit_exceeded",
+      randomFn: () => 0.5,
+    });
+
+    expect(delay).toBe(RATE_LIMIT_RETRY_DELAY_MS);
+  });
+
+  it("429 かつ retry-after がある場合は retry-after を優先する", () => {
+    const delay = computeRetryDelayMs({
+      attempt: 0,
+      statusCode: 429,
+      errorName: "rate_limit_exceeded",
+      retryAfterSeconds: 2,
+      randomFn: () => 1,
+    });
+
+    expect(delay).toBe(2000);
+  });
+
+  it("通常リトライは指数バックオフになる", () => {
+    const delay = computeRetryDelayMs({
+      attempt: 2,
+      randomFn: () => 0.5,
+    });
+
+    expect(delay).toBe(INITIAL_RETRY_DELAY_MS * 4);
+  });
+
+  it("jitter が遅延に反映される", () => {
+    const delay = computeRetryDelayMs({
+      attempt: 0,
+      randomFn: () => 1,
+    });
+
+    expect(delay).toBe(1200);
+  });
+});


### PR DESCRIPTION
## 概要

メール送信（Resend）周りの実装を整理し、設定解決・エラー分類・再試行方針を分離して保守性と堅牢性を改善します。
* #313

## 変更内容

### 1. 設定解決の分離

* `email-config` を追加
* `FROM_EMAIL / FROM_NAME / ADMIN_EMAIL` の解決処理を集約
* non-development 環境では必須値を明確化
* 未設定時のデフォルト値適用と warning ログ出力を整理

### 2. メールプロバイダエラー分類の整理

* `email-error-policy` を追加
* provider の `name` / `statusCode` / メッセージ内容をもとに

  * `transient`
  * `permanent`
    に分類する方針を分離
* `isRecord` な入力でも `message` を保持したまま扱えるよう改善

### 3. 再試行ポリシーの分離

* `email-retry-policy` を追加
* 再試行可否判定を共通化
* 指数バックオフ + jitter を導入
* 429 時は `Retry-After` を優先して待機時間を決定

### 4. `email-service` の整理

* Resend SDK の利用を簡素化
* `sendEmail` の失敗処理を整理し、責務を明確化
* タイムアウトを **30s → 10s** に短縮
* `AbortController` を使ってタイムアウト時にリクエストを中断
* 開発環境では送信をスキップし、meta に `skipped` を付与

### 5. 型定義の更新

* `ResendErrorType` を `EmailErrorType` にリネーム
* `NotificationMeta` を見直し、`providerErrorName` を追加

### 6. テストの追加・更新

* `email-config`
* `email-error-policy`
* `email-retry-policy`
* `email-service`

上記に対する unit test を追加・更新し、レート制限・quota 超過・timeout・retry-after などのケースを補強しました。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rytkhs/event-pay/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
