### PR TITLE
refactor(participants): 参加者一覧の表示モードをデバイス別に最適化し、ハイドレーションの不整合を修正

### DIFF
--- a/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantsTableV2.tsx
+++ b/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantsTableV2.tsx
@@ -66,8 +66,33 @@ type BulkUpdateCashStatusAction = (
   input: BulkUpdateCashStatusInput
 ) => Promise<ActionResult<BulkUpdateResult>>;
 
+const MOBILE_BREAKPOINT = 768;
+const VIEW_MODE_STORAGE_KEYS = {
+  mobile: "event-participants-view-mode-mobile",
+  desktop: "event-participants-view-mode-desktop",
+} as const;
+
 function isViewMode(value: string): value is "table" | "cards" {
   return value === "table" || value === "cards";
+}
+
+function getDeviceType(width: number): keyof typeof VIEW_MODE_STORAGE_KEYS {
+  return width < MOBILE_BREAKPOINT ? "mobile" : "desktop";
+}
+
+function getDefaultViewMode(deviceType: keyof typeof VIEW_MODE_STORAGE_KEYS): "table" | "cards" {
+  return deviceType === "mobile" ? "cards" : "table";
+}
+
+function getInitialViewMode(): "table" | "cards" {
+  const deviceType = getDeviceType(window.innerWidth);
+  const saved = window.localStorage.getItem(VIEW_MODE_STORAGE_KEYS[deviceType]);
+
+  if (saved && isViewMode(saved)) {
+    return saved;
+  }
+
+  return getDefaultViewMode(deviceType);
 }
 
 function compareString(a: string, b: string, order: ParticipantSortOrder): number {
@@ -157,23 +182,15 @@ export function ParticipantsTableV2({
   const isFreeEvent = eventFee === 0;
   const router = useRouter();
 
-  const [viewMode, setViewMode] = useState<"table" | "cards">("table");
+  const [viewMode, setViewMode] = useState<"table" | "cards" | null>(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isBulkUpdating, setIsBulkUpdating] = useState(false);
   const [selectedPaymentIds, setSelectedPaymentIds] = useState<string[]>([]);
 
-  // localStorage によるビュー永続化 + モバイル時は強制cards
+  // 端末別に初回デフォルトを決めつつ、保存済みの選択を復元する
   useEffect(() => {
-    const saved = localStorage.getItem("event-participants-view-mode") as "table" | "cards" | null;
-    const check = () => {
-      const mobile = window.innerWidth < 768;
-      if (mobile) setViewMode("cards");
-      else if (saved) setViewMode(saved);
-    };
-    check();
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
+    setViewMode(getInitialViewMode());
   }, []);
 
   // 選択モードがOFFになったら選択状態をクリア
@@ -188,7 +205,8 @@ export function ParticipantsTableV2({
     setIsTransitioning(true);
     setTimeout(() => {
       setViewMode(newMode);
-      localStorage.setItem("event-participants-view-mode", newMode);
+      const deviceType = getDeviceType(window.innerWidth);
+      localStorage.setItem(VIEW_MODE_STORAGE_KEYS[deviceType], newMode);
       setTimeout(() => setIsTransitioning(false), 200);
     }, 100);
   };
@@ -560,60 +578,68 @@ export function ParticipantsTableV2({
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg font-semibold">参加者一覧 ({totalCount}件)</CardTitle>
-          <ToggleGroup
-            type="single"
-            value={viewMode}
-            onValueChange={(v) => {
-              if (isViewMode(v)) {
-                handleViewModeChange(v);
-              }
-            }}
-            className="border rounded-md"
-            aria-label="表示形式を選択"
-          >
-            <ToggleGroupItem value="table" aria-label="テーブル表示">
-              <TableIcon className="h-4 w-4" />
-            </ToggleGroupItem>
-            <ToggleGroupItem value="cards" aria-label="カード表示">
-              <LayoutGridIcon className="h-4 w-4" />
-            </ToggleGroupItem>
-          </ToggleGroup>
+          {viewMode ? (
+            <ToggleGroup
+              type="single"
+              value={viewMode}
+              onValueChange={(v) => {
+                if (isViewMode(v)) {
+                  handleViewModeChange(v);
+                }
+              }}
+              className="border rounded-md"
+              aria-label="表示形式を選択"
+            >
+              <ToggleGroupItem value="table" aria-label="テーブル表示">
+                <TableIcon className="h-4 w-4" />
+              </ToggleGroupItem>
+              <ToggleGroupItem value="cards" aria-label="カード表示">
+                <LayoutGridIcon className="h-4 w-4" />
+              </ToggleGroupItem>
+            </ToggleGroup>
+          ) : (
+            <div className="h-9 w-20 rounded-md border bg-muted/20" aria-hidden="true" />
+          )}
         </div>
       </CardHeader>
       <CardContent className="px-3">
-        <div
-          className={`transition-opacity duration-200 ${isTransitioning ? "opacity-50" : "opacity-100"}`}
-        >
-          {viewMode === "table" ? (
-            <DataTable
-              columns={columns}
-              data={paginatedParticipants}
-              pageIndex={page - 1}
-              pageSize={limit}
-              pageCount={totalPages}
-              sorting={sorting}
-              onSortingChange={handleSortingChange}
-              getRowClassName={getRowClassName}
-            />
-          ) : (
-            <CardsView
-              participants={paginatedParticipants}
-              eventFee={eventFee}
-              isUpdating={isUpdating}
-              onReceive={handleReceive}
-              onCancel={handleCancel}
-              bulkSelection={
-                !isFreeEvent && isSelectionMode
-                  ? {
-                      selectedPaymentIds: validSelectedPaymentIds,
-                      onSelect: handleSelectPayment,
-                      isDisabled: isBulkUpdating || isUpdating,
-                    }
-                  : undefined
-              }
-            />
-          )}
-        </div>
+        {viewMode ? (
+          <div
+            className={`transition-opacity duration-200 ${isTransitioning ? "opacity-50" : "opacity-100"}`}
+          >
+            {viewMode === "table" ? (
+              <DataTable
+                columns={columns}
+                data={paginatedParticipants}
+                pageIndex={page - 1}
+                pageSize={limit}
+                pageCount={totalPages}
+                sorting={sorting}
+                onSortingChange={handleSortingChange}
+                getRowClassName={getRowClassName}
+              />
+            ) : (
+              <CardsView
+                participants={paginatedParticipants}
+                eventFee={eventFee}
+                isUpdating={isUpdating}
+                onReceive={handleReceive}
+                onCancel={handleCancel}
+                bulkSelection={
+                  !isFreeEvent && isSelectionMode
+                    ? {
+                        selectedPaymentIds: validSelectedPaymentIds,
+                        onSelect: handleSelectPayment,
+                        isDisabled: isBulkUpdating || isUpdating,
+                      }
+                    : undefined
+                }
+              />
+            )}
+          </div>
+        ) : (
+          <div className="h-40 rounded-md border bg-muted/10" aria-hidden="true" />
+        )}
 
         {(totalPages > 1 || totalCount > 150) && (
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 px-4 py-3 sm:px-6 border-t">

--- a/tests/unit/participants/participants-table-v2.test.tsx
+++ b/tests/unit/participants/participants-table-v2.test.tsx
@@ -53,6 +53,14 @@ Object.defineProperty(window, "localStorage", {
   value: mockLocalStorage,
 });
 
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
 // ResizeObserver をモック
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
@@ -137,6 +145,7 @@ describe("ParticipantsTableV2", () => {
   };
 
   beforeEach(() => {
+    setViewportWidth(1280);
     mockLocalStorage.getItem.mockReturnValue(null);
     jest.clearAllMocks();
     mockRefresh.mockClear();
@@ -326,8 +335,59 @@ describe("ParticipantsTableV2", () => {
   });
 
   describe("ビュー切替", () => {
+    it("desktop 初回表示はテーブルビューになる", async () => {
+      setViewportWidth(1280);
+
+      render(<ParticipantsTableV2 {...defaultProps} />);
+
+      await waitFor(() => {
+        const tableButton = screen.getByLabelText("テーブル表示");
+        expect(tableButton).toHaveAttribute("data-state", "on");
+      });
+    });
+
+    it("mobile 初回表示はカードビューになる", async () => {
+      setViewportWidth(375);
+
+      render(<ParticipantsTableV2 {...defaultProps} />);
+
+      await waitFor(() => {
+        const cardsButton = screen.getByLabelText("カード表示");
+        expect(cardsButton).toHaveAttribute("data-state", "on");
+      });
+    });
+
+    it("desktop 保存値があれば desktop で復元する", async () => {
+      setViewportWidth(1280);
+      mockLocalStorage.getItem.mockImplementation((key: string) =>
+        key === "event-participants-view-mode-desktop" ? "cards" : null
+      );
+
+      render(<ParticipantsTableV2 {...defaultProps} />);
+
+      await waitFor(() => {
+        const cardsButton = screen.getByLabelText("カード表示");
+        expect(cardsButton).toHaveAttribute("data-state", "on");
+      });
+    });
+
+    it("mobile では desktop 保存値を引き継がず mobile デフォルトを使う", async () => {
+      setViewportWidth(375);
+      mockLocalStorage.getItem.mockImplementation((key: string) =>
+        key === "event-participants-view-mode-desktop" ? "table" : null
+      );
+
+      render(<ParticipantsTableV2 {...defaultProps} />);
+
+      await waitFor(() => {
+        const cardsButton = screen.getByLabelText("カード表示");
+        expect(cardsButton).toHaveAttribute("data-state", "on");
+      });
+    });
+
     it("カードビューに切り替えられる", async () => {
       const user = userEvent.setup();
+      setViewportWidth(1280);
 
       render(<ParticipantsTableV2 {...defaultProps} />);
 
@@ -337,8 +397,25 @@ describe("ParticipantsTableV2", () => {
       // setTimeoutによる非同期処理を待つ
       await waitFor(() => {
         expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-          "event-participants-view-mode",
+          "event-participants-view-mode-desktop",
           "cards"
+        );
+      });
+    });
+
+    it("mobile でテーブルビューに切り替えると mobile 用キーに保存する", async () => {
+      const user = userEvent.setup();
+      setViewportWidth(375);
+
+      render(<ParticipantsTableV2 {...defaultProps} />);
+
+      const tableViewButton = await screen.findByLabelText("テーブル表示");
+      await user.click(tableViewButton);
+
+      await waitFor(() => {
+        expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+          "event-participants-view-mode-mobile",
+          "table"
         );
       });
     });


### PR DESCRIPTION
## 概要
参加者一覧の表示形式（テーブル/カード）の切り替えロジックをリファクタリングし、デバイスごとの最適なユーザー体験と、SSR環境での安定性を向上させました。

## 変更内容
- デバイス別の表示設定: localStorage のキーをモバイルとデスクトップで分離。PCでテーブル、スマホでカードといった、デバイスごとの好みを個別に保持できるようになりました。
- ハイドレーション・ミスマッチの解消: 初期表示時の viewMode を null に設定。クライアント側での判定が完了するまでスケルトン（プレースホルダー）を表示するようにし、サーバー・クライアント間の表示の食い違いやチラつきを防止しました。
- ロジックの抽出: デバイス判定や初期値取得のロジックを純粋関数へ抽出し、コンポーネントの見通しを改善しました。
テストの更新: 仕様変更に伴い、関連する単体テストを修正しました。

## 修正の理由
- UXの向上: 以前は全デバイス共通の設定だったため、PCの設定がスマホの表示に悪影響を与えることがありました。これを分離することで、各デバイスに最適な表示を維持できます。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rytkhs/event-pay/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
