### PR TITLE
refactor: IP検出を CF-Connecting-IP ベースに簡素化し null 返却へ変更

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -76,7 +76,7 @@ export async function loginAction(formData: FormData): Promise<ActionResult<{ us
     // レート制限チェック（ip + emailHash の AND）
     try {
       const headersList = await headers();
-      const ip = getClientIPFromHeaders(headersList);
+      const ip = getClientIPFromHeaders(headersList) ?? undefined;
       const keyInput = buildKey({ scope: "auth.login", ip, email: sanitizedEmail });
       const rateLimitResult = await enforceRateLimit({
         keys: Array.isArray(keyInput) ? keyInput : [keyInput],
@@ -252,7 +252,7 @@ export async function registerAction(formData: FormData): Promise<ActionResult<{
     // レート制限チェック（ip + emailHash の AND）
     try {
       const headersList = await headers();
-      const ip = getClientIPFromHeaders(headersList);
+      const ip = getClientIPFromHeaders(headersList) ?? undefined;
       const keyInput = buildKey({ scope: "auth.register", ip, email: sanitizedEmail });
       const rateLimitResult = await enforceRateLimit({
         keys: Array.isArray(keyInput) ? keyInput : [keyInput],
@@ -515,7 +515,7 @@ export async function resendOtpAction(formData: FormData): Promise<ActionResult>
     // レート制限チェック（ip + emailHash の AND）
     try {
       const headersList = await headers();
-      const ip = getClientIPFromHeaders(headersList);
+      const ip = getClientIPFromHeaders(headersList) ?? undefined;
       const sanitizedEmail = InputSanitizer.sanitizeEmail(email);
       const keyInput = buildKey({ scope: "auth.emailResend", ip, email: sanitizedEmail });
       const rateLimitResult = await enforceRateLimit({
@@ -623,7 +623,7 @@ export async function resetPasswordAction(formData: FormData): Promise<ActionRes
     // レート制限チェック（ip + emailHash の AND）
     try {
       const headersList = await headers();
-      const ip = getClientIPFromHeaders(headersList);
+      const ip = getClientIPFromHeaders(headersList) ?? undefined;
       const keyInput = buildKey({ scope: "auth.passwordReset", ip, email });
       const rateLimitResult = await enforceRateLimit({
         keys: Array.isArray(keyInput) ? keyInput : [keyInput],

--- a/app/(public)/contact/actions.ts
+++ b/app/(public)/contact/actions.ts
@@ -40,7 +40,7 @@ export async function submitContact(input: ContactInput) {
   }
 
   const h = await headers();
-  const ip = getClientIPFromHeaders(h);
+  const ip = getClientIPFromHeaders(h) ?? undefined;
 
   // 2. レート制限チェック
   const rateLimitKey = buildKey({ scope: "contact.submit", ip });

--- a/app/api/csp-report/route.ts
+++ b/app/api/csp-report/route.ts
@@ -40,7 +40,7 @@ const MAX_PAYLOAD_SIZE = 10 * 1024;
  */
 export async function POST(request: NextRequest) {
   const requestId = request.headers.get("x-request-id") || generateSecureUuid();
-  const clientIP = getClientIP(request);
+  const clientIP = getClientIP(request) ?? undefined;
 
   try {
     // レート制限チェック

--- a/app/api/errors/route.ts
+++ b/app/api/errors/route.ts
@@ -191,7 +191,7 @@ function queueErrorNotification(
 }
 
 export async function POST(req: NextRequest) {
-  const clientIp = getClientIP(req);
+  const clientIp = getClientIP(req) ?? undefined;
   const requestUserAgent = req.headers.get("user-agent") || undefined;
 
   try {

--- a/app/api/payments/verify-session/route.ts
+++ b/app/api/payments/verify-session/route.ts
@@ -35,11 +35,13 @@ interface VerificationResult {
 
 export async function GET(request: NextRequest) {
   try {
+    const clientIP = getClientIP(request) ?? undefined;
+
     // 事前レート制限（署名検証互換: ボディ未消費）
     const mw = withRateLimit(POLICIES["stripe.checkout"], (r) =>
       buildKey({
         scope: "stripe.checkout",
-        ip: getClientIP(r),
+        ip: clientIP,
         token: r.headers.get("x-guest-token") || undefined,
       })
     );
@@ -61,7 +63,7 @@ export async function GET(request: NextRequest) {
         details: {
           endpoint: "/api/payments/verify-session",
         },
-        ip: getClientIP(request),
+        ip: clientIP,
         timestamp: new Date(),
       });
       return respondWithCode("MISSING_PARAMETER", {
@@ -149,7 +151,7 @@ export async function GET(request: NextRequest) {
           tokenMatch: false,
           attendanceExists: !!attendanceData,
         },
-        ip: getClientIP(request),
+        ip: clientIP,
         timestamp: new Date(),
       });
 
@@ -284,7 +286,7 @@ export async function GET(request: NextRequest) {
                   paymentId: fallbackPayment.id,
                   reason: "session_outdated",
                 },
-                ip: getClientIP(request),
+                ip: clientIP,
                 timestamp: new Date(),
               });
 
@@ -306,7 +308,7 @@ export async function GET(request: NextRequest) {
                 paymentId: fallbackPayment.id,
                 reason: "fallback_matched",
               },
-              ip: getClientIP(request),
+              ip: clientIP,
               timestamp: new Date(),
             });
           }
@@ -325,7 +327,7 @@ export async function GET(request: NextRequest) {
             hasGuestToken: !!guestToken,
             dbErrorCode: dbError ? toErrorLike(dbError).code : undefined,
           },
-          ip: getClientIP(request),
+          ip: clientIP,
           timestamp: new Date(),
         });
 

--- a/app/api/webhooks/stripe-connect/route.ts
+++ b/app/api/webhooks/stripe-connect/route.ts
@@ -38,7 +38,7 @@ const getQstashClient = () => {
 export async function POST(request: NextRequest) {
   ensureFeaturesRegistered();
 
-  const _clientIP = getClientIP(request);
+  const _clientIP = getClientIP(request) ?? undefined;
   const requestId = request.headers.get("x-request-id") || generateSecureUuid();
   const baseLogContext = { category: "stripe_webhook" as const, actorType: "webhook" as const };
   const connectLogger = logger.withContext({
@@ -55,6 +55,22 @@ export async function POST(request: NextRequest) {
     // 本番のみ: Stripe Webhook 送信元 IP の許可リスト検証
     if (shouldEnforceStripeWebhookIpCheck()) {
       const clientIp = _clientIP;
+      if (!clientIp) {
+        logger.warn("Webhook IP missing", {
+          category: "security",
+          action: "webhook_ip_check",
+          actor_type: "webhook",
+          userAgent: request.headers.get("user-agent") || undefined,
+          outcome: "failure",
+        });
+        return respondWithCode("FORBIDDEN", {
+          instance: "/api/webhooks/stripe-connect",
+          detail: "IP not allowed",
+          correlationId: requestId,
+          logContext: { ...baseLogContext, action: "webhook_ip_missing" },
+        });
+      }
+
       const allowed = await isStripeWebhookIpAllowed(clientIp);
       if (!allowed) {
         // Security logging replaced with standard logger

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -50,10 +50,31 @@ export async function POST(request: NextRequest) {
   });
 
   try {
-    const clientIP = getClientIP(request);
+    const clientIP = getClientIP(request) ?? undefined;
 
     // IP許可リストのチェック（本番環境でのセキュリティ）
     if (shouldEnforceStripeWebhookIpCheck()) {
+      if (!clientIP) {
+        logSecurityEvent({
+          type: "WEBHOOK_IP_REJECTED",
+          severity: "MEDIUM",
+          message: "Webhook request missing CF-Connecting-IP",
+          details: {
+            request_id: requestId,
+            path: "/api/webhooks/stripe",
+            reason: "missing_client_ip",
+          },
+          userAgent: request.headers.get("user-agent") || undefined,
+          timestamp: new Date(),
+        });
+        return respondWithCode("FORBIDDEN", {
+          instance: "/api/webhooks/stripe",
+          detail: "IP address not authorized for webhook access",
+          correlationId: requestId,
+          logContext: { ...baseLogContext, action: "webhook_ip_missing" },
+        });
+      }
+
       const allowed = await isStripeWebhookIpAllowed(clientIP);
       if (!allowed) {
         logSecurityEvent({

--- a/app/api/workers/event-cancel/route.ts
+++ b/app/api/workers/event-cancel/route.ts
@@ -32,6 +32,7 @@ export async function POST(request: NextRequest) {
   const start = Date.now();
   const corr = `qstash_cancel_${generateSecureUuid()}`;
   const baseLogContext = { category: "event_management" as const, actorType: "webhook" as const };
+  const clientIP = getClientIP(request) ?? undefined;
 
   const cancelLogger = logger.withContext({
     category: "event_management",
@@ -57,7 +58,7 @@ export async function POST(request: NextRequest) {
         message: "Missing QStash signature (event-cancel)",
         details: { correlation_id: corr, path: "/api/workers/event-cancel" },
         userAgent: request.headers.get("user-agent") || undefined,
-        ip: getClientIP(request),
+        ip: clientIP,
         timestamp: new Date(),
       });
       return respondWithCode("UNAUTHORIZED", {
@@ -79,7 +80,7 @@ export async function POST(request: NextRequest) {
         message: "Invalid QStash signature (event-cancel)",
         details: { correlation_id: corr, path: "/api/workers/event-cancel" },
         userAgent: request.headers.get("user-agent") || undefined,
-        ip: getClientIP(request),
+        ip: clientIP,
         timestamp: new Date(),
       });
       return respondWithCode("UNAUTHORIZED", {

--- a/app/api/workers/stripe-connect-webhook/route.ts
+++ b/app/api/workers/stripe-connect-webhook/route.ts
@@ -67,6 +67,7 @@ export async function POST(request: NextRequest) {
   const messageId = request.headers.get("Upstash-Message-Id");
   const retried = request.headers.get("Upstash-Retried");
   const retriedCount = retried ? parseInt(retried, 10) : 0;
+  const clientIP = getClientIP(request) ?? undefined;
 
   const connectLogger = logger.withContext({
     category: "stripe_webhook",
@@ -90,7 +91,7 @@ export async function POST(request: NextRequest) {
 
     if (!signature) {
       connectLogger.warn("Missing QStash signature (connect) - non-retryable", {
-        ip: getClientIP(request),
+        ip: clientIP,
         message_id: messageId,
         outcome: "failure",
       });
@@ -102,7 +103,7 @@ export async function POST(request: NextRequest) {
     const isValid = await receiver.verify({ signature, body: rawBody, url });
     if (!isValid) {
       connectLogger.warn("Invalid QStash signature (connect) - non-retryable", {
-        ip: getClientIP(request),
+        ip: clientIP,
         message_id: messageId,
         outcome: "failure",
       });

--- a/app/api/workers/stripe-webhook/route.ts
+++ b/app/api/workers/stripe-webhook/route.ts
@@ -80,6 +80,7 @@ export async function POST(request: NextRequest) {
   const messageId = request.headers.get("Upstash-Message-Id");
   const retried = request.headers.get("Upstash-Retried");
   const retriedCount = retried ? parseInt(retried, 10) : 0;
+  const clientIP = getClientIP(request) ?? undefined;
 
   const qstashLogger = logger.withContext({
     category: "stripe_webhook",
@@ -117,7 +118,7 @@ export async function POST(request: NextRequest) {
           path: "/api/workers/stripe-webhook",
         },
         userAgent: request.headers.get("user-agent") || undefined,
-        ip: getClientIP(request),
+        ip: clientIP,
         timestamp: new Date(),
       });
       qstashLogger.warn("Missing QStash signature - non-retryable", {
@@ -148,7 +149,7 @@ export async function POST(request: NextRequest) {
           path: "/api/workers/stripe-webhook",
         },
         userAgent: request.headers.get("user-agent") || undefined,
-        ip: getClientIP(request),
+        ip: clientIP,
         timestamp: new Date(),
       });
       qstashLogger.warn("Invalid QStash signature - non-retryable", {

--- a/app/guest/[token]/page.tsx
+++ b/app/guest/[token]/page.tsx
@@ -65,7 +65,7 @@ export default async function GuestPage(props: GuestPageProps) {
     // リクエスト情報を取得（セキュリティログ用）
     const headersList = await headers();
     const userAgent = headersList.get("user-agent") || undefined;
-    const ip = getClientIPFromHeaders(headersList);
+    const ip = getClientIPFromHeaders(headersList) ?? undefined;
 
     // ゲストトークンの検証
     const validation = await getGuestValidation(token);
@@ -104,7 +104,7 @@ export default async function GuestPage(props: GuestPageProps) {
     // リクエスト情報を取得（エラーハンドリング用）
     const errorHeadersList = await headers();
     const errorUserAgent = errorHeadersList.get("user-agent") || undefined;
-    const errorIp = getClientIPFromHeaders(errorHeadersList);
+    const errorIp = getClientIPFromHeaders(errorHeadersList) ?? undefined;
 
     const errorContext = {
       action: "guest_page_load",

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -27,7 +27,7 @@ export default async function InvitePage(props: InvitePageProps) {
   // リクエスト情報を取得（セキュリティログ用）
   const headersList = await headers();
   const userAgent = headersList.get("user-agent") || undefined;
-  const ip = getClientIPFromHeaders(headersList);
+  const ip = getClientIPFromHeaders(headersList) ?? undefined;
 
   try {
     if (!params?.token) {

--- a/core/utils/ip-detection.ts
+++ b/core/utils/ip-detection.ts
@@ -1,12 +1,9 @@
-import { createHash } from "crypto";
-
-import { NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
 
 import { logger } from "@core/logging/app-logger";
 
 /**
  * ヘッダーアクセス用のインターフェース
- * NextRequest.headers、Web API Headers、Next.js ReadonlyHeaders すべてに対応
  */
 interface HeaderLike {
   get(name: string): string | null;
@@ -18,47 +15,21 @@ interface HeaderLike {
 const IPv4_REGEX =
   /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
-/**
- * プライベートIPアドレスの範囲
- */
-const PRIVATE_IP_RANGES = [
-  /^127\./, // 127.0.0.0/8 (localhost)
-  /^10\./, // 10.0.0.0/8
-  /^172\.1[6-9]\./, // 172.16.0.0/12
-  /^172\.2[0-9]\./, // 172.16.0.0/12
-  /^172\.3[0-1]\./, // 172.16.0.0/12
-  /^192\.168\./, // 192.168.0.0/16
-  /^169\.254\./, // 169.254.0.0/16 (link-local)
-];
-
-/**
- * IPv6アドレスが有効かどうかを検証する（簡易版）
- */
 function isValidIPv6(ip: string): boolean {
-  // よく使われるIPv6パターンをチェック
-  if (ip === "::1" || ip === "::") {
+  if (!ip.includes(":")) {
+    return false;
+  }
+
+  try {
+    // WHATWG URL parserにIPv6リテラルとして解釈させて厳格検証する
+    // 例: http://[2001:db8::1]
+    void new URL(`http://[${ip}]`);
     return true;
+  } catch {
+    return false;
   }
-
-  // 基本的なIPv6形式チェック（コロンを含み、16進数文字のみ）
-  if (ip.includes(":") && /^[0-9a-fA-F:]+$/.test(ip)) {
-    // 完全なIPv6アドレス（例：2001:0db8:85a3:0000:0000:8a2e:0370:7334）
-    if (/^[0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){7}$/.test(ip)) {
-      return true;
-    }
-
-    // 圧縮形式のIPv6アドレス（::を含む）
-    if (ip.includes("::")) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
-/**
- * IPアドレスが有効かどうかを検証する
- */
 function isValidIP(ip: string): boolean {
   if (!ip || typeof ip !== "string") {
     return false;
@@ -75,323 +46,54 @@ function isValidIP(ip: string): boolean {
   return IPv4_REGEX.test(trimmedIP) || isValidIPv6(trimmedIP);
 }
 
-/**
- * IPアドレスがプライベートIPかどうかを判定する
- */
-function isPrivateIP(ip: string): boolean {
-  if (!isValidIP(ip)) {
-    return false;
+function normalizeCandidateIP(raw: string | null): string | null {
+  if (!raw) {
+    return null;
   }
 
-  // IPv6のlocalhostチェック
-  if (ip === "::1" || ip === "::") {
-    return true;
+  const candidate = raw.split(",")[0]?.trim().toLowerCase();
+  if (!candidate) {
+    return null;
   }
 
-  // IPv4のプライベートIPチェック
-  return PRIVATE_IP_RANGES.some((range) => range.test(ip));
-}
-
-/**
- * IPアドレスを正規化する
- */
-function normalizeIP(ip: string): string {
-  if (!ip || typeof ip !== "string") {
-    return "127.0.0.1";
-  }
-
-  const trimmedIP = ip.trim().toLowerCase();
-
-  // 基本的な検証
-  if (!isValidIP(trimmedIP)) {
-    // 本番環境では適切なログシステムに出力
-    if (process.env.NODE_ENV === "development") {
-      logger.warn("Invalid IP address detected. Using fallback.", {
-        category: "system",
-        action: "ip_detection",
-        actor_type: "anonymous",
-        ip,
-        outcome: "failure",
-      });
-    }
-    return "127.0.0.1";
-  }
-
-  return trimmedIP;
-}
-
-/**
- * フォールバック識別子を生成する
- * プロキシヘッダーが全て存在しない場合の代替手段
- */
-function generateFallbackIdentifier(request: NextRequest): string {
-  // セッション固有の情報からハッシュを生成
-  const sessionData = [
-    request.headers.get("user-agent") || "",
-    request.headers.get("accept-language") || "",
-    request.headers.get("accept-encoding") || "",
-    request.headers.get("x-request-id") || "",
-    Date.now().toString().slice(0, -3), // 1秒単位での時間（レート制限用）
-  ].join("|");
-
-  // SHA-256ハッシュの最初の16文字を使用（IP形式に近づける）
-  const hash = createHash("sha256").update(sessionData).digest("hex").substring(0, 16);
-
-  // 擬似IPアドレス形式に変換（識別しやすくするため）
-  const segments = [
-    parseInt(hash.substring(0, 2), 16) % 255,
-    parseInt(hash.substring(2, 4), 16) % 255,
-    parseInt(hash.substring(4, 6), 16) % 255,
-    parseInt(hash.substring(6, 8), 16) % 255,
-  ];
-
-  return segments.join(".");
+  return isValidIP(candidate) ? candidate : null;
 }
 
 /**
  * クライアントIPアドレスを取得する（Edge Runtime互換版）
  *
  * @param request - Next.js Request オブジェクト
- * @returns クライアントのIPアドレス
+ * @returns クライアントのIPアドレス。取得できない場合はnull
  */
-export function getClientIP(request: NextRequest): string;
-export function getClientIP(headers: HeaderLike): string;
-export function getClientIP(requestOrHeaders: NextRequest | HeaderLike): string {
+export function getClientIP(request: NextRequest): string | null;
+export function getClientIP(headers: HeaderLike): string | null;
+export function getClientIP(requestOrHeaders: NextRequest | HeaderLike): string | null {
   // NextRequestかHeaderLikeかを判定
   const headers = "headers" in requestOrHeaders ? requestOrHeaders.headers : requestOrHeaders;
 
-  // 信頼度ベースでのIPヘッダー優先順位
-  // セキュリティ重要度: HIGH > MEDIUM > LOW
-  const ipSources = [
-    // 🟢 HIGH: 偽装が困難な信頼できるヘッダー
-    {
-      ip: headers.get("x-vercel-forwarded-for")?.split(",")[0]?.trim(),
-      trust: "high",
-      source: "Vercel",
-    },
-    {
-      ip: headers.get("cf-connecting-ip"),
-      trust: "high",
-      source: "Cloudflare",
-    },
-
-    // 🟡 MEDIUM: CDN/プロキシ固有ヘッダー（中程度の信頼度）
-    {
-      ip: headers.get("x-real-ip"),
-      trust: "medium",
-      source: "Nginx",
-    },
-    {
-      ip: headers.get("x-client-ip"),
-      trust: "medium",
-      source: "Apache",
-    },
-
-    // 🔴 LOW: 偽装可能な汎用ヘッダー（注意深い使用）
-    {
-      ip: headers.get("x-forwarded-for")?.split(",")[0]?.trim(),
-      trust: "low",
-      source: "X-Forwarded-For",
-    },
-    {
-      ip: headers.get("x-cluster-client-ip"),
-      trust: "low",
-      source: "Cluster",
-    },
-    {
-      ip: headers.get("x-forwarded"),
-      trust: "low",
-      source: "Forwarded",
-    },
-    {
-      ip: headers.get("forwarded-for"),
-      trust: "low",
-      source: "Forwarded-For",
-    },
-
-    // 最後の手段（Edge Runtimeでは常にundefined）
-    {
-      ip:
-        "ip" in requestOrHeaders && typeof requestOrHeaders.ip === "string"
-          ? requestOrHeaders.ip
-          : undefined,
-      trust: "low",
-      source: "Request.ip",
-    },
-  ];
-
-  // 信頼度の高いIPアドレスを優先して探す
-  let selectedIP: string | null = null;
-  let selectedTrust: string | null = null;
-  let selectedSource: string | null = null;
-
-  for (const { ip, trust, source } of ipSources) {
-    if (ip && isValidIP(ip)) {
-      const normalizedIP = normalizeIP(ip);
-
-      // プライベートIPでない場合は採用候補
-      if (!isPrivateIP(normalizedIP)) {
-        selectedIP = normalizedIP;
-        selectedTrust = trust;
-        selectedSource = source;
-
-        // 高信頼度の場合は即座に採用
-        if (trust === "high") {
-          break;
-        }
-      }
-
-      // 明示的にlocalhostの場合は開発環境用として採用
-      if ((ip === "127.0.0.1" || ip === "::1") && !selectedIP) {
-        selectedIP = normalizedIP;
-        selectedTrust = trust;
-        selectedSource = source;
-      }
-    }
+  const rawIp = headers.get("cf-connecting-ip");
+  const normalizedIP = normalizeCandidateIP(rawIp);
+  if (normalizedIP) {
+    return normalizedIP;
   }
 
-  // 選択されたIPアドレスがある場合
-  if (selectedIP) {
-    // セキュリティログ: 低信頼度ヘッダーの使用を警告
-    if (selectedTrust === "low" && process.env.NODE_ENV === "development") {
-      logger.warn("Using low-trust IP header", {
-        category: "system",
-        action: "ip_detection",
-        actor_type: "anonymous",
-        source: selectedSource || undefined,
-        ip: selectedIP,
-        outcome: "success",
-      });
-    }
-    return selectedIP;
+  if (process.env.NODE_ENV !== "test") {
+    logger.warn("Unable to resolve client IP from CF-Connecting-IP", {
+      category: "system",
+      action: "ip_detection_missing_or_invalid_cf_ip",
+      actor_type: "anonymous",
+      has_cf_connecting_ip: !!rawIp,
+      raw_cf_connecting_ip: rawIp ?? undefined,
+      outcome: "failure",
+    });
   }
-
-  // 全てのプロキシヘッダーが存在しない場合のフォールバック戦略
-  if (process.env.NODE_ENV === "development") {
-    // 開発環境ではlocalhostを返す
-    return "127.0.0.1";
-  } else {
-    // 本番環境では擬似IPを生成（レート制限機能を維持するため）
-    // NextRequestの場合のみfallback identifierを生成可能
-    const fallbackIP =
-      "headers" in requestOrHeaders ? generateFallbackIdentifier(requestOrHeaders) : "127.0.0.1"; // Headersのみの場合はlocalhostを使用
-
-    // 本番環境では適切なログシステムに出力
-    if (process.env.NODE_ENV === "production") {
-      logger.warn("No valid client IP found, using fallback identifier", {
-        category: "system",
-        action: "ip_detection",
-        actor_type: "anonymous",
-        fallback_ip: fallbackIP,
-        user_agent: headers.get("user-agent") || undefined,
-        outcome: "failure",
-      });
-    }
-
-    return fallbackIP;
-  }
+  return null;
 }
 
 /**
  * Server Component/Server Actions用のIPアドレス取得関数
  * Next.js の headers() 関数から取得したオブジェクトに特化
  */
-export function getClientIPFromHeaders(headersList: HeaderLike): string {
-  // 信頼度ベースでのIPヘッダー優先順位（Server Components用）
-  const ipSources = [
-    // 🟢 HIGH: 偽装が困難な信頼できるヘッダー
-    {
-      ip: headersList.get("x-vercel-forwarded-for")?.split(",")[0]?.trim(),
-      trust: "high",
-      source: "Vercel",
-    },
-    {
-      ip: headersList.get("cf-connecting-ip"),
-      trust: "high",
-      source: "Cloudflare",
-    },
-
-    // 🟡 MEDIUM: CDN/プロキシ固有ヘッダー（中程度の信頼度）
-    {
-      ip: headersList.get("x-real-ip"),
-      trust: "medium",
-      source: "Nginx",
-    },
-    {
-      ip: headersList.get("x-client-ip"),
-      trust: "medium",
-      source: "Apache",
-    },
-
-    // 🔴 LOW: 偽装可能な汎用ヘッダー（注意深い使用）
-    {
-      ip: headersList.get("x-forwarded-for")?.split(",")[0]?.trim(),
-      trust: "low",
-      source: "X-Forwarded-For",
-    },
-    {
-      ip: headersList.get("x-cluster-client-ip"),
-      trust: "low",
-      source: "Cluster",
-    },
-    {
-      ip: headersList.get("x-forwarded"),
-      trust: "low",
-      source: "Forwarded",
-    },
-    {
-      ip: headersList.get("forwarded-for"),
-      trust: "low",
-      source: "Forwarded-For",
-    },
-  ];
-
-  // 信頼度の高いIPアドレスを優先して探す
-  let selectedIP: string | null = null;
-  let selectedTrust: string | null = null;
-  let selectedSource: string | null = null;
-
-  for (const { ip, trust, source } of ipSources) {
-    if (ip && isValidIP(ip)) {
-      const normalizedIP = normalizeIP(ip);
-
-      // プライベートIPでない場合は採用候補
-      if (!isPrivateIP(normalizedIP)) {
-        selectedIP = normalizedIP;
-        selectedTrust = trust;
-        selectedSource = source;
-
-        // 高信頼度の場合は即座に採用
-        if (trust === "high") {
-          break;
-        }
-      }
-
-      // 明示的にlocalhostの場合は開発環境用として採用
-      if ((ip === "127.0.0.1" || ip === "::1") && !selectedIP) {
-        selectedIP = normalizedIP;
-        selectedTrust = trust;
-        selectedSource = source;
-      }
-    }
-  }
-
-  // 選択されたIPアドレスがある場合
-  if (selectedIP) {
-    // セキュリティログ: 低信頼度ヘッダーの使用を警告
-    if (selectedTrust === "low" && process.env.NODE_ENV === "development") {
-      logger.warn("[Server Component] Using low-trust IP header", {
-        category: "system",
-        action: "ip_detection",
-        actor_type: "anonymous",
-        source: selectedSource || undefined,
-        ip: selectedIP,
-        outcome: "success",
-      });
-    }
-    return selectedIP;
-  }
-
-  // 全てのプロキシヘッダーが存在しない場合は開発環境想定のlocalhostを返す
-  return "127.0.0.1";
+export function getClientIPFromHeaders(headersList: HeaderLike): string | null {
+  return getClientIP(headersList);
 }

--- a/core/utils/next.ts
+++ b/core/utils/next.ts
@@ -37,7 +37,7 @@ export async function getHeaders(): Promise<{
 
     if (headersList) {
       const userAgent = headersList.get("user-agent") ?? undefined;
-      const ip = getClientIPFromHeaders(headersList);
+      const ip = getClientIPFromHeaders(headersList) ?? undefined;
       return { headersList, context: { userAgent, ip } };
     }
 

--- a/features/demo/actions/start-demo.ts
+++ b/features/demo/actions/start-demo.ts
@@ -27,9 +27,10 @@ export async function startDemoSession(): Promise<ActionResult<{ redirectUrl: st
   }
 
   // Rate Limit: 同一IPからのデモ作成を制限 (1時間に10回まで)
-  const ip = getClientIPFromHeaders(await headers());
+  const ip = getClientIPFromHeaders(await headers()) ?? undefined;
+  const keyInput = buildKey({ scope: "demo.create", ip });
   const rlResult = await enforceRateLimit({
-    keys: [buildKey({ scope: "demo.create", ip }) as string],
+    keys: Array.isArray(keyInput) ? keyInput : [keyInput],
     policy: POLICIES["demo.create"],
   });
 

--- a/features/guest/actions/update-attendance.ts
+++ b/features/guest/actions/update-attendance.ts
@@ -28,7 +28,7 @@ export async function updateGuestAttendanceAction(
   try {
     const headersList = await headers();
     const userAgent = headersList.get("user-agent") || undefined;
-    const ip = getClientIPFromHeaders(headersList);
+    const ip = getClientIPFromHeaders(headersList) ?? undefined;
     securityContext = { userAgent, ip };
   } catch (_error) {
     // テスト環境など、headers()が利用できない場合は空のコンテキストを使用

--- a/tests/helpers/test-verify-session.ts
+++ b/tests/helpers/test-verify-session.ts
@@ -142,6 +142,7 @@ export class VerifySessionTestHelper {
 
     const headers = new Headers();
     headers.set("Content-Type", "application/json");
+    headers.set("cf-connecting-ip", "203.0.113.10");
     if (guestToken) headers.set("x-guest-token", guestToken);
 
     return new NextRequest(url, { headers });
@@ -177,6 +178,7 @@ export class VerifySessionTestHelper {
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
+      "cf-connecting-ip": "203.0.113.10",
     };
 
     if (guestToken) {

--- a/tests/integration/api/csp-report/csp-report.integration.test.ts
+++ b/tests/integration/api/csp-report/csp-report.integration.test.ts
@@ -105,7 +105,7 @@ describe("CSPレポートAPI統合テスト (/api/csp-report)", () => {
       method: "POST",
       headers: {
         "content-type": "application/csp-report",
-        "x-forwarded-for": "203.0.113.1",
+        "cf-connecting-ip": "203.0.113.1",
         "user-agent": "Mozilla/5.0",
       },
       body: JSON.stringify(cspReport),
@@ -178,7 +178,7 @@ describe("CSPレポートAPI統合テスト (/api/csp-report)", () => {
       method: "POST",
       headers: {
         "content-type": "application/reports+json",
-        "x-forwarded-for": "203.0.113.1",
+        "cf-connecting-ip": "203.0.113.1",
       },
       body: JSON.stringify(reports),
     });
@@ -230,7 +230,7 @@ describe("CSPレポートAPI統合テスト (/api/csp-report)", () => {
       method: "POST",
       headers: {
         "content-type": "text/plain", // 不正なContent-Type
-        "x-forwarded-for": "203.0.113.1",
+        "cf-connecting-ip": "203.0.113.1",
       },
       body: JSON.stringify(cspReport),
     });
@@ -278,7 +278,7 @@ describe("CSPレポートAPI統合テスト (/api/csp-report)", () => {
       headers: {
         "content-type": "application/csp-report",
         "content-length": String(payloadString.length),
-        "x-forwarded-for": "203.0.113.1",
+        "cf-connecting-ip": "203.0.113.1",
       },
       body: payloadString,
     });
@@ -329,7 +329,7 @@ describe("CSPレポートAPI統合テスト (/api/csp-report)", () => {
       method: "POST",
       headers: {
         "content-type": "application/csp-report",
-        "x-forwarded-for": "203.0.113.1",
+        "cf-connecting-ip": "203.0.113.1",
       },
       body: JSON.stringify(cspReport),
     });
@@ -369,7 +369,7 @@ describe("CSPレポートAPI統合テスト (/api/csp-report)", () => {
       method: "POST",
       headers: {
         "content-type": "application/csp-report",
-        "x-forwarded-for": "203.0.113.1",
+        "cf-connecting-ip": "203.0.113.1",
       },
       body: invalidJSON,
     });
@@ -411,7 +411,7 @@ describe("CSPレポートAPI統合テスト (/api/csp-report)", () => {
       method: "POST",
       headers: {
         "content-type": "application/csp-report",
-        "x-forwarded-for": "203.0.113.1",
+        "cf-connecting-ip": "203.0.113.1",
       },
       body: JSON.stringify(invalidReport),
     });

--- a/tests/integration/api/errors/error-collection.integration.test.ts
+++ b/tests/integration/api/errors/error-collection.integration.test.ts
@@ -270,7 +270,7 @@ describe("エラー収集API統合テスト (/api/errors)", () => {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-forwarded-for": "8.8.8.8, 1.1.1.1",
+        "cf-connecting-ip": "8.8.8.8",
       },
       body: JSON.stringify({
         error: {

--- a/tests/unit/core/utils/ip-detection.test.ts
+++ b/tests/unit/core/utils/ip-detection.test.ts
@@ -1,0 +1,45 @@
+import { getClientIP, getClientIPFromHeaders } from "@core/utils/ip-detection";
+
+function createHeaderLike(init?: Record<string, string>) {
+  return new Headers(init);
+}
+
+describe("ip-detection", () => {
+  test("CF-Connecting-IP の IPv4 を返す", () => {
+    const headers = createHeaderLike({ "cf-connecting-ip": "203.0.113.10" });
+
+    expect(getClientIPFromHeaders(headers)).toBe("203.0.113.10");
+  });
+
+  test("CF-Connecting-IP の IPv6 を返す（小文字化）", () => {
+    const headers = createHeaderLike({ "cf-connecting-ip": "2001:DB8::1" });
+
+    expect(getClientIPFromHeaders(headers)).toBe("2001:db8::1");
+  });
+
+  test("CF-Connecting-IP が欠落している場合は null", () => {
+    const headers = createHeaderLike();
+
+    expect(getClientIPFromHeaders(headers)).toBeNull();
+  });
+
+  test("CF-Connecting-IP が不正値の場合は null", () => {
+    const headers = createHeaderLike({ "cf-connecting-ip": "::::" });
+
+    expect(getClientIPFromHeaders(headers)).toBeNull();
+  });
+
+  test("CF-Connecting-IP 以外のヘッダーは無視する", () => {
+    const headers = createHeaderLike({ "x-forwarded-for": "198.51.100.1" });
+
+    expect(getClientIPFromHeaders(headers)).toBeNull();
+  });
+
+  test("NextRequest 互換オブジェクトでも取得できる", () => {
+    const requestLike = {
+      headers: createHeaderLike({ "cf-connecting-ip": "198.51.100.44" }),
+    };
+
+    expect(getClientIP(requestLike as Parameters<typeof getClientIP>[0])).toBe("198.51.100.44");
+  });
+});


### PR DESCRIPTION
### 変更概要

* IP検出を **CF-Connecting-IP のみに簡素化**し、取得できない/不正な場合は **null** を返すよう変更。
* 既存の呼び出し元は `?? undefined` で **IPが無いケースを許容**するよう調整（レート制限キー/ログ等）。
* Stripe Webhook のIP許可リスト検証が有効な場合、**IP欠落時は 403** で拒否するように変更（ログも追加）。

### 影響範囲

* API / Server Actions / Pages など、`getClientIP*` を利用していた箇所を一括更新。
* テストは `x-forwarded-for` から `cf-connecting-ip` に移行。
* `ip-detection` のユニットテストを追加。

### テスト

* unit: `tests/unit/core/utils/ip-detection.test.ts`
* integration: CSP report / errors collection / verify-session 周辺（ヘッダー差し替え含む）

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rytkhs/event-pay/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
