### PR TITLE
fix: ReadonlyHeaders互換オブジェクトでgetClientIPが誤判定する問題を修正

### DIFF
--- a/core/utils/ip-detection.ts
+++ b/core/utils/ip-detection.ts
@@ -9,6 +9,12 @@ interface HeaderLike {
   get(name: string): string | null;
 }
 
+function hasGetMethod(value: unknown): value is HeaderLike {
+  return (
+    typeof value === "object" && value !== null && "get" in value && typeof value.get === "function"
+  );
+}
+
 /**
  * IPアドレス検証用の正規表現
  */
@@ -68,8 +74,25 @@ function normalizeCandidateIP(raw: string | null): string | null {
 export function getClientIP(request: NextRequest): string | null;
 export function getClientIP(headers: HeaderLike): string | null;
 export function getClientIP(requestOrHeaders: NextRequest | HeaderLike): string | null {
-  // NextRequestかHeaderLikeかを判定
-  const headers = "headers" in requestOrHeaders ? requestOrHeaders.headers : requestOrHeaders;
+  // Next.js の ReadonlyHeaders 実装は `.headers` プロパティを内部に持つため、
+  // `headers in value` のみで判定すると HeaderLike を誤って NextRequest 扱いしてしまう。
+  const headers = hasGetMethod(requestOrHeaders)
+    ? requestOrHeaders
+    : hasGetMethod(requestOrHeaders.headers)
+      ? requestOrHeaders.headers
+      : null;
+
+  if (!headers) {
+    if (process.env.NODE_ENV !== "test") {
+      logger.warn("Unable to resolve client IP because headers-like access is unavailable", {
+        category: "system",
+        action: "ip_detection_invalid_headers_shape",
+        actor_type: "system",
+        outcome: "failure",
+      });
+    }
+    return null;
+  }
 
   const rawIp = headers.get("cf-connecting-ip");
   const normalizedIP = normalizeCandidateIP(rawIp);

--- a/tests/unit/core/utils/ip-detection.test.ts
+++ b/tests/unit/core/utils/ip-detection.test.ts
@@ -42,4 +42,13 @@ describe("ip-detection", () => {
 
     expect(getClientIP(requestLike as Parameters<typeof getClientIP>[0])).toBe("198.51.100.44");
   });
+
+  test("Next.js ReadonlyHeaders 互換オブジェクトでも取得できる", () => {
+    const headers = createHeaderLike({ "cf-connecting-ip": "198.51.100.55" });
+    const nextReadonlyHeadersLike = Object.assign(headers, {
+      headers: { "cf-connecting-ip": "198.51.100.55" },
+    });
+
+    expect(getClientIPFromHeaders(nextReadonlyHeadersLike)).toBe("198.51.100.55");
+  });
 });


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rytkhs/event-pay/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
