### PR TITLE
fix(auth): 未認証時の挙動整理と logout の revalidate 削除

### DIFF
--- a/app/(auth)/_actions/logout-action.ts
+++ b/app/(auth)/_actions/logout-action.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
-
 import type { ActionResult } from "@core/errors/adapters/server-actions";
 
 import { logoutAction as logoutActionImpl } from "@features/auth/server";
@@ -19,10 +17,6 @@ export async function logoutAction(): Promise<ActionResult> {
 
   const result = await logoutActionImpl();
   const { actionResult, sideEffects } = projectAuthCommandResult(result);
-
-  if (result.success) {
-    revalidatePath("/", "layout");
-  }
 
   if (sideEffects?.telemetry) {
     trackAuthEvent(sideEffects.telemetry);

--- a/core/auth/auth-utils.ts
+++ b/core/auth/auth-utils.ts
@@ -1,11 +1,13 @@
 import { cache } from "react";
 
+import { redirect } from "next/navigation";
 import type { User } from "@supabase/supabase-js";
 
 import {
   createServerActionSupabaseClient,
   createServerComponentSupabaseClient,
 } from "@core/supabase/factory";
+import { isMissingAuthSessionError } from "@core/supabase/auth-guards";
 import { handleServerError } from "@core/utils/error-handler.server";
 
 type AuthLookupContext = "server_action" | "server_component";
@@ -17,6 +19,8 @@ export type CurrentAppUser = {
   email?: string | null;
   name: string | null;
 };
+
+const LOGIN_PATH = "/login";
 
 async function getCurrentUserWithClient(createClient: CreateUserClient) {
   const supabase = await createClient();
@@ -49,7 +53,19 @@ function throwMissingAuthenticatedUser(context: AuthLookupContext): never {
   throw error;
 }
 
+function isUnauthenticatedLookupResult(result: UserLookupResult): boolean {
+  if (!result.user && !result.authError) {
+    return true;
+  }
+
+  return !result.user && isMissingAuthSessionError(result.authError);
+}
+
 function resolveRequiredUser(result: UserLookupResult, context: AuthLookupContext): User {
+  if (context === "server_component" && isUnauthenticatedLookupResult(result)) {
+    redirect(LOGIN_PATH);
+  }
+
   if (result.authError) {
     logAuthLookupError(context, result.authError);
     throw new Error("Failed to resolve authenticated user from Supabase Auth.");
@@ -72,12 +88,18 @@ async function getCurrentUserLookup(context: AuthLookupContext): Promise<UserLoo
 }
 
 async function getOptionalCurrentUser(context: AuthLookupContext): Promise<User | null> {
-  const { user, authError } = await getCurrentUserLookup(context);
-  if (authError) {
-    logAuthLookupError(context, authError);
+  const result = await getCurrentUserLookup(context);
+
+  if (isUnauthenticatedLookupResult(result)) {
     return null;
   }
-  return user;
+
+  if (result.authError) {
+    logAuthLookupError(context, result.authError);
+    return null;
+  }
+
+  return result.user;
 }
 
 async function requireCurrentUser(context: AuthLookupContext): Promise<User> {

--- a/core/supabase/auth-guards.ts
+++ b/core/supabase/auth-guards.ts
@@ -1,4 +1,4 @@
-import { AuthError, isAuthApiError } from "@supabase/supabase-js";
+import { AuthError, isAuthApiError, isAuthSessionMissingError } from "@supabase/supabase-js";
 
 /**
  * AuthErrorのmessageプロパティを安全に取得
@@ -25,6 +25,21 @@ export function hasAuthErrorCode(error: unknown, code: string): boolean {
   if (isAuthApiError(error)) {
     return error.code === code;
   }
+  return false;
+}
+
+/**
+ * セッション欠如を表す認証エラーかどうかを判定する
+ */
+export function isMissingAuthSessionError(error: unknown): boolean {
+  if (hasAuthErrorCode(error, "session_missing")) {
+    return true;
+  }
+
+  if (isAuthSessionMissingError(error)) {
+    return true;
+  }
+
   return false;
 }
 

--- a/tests/unit/actions/logout-action.test.ts
+++ b/tests/unit/actions/logout-action.test.ts
@@ -1,0 +1,51 @@
+import { jest } from "@jest/globals";
+
+const mockLogoutActionImpl = jest.fn();
+const mockTrackAuthEvent = jest.fn();
+const mockEnsureFeaturesRegistered = jest.fn();
+const mockProjectAuthCommandResult = jest.fn();
+const mockRevalidatePath = jest.fn();
+
+jest.mock("next/cache", () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+jest.mock("@features/auth/server", () => ({
+  logoutAction: (...args: unknown[]) => mockLogoutActionImpl(...args),
+}));
+
+jest.mock("@/app/_init/feature-registrations", () => ({
+  ensureFeaturesRegistered: () => mockEnsureFeaturesRegistered(),
+}));
+
+jest.mock("@/app/(auth)/_actions/_shared/auth-telemetry", () => ({
+  trackAuthEvent: (...args: unknown[]) => mockTrackAuthEvent(...args),
+}));
+
+jest.mock("@/app/(auth)/_actions/_shared/result-projection", () => ({
+  projectAuthCommandResult: (...args: unknown[]) => mockProjectAuthCommandResult(...args),
+}));
+
+describe("app/(auth)/_actions/logout-action", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("成功時も revalidatePath を呼ばず redirectUrl を返す", async () => {
+    const result = { success: true, meta: {} };
+    const actionResult = { success: true, redirectUrl: "/login" };
+    const sideEffects = { telemetry: { name: "logout", userId: "user_1" } };
+
+    mockLogoutActionImpl.mockResolvedValue(result);
+    mockProjectAuthCommandResult.mockReturnValue({ actionResult, sideEffects });
+
+    const { logoutAction } = await import("@/app/(auth)/_actions/logout-action");
+
+    await expect(logoutAction()).resolves.toEqual(actionResult);
+    expect(mockEnsureFeaturesRegistered).toHaveBeenCalledTimes(1);
+    expect(mockLogoutActionImpl).toHaveBeenCalledTimes(1);
+    expect(mockProjectAuthCommandResult).toHaveBeenCalledWith(result);
+    expect(mockTrackAuthEvent).toHaveBeenCalledWith(sideEffects.telemetry);
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/core/auth/auth-utils.test.ts
+++ b/tests/unit/core/auth/auth-utils.test.ts
@@ -3,6 +3,9 @@ import { jest } from "@jest/globals";
 const mockCreateServerActionSupabaseClient = jest.fn();
 const mockCreateServerComponentSupabaseClient = jest.fn();
 const mockHandleServerError = jest.fn();
+const mockRedirect = jest.fn((path: string) => {
+  throw new Error(`NEXT_REDIRECT:${path}`);
+});
 
 jest.mock("@core/supabase/factory", () => ({
   createServerActionSupabaseClient: mockCreateServerActionSupabaseClient,
@@ -11,6 +14,10 @@ jest.mock("@core/supabase/factory", () => ({
 
 jest.mock("@core/utils/error-handler.server", () => ({
   handleServerError: mockHandleServerError,
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: mockRedirect,
 }));
 
 type AuthUtilsModule = typeof import("@core/auth/auth-utils");
@@ -129,6 +136,33 @@ describe("core/auth/auth-utils", () => {
     );
   });
 
+  it("セッション欠如時は requireCurrentUserForServerComponent が /login に redirect する", async () => {
+    const { client } = createLookupClient({
+      authError: new Error("Auth session missing!"),
+      user: null,
+    });
+    mockCreateServerComponentSupabaseClient.mockResolvedValue(client);
+
+    const { requireCurrentUserForServerComponent } = await loadAuthUtils();
+
+    await expect(requireCurrentUserForServerComponent()).rejects.toThrow("NEXT_REDIRECT:/login");
+    expect(mockRedirect).toHaveBeenCalledWith("/login");
+    expect(mockHandleServerError).not.toHaveBeenCalled();
+  });
+
+  it("未認証時は requireCurrentAppUserForServerComponent が /login に redirect する", async () => {
+    const { client } = createLookupClient({
+      user: null,
+    });
+    mockCreateServerComponentSupabaseClient.mockResolvedValue(client);
+
+    const { requireCurrentAppUserForServerComponent } = await loadAuthUtils();
+
+    await expect(requireCurrentAppUserForServerComponent()).rejects.toThrow("NEXT_REDIRECT:/login");
+    expect(mockRedirect).toHaveBeenCalledWith("/login");
+    expect(mockHandleServerError).not.toHaveBeenCalled();
+  });
+
   it("requireCurrentUserForServerComponent は server component の user を返す", async () => {
     const { client, spies } = createLookupClient();
     mockCreateServerComponentSupabaseClient.mockResolvedValue(client);
@@ -142,6 +176,19 @@ describe("core/auth/auth-utils", () => {
 
     expect(mockCreateServerComponentSupabaseClient).toHaveBeenCalledTimes(1);
     expect(spies.authGetUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("getOptionalCurrentUserForServerComponent はセッション欠如を null として扱う", async () => {
+    const { client } = createLookupClient({
+      authError: new Error("Auth session missing!"),
+      user: null,
+    });
+    mockCreateServerComponentSupabaseClient.mockResolvedValue(client);
+
+    const { getOptionalCurrentUserForServerComponent } = await loadAuthUtils();
+
+    await expect(getOptionalCurrentUserForServerComponent()).resolves.toBeNull();
+    expect(mockHandleServerError).not.toHaveBeenCalled();
   });
 
   it("requireCurrentAppUserForServerComponent は users.name のみを問い合わせる", async () => {


### PR DESCRIPTION
- logoutAction 成功時の revalidatePath 呼び出しを削除（redirectUrl ベースに統一）
- Supabase の session_missing を判定する isMissingAuthSessionError を追加
- server component の requireCurrentUser* で未認証時に /login へ redirect
- getOptionalCurrentUser* で session_missing を null 扱いに変更
- 関連ユニットテストを追加・更新
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rytkhs/event-pay/pull/332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
