### PR TITLE
feat: 主催者による代理出欠変更を追加・定員超過 bypass を廃止

### DIFF
--- a/app/(app)/events/[id]/components/EventManagementPage.tsx
+++ b/app/(app)/events/[id]/components/EventManagementPage.tsx
@@ -24,6 +24,7 @@ interface EventManagementPageProps {
   collectionSummary: CollectionProgressSummary | null;
   overviewStats: { attending_count: number; maybe_count: number } | null;
   participantsData: GetParticipantsResponse | null;
+  adminUpdateAttendanceStatusAction: ParticipantsTableV2Props["adminUpdateAttendanceStatusAction"];
   deleteMistakenAttendanceAction: ParticipantsTableV2Props["deleteMistakenAttendanceAction"];
   updateCashStatusAction: ParticipantsTableV2Props["updateCashStatusAction"];
   bulkUpdateCashStatusAction: ParticipantsTableV2Props["bulkUpdateCashStatusAction"];
@@ -36,6 +37,7 @@ export function EventManagementPage({
   collectionSummary,
   overviewStats,
   participantsData,
+  adminUpdateAttendanceStatusAction,
   deleteMistakenAttendanceAction,
   updateCashStatusAction,
   bulkUpdateCashStatusAction,
@@ -62,6 +64,7 @@ export function EventManagementPage({
               eventDetail={eventDetail}
               participantsData={participantsData}
               query={query}
+              adminUpdateAttendanceStatusAction={adminUpdateAttendanceStatusAction}
               deleteMistakenAttendanceAction={deleteMistakenAttendanceAction}
               updateCashStatusAction={updateCashStatusAction}
               bulkUpdateCashStatusAction={bulkUpdateCashStatusAction}

--- a/app/(app)/events/[id]/components/EventParticipantsTab.tsx
+++ b/app/(app)/events/[id]/components/EventParticipantsTab.tsx
@@ -27,6 +27,7 @@ interface EventParticipantsTabProps {
   eventDetail: Event;
   participantsData: GetParticipantsResponse | null;
   query: EventManagementQuery;
+  adminUpdateAttendanceStatusAction: ParticipantsTableV2Props["adminUpdateAttendanceStatusAction"];
   deleteMistakenAttendanceAction: ParticipantsTableV2Props["deleteMistakenAttendanceAction"];
   updateCashStatusAction: ParticipantsTableV2Props["updateCashStatusAction"];
   bulkUpdateCashStatusAction: ParticipantsTableV2Props["bulkUpdateCashStatusAction"];
@@ -37,6 +38,7 @@ export function EventParticipantsTab({
   eventDetail,
   participantsData,
   query,
+  adminUpdateAttendanceStatusAction,
   deleteMistakenAttendanceAction,
   updateCashStatusAction,
   bulkUpdateCashStatusAction,
@@ -132,9 +134,12 @@ export function EventParticipantsTab({
           <ParticipantsTableV2
             eventId={eventId}
             eventFee={eventDetail.fee}
+            eventStatus={eventDetail.status}
+            eventPaymentMethods={eventDetail.payment_methods}
             allParticipants={allParticipants}
             query={optimisticQuery}
             onParamsChange={handleFiltersUpdate}
+            adminUpdateAttendanceStatusAction={adminUpdateAttendanceStatusAction}
             deleteMistakenAttendanceAction={deleteMistakenAttendanceAction}
             updateCashStatusAction={updateCashStatusAction}
             bulkUpdateCashStatusAction={bulkUpdateCashStatusAction}

--- a/app/(app)/events/[id]/page.tsx
+++ b/app/(app)/events/[id]/page.tsx
@@ -22,6 +22,7 @@ import { getEventDetailAction, getEventParticipantsAction, getEventStatsAction }
 import { EventManagementPage } from "./components/EventManagementPage";
 import {
   bulkUpdateCashStatusAction,
+  adminUpdateAttendanceStatusAction,
   deleteMistakenAttendanceAction,
   updateCashStatusAction,
 } from "./participants/actions";
@@ -124,6 +125,7 @@ export default async function EventDetailPage(props: {
         collectionSummary={collectionSummary}
         overviewStats={stats}
         participantsData={participantsData}
+        adminUpdateAttendanceStatusAction={adminUpdateAttendanceStatusAction}
         deleteMistakenAttendanceAction={deleteMistakenAttendanceAction}
         updateCashStatusAction={updateCashStatusAction}
         bulkUpdateCashStatusAction={bulkUpdateCashStatusAction}

--- a/app/(app)/events/[id]/participants/actions.ts
+++ b/app/(app)/events/[id]/participants/actions.ts
@@ -2,6 +2,7 @@
 
 import {
   adminAddAttendanceAction as adminAddAttendanceActionImpl,
+  adminUpdateAttendanceStatusAction as adminUpdateAttendanceStatusActionImpl,
   deleteMistakenAttendanceAction as deleteMistakenAttendanceActionImpl,
   exportParticipantsCsvAction as exportParticipantsCsvActionImpl,
 } from "@features/events/server";
@@ -13,6 +14,7 @@ import {
 import { ensureFeaturesRegistered } from "@/app/_init/feature-registrations";
 
 type AdminAddAttendanceInput = Parameters<typeof adminAddAttendanceActionImpl>[0];
+type AdminUpdateAttendanceStatusInput = Parameters<typeof adminUpdateAttendanceStatusActionImpl>[0];
 type DeleteMistakenAttendanceInput = Parameters<typeof deleteMistakenAttendanceActionImpl>[0];
 type ExportParticipantsCsvParams = Parameters<typeof exportParticipantsCsvActionImpl>[0];
 type UpdateCashStatusInput = Parameters<typeof updateCashStatusActionImpl>[0];
@@ -21,6 +23,11 @@ type BulkUpdateCashStatusInput = Parameters<typeof bulkUpdateCashStatusActionImp
 export async function adminAddAttendanceAction(input: AdminAddAttendanceInput) {
   ensureFeaturesRegistered();
   return adminAddAttendanceActionImpl(input);
+}
+
+export async function adminUpdateAttendanceStatusAction(input: AdminUpdateAttendanceStatusInput) {
+  ensureFeaturesRegistered();
+  return adminUpdateAttendanceStatusActionImpl(input);
 }
 
 export async function exportParticipantsCsvAction(params: ExportParticipantsCsvParams) {

--- a/app/(app)/events/[id]/participants/components/ParticipantsActionBarV2.tsx
+++ b/app/(app)/events/[id]/participants/components/ParticipantsActionBarV2.tsx
@@ -65,10 +65,6 @@ export function ParticipantsActionBarV2({
   const [isAdding, setIsAdding] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [paymentMethod, setPaymentMethod] = useState<"cash">("cash");
-  const [confirmOverCapacity, setConfirmOverCapacity] = useState<null | {
-    capacity?: number | null;
-    current?: number;
-  }>(null);
 
   // インライン検索
   const [searchQuery, setSearchQuery] = useState(query.search);
@@ -97,13 +93,12 @@ export function ParticipantsActionBarV2({
 
   const handleOpenAdd = () => {
     setAddNickname("");
-    setConfirmOverCapacity(null);
     setAddError(null);
     setPaymentMethod("cash");
     setShowAddDialog(true);
   };
 
-  const handleSubmitAdd = async (forceBypass = false) => {
+  const handleSubmitAdd = async () => {
     if (isAdding) return;
     if (!addNickname || addNickname.trim().length === 0) {
       setAddError("ニックネームを入力してください");
@@ -123,7 +118,6 @@ export function ParticipantsActionBarV2({
         eventId,
         nickname: addNickname,
         status: "attending",
-        bypassCapacity: forceBypass,
         ...(isPayingEvent && { paymentMethod }),
       });
 
@@ -133,13 +127,6 @@ export function ParticipantsActionBarV2({
           description: result.error?.userMessage || "参加者の追加に失敗しました",
           variant: "destructive",
         });
-        return;
-      }
-
-      // confirmRequired の特殊ケース（成功として返される）
-      if ("confirmRequired" in result.data && result.data.confirmRequired) {
-        const payload = result.data;
-        setConfirmOverCapacity({ capacity: payload.capacity, current: payload.current });
         return;
       }
 
@@ -155,7 +142,6 @@ export function ParticipantsActionBarV2({
         description: successDescription,
       });
       setShowAddDialog(false);
-      setConfirmOverCapacity(null);
 
       window.location.reload();
     } catch (_error) {
@@ -452,7 +438,7 @@ export function ParticipantsActionBarV2({
               onChange={(e) => setAddNickname(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
-                  void handleSubmitAdd(false);
+                  void handleSubmitAdd();
                 }
               }}
               required
@@ -483,41 +469,15 @@ export function ParticipantsActionBarV2({
             )}
 
             {addError && <div className="text-sm text-red-600">{addError}</div>}
-            {confirmOverCapacity && (
-              <div className="text-sm text-orange-700 bg-orange-50 border border-orange-200 rounded p-2">
-                定員（{confirmOverCapacity.capacity ?? "-"}）を超過しています（現在{" "}
-                {confirmOverCapacity.current ?? "-"} 名）。本当に追加しますか？
-              </div>
-            )}
           </div>
           <DialogFooter>
-            {!confirmOverCapacity ? (
-              <Button
-                onClick={() => void handleSubmitAdd(false)}
-                disabled={isAdding || !addNickname || addNickname.trim().length === 0}
-                className="w-full sm:w-auto"
-              >
-                {isAdding ? "追加中..." : "追加"}
-              </Button>
-            ) : (
-              <div className="flex flex-col sm:flex-row gap-2 w-full">
-                <Button
-                  variant="outline"
-                  onClick={() => setConfirmOverCapacity(null)}
-                  disabled={isAdding}
-                  className="w-full sm:w-auto"
-                >
-                  戻る
-                </Button>
-                <Button
-                  onClick={() => void handleSubmitAdd(true)}
-                  disabled={isAdding}
-                  className="bg-red-600 hover:bg-red-700 w-full sm:w-auto"
-                >
-                  {isAdding ? "処理中..." : "定員超過で追加"}
-                </Button>
-              </div>
-            )}
+            <Button
+              onClick={() => void handleSubmitAdd()}
+              disabled={isAdding || !addNickname || addNickname.trim().length === 0}
+              className="w-full sm:w-auto"
+            >
+              {isAdding ? "追加中..." : "追加"}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/app/(app)/events/[id]/participants/components/participants-table-v2/CardsView.tsx
+++ b/app/(app)/events/[id]/participants/components/participants-table-v2/CardsView.tsx
@@ -33,6 +33,7 @@ export interface CardsViewProps {
   onReceive: (paymentId: string) => void;
   onCancel: (paymentId: string) => void;
   onDeleteMistaken: (participant: ParticipantView) => void;
+  onUpdateAttendance: (participant: ParticipantView) => void;
   isSelectionMode?: boolean;
   bulkSelection?: BulkSelectionConfig;
 }
@@ -44,6 +45,7 @@ export function CardsView({
   onReceive,
   onCancel,
   onDeleteMistaken,
+  onUpdateAttendance,
   isSelectionMode: isSelectionModeProp = false,
   bulkSelection,
 }: CardsViewProps) {
@@ -153,9 +155,11 @@ export function CardsView({
                     participant={p}
                     canCancel={false}
                     canDeleteMistaken={actionState.canDeleteMistakenAttendance}
+                    canUpdateAttendance={actionState.canUpdateAttendanceStatus}
                     isUpdating={isUpdating}
                     onCancel={onCancel}
                     onDeleteMistaken={onDeleteMistaken}
+                    onUpdateAttendance={onUpdateAttendance}
                     triggerSize="sm"
                     triggerClassName="h-8 w-8 shrink-0 rounded-xl p-0 text-muted-foreground hover:bg-muted/60 transition-colors"
                     triggerAriaLabel={`${p.nickname}の操作メニューを開く`}
@@ -172,7 +176,7 @@ export function CardsView({
                 <div className="flex items-center justify-between gap-2 min-h-[2.25rem]">
                   {/* Status Badge */}
                   <div className="flex items-center gap-2">
-                    {p.status === "attending" && !isCanceledPayment ? (
+                    {p.payment_status && !isCanceledPayment ? (
                       <>
                         {getPaymentMethodIcon(p.payment_method) && (
                           <div className="flex items-center justify-center bg-muted/40 w-[1.375rem] h-[1.375rem] rounded-md shadow-[inset_0_1px_0_rgba(255,255,255,0.5)]">
@@ -213,9 +217,11 @@ export function CardsView({
                         participant={p}
                         canCancel={actionState.canCancelCashReceipt}
                         canDeleteMistaken={actionState.canDeleteMistakenAttendance}
+                        canUpdateAttendance={actionState.canUpdateAttendanceStatus}
                         isUpdating={isUpdating}
                         onCancel={onCancel}
                         onDeleteMistaken={onDeleteMistaken}
+                        onUpdateAttendance={onUpdateAttendance}
                         triggerSize="sm"
                         triggerClassName="h-8 w-8 p-0 rounded-xl text-muted-foreground hover:bg-muted/60 transition-colors"
                         contentClassName="rounded-xl shadow-xl border-border/60 min-w-[8rem] p-1.5"

--- a/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantActionMenu.tsx
+++ b/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantActionMenu.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 
-import { MoreVertical, RotateCcw, Trash2 } from "lucide-react";
+import { MoreVertical, RotateCcw, Trash2, UserCheck } from "lucide-react";
 
 import { hasPaymentId } from "@core/utils/payment-status-mapper";
 import type { ParticipantView } from "@core/validation/participant-management";
@@ -22,9 +22,11 @@ interface ParticipantActionMenuProps {
   participant: ParticipantView;
   canCancel: boolean;
   canDeleteMistaken: boolean;
+  canUpdateAttendance: boolean;
   isUpdating?: boolean;
   onCancel: (paymentId: string) => void;
   onDeleteMistaken: (participant: ParticipantView) => void;
+  onUpdateAttendance: (participant: ParticipantView) => void;
   triggerSize: ButtonSize;
   triggerClassName: string;
   contentClassName: string;
@@ -38,9 +40,11 @@ export function ParticipantActionMenu({
   participant,
   canCancel,
   canDeleteMistaken,
+  canUpdateAttendance,
   isUpdating,
   onCancel,
   onDeleteMistaken,
+  onUpdateAttendance,
   triggerSize,
   triggerClassName,
   contentClassName,
@@ -49,7 +53,7 @@ export function ParticipantActionMenu({
   itemIconClassName,
   triggerAriaLabel,
 }: ParticipantActionMenuProps) {
-  if (!canCancel && !canDeleteMistaken) {
+  if (!canCancel && !canDeleteMistaken && !canUpdateAttendance) {
     return null;
   }
 
@@ -68,6 +72,15 @@ export function ParticipantActionMenu({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className={contentClassName}>
         <DropdownMenuGroup>
+          {canUpdateAttendance && (
+            <DropdownMenuItem
+              onClick={() => onUpdateAttendance(participant)}
+              className={cancelItemClassName}
+            >
+              <UserCheck className={itemIconClassName} />
+              出欠を代理変更
+            </DropdownMenuItem>
+          )}
           {canCancel && (
             <DropdownMenuItem
               onClick={() => hasPaymentId(participant) && onCancel(participant.payment_id)}

--- a/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantsTableV2.tsx
+++ b/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantsTableV2.tsx
@@ -97,7 +97,6 @@ type AdminUpdateAttendanceStatusInput = {
   attendanceId: string;
   status: AttendanceStatus;
   paymentMethod?: PaymentMethod;
-  bypassCapacity?: boolean;
   acknowledgedFinalizedPayment?: boolean;
   acknowledgedPastEvent?: boolean;
   notes?: string;
@@ -263,10 +262,6 @@ export function ParticipantsTableV2({
     undefined
   );
   const [attendanceErrorMessage, setAttendanceErrorMessage] = useState<string | null>(null);
-  const [capacityConfirmation, setCapacityConfirmation] = useState<{
-    capacity?: number | null;
-    current?: number | null;
-  } | null>(null);
   const [requiresFinalizedPaymentConfirmation, setRequiresFinalizedPaymentConfirmation] =
     useState(false);
   const [requiresPastEventConfirmation, setRequiresPastEventConfirmation] = useState(false);
@@ -663,7 +658,6 @@ export function ParticipantsTableV2({
           : undefined
       );
       setAttendanceErrorMessage(null);
-      setCapacityConfirmation(null);
       setRequiresFinalizedPaymentConfirmation(false);
       setRequiresPastEventConfirmation(false);
     },
@@ -673,7 +667,6 @@ export function ParticipantsTableV2({
   const handleCloseAttendanceUpdate = useCallback(() => {
     setAttendanceTarget(null);
     setAttendanceErrorMessage(null);
-    setCapacityConfirmation(null);
     setRequiresFinalizedPaymentConfirmation(false);
     setRequiresPastEventConfirmation(false);
   }, []);
@@ -681,7 +674,6 @@ export function ParticipantsTableV2({
   const handleNextAttendanceStatusChange = useCallback(
     (value: AttendanceStatus) => {
       setNextAttendanceStatus(value);
-      setCapacityConfirmation(null);
       if (attendanceTarget && requiresPaymentMethodForAttendance(attendanceTarget, value)) {
         setAttendancePaymentMethod((current) => current ?? getDefaultPaymentMethod());
       } else {
@@ -770,7 +762,6 @@ export function ParticipantsTableV2({
         ...(requiresPaymentMethod && attendancePaymentMethod
           ? { paymentMethod: attendancePaymentMethod }
           : {}),
-        bypassCapacity: capacityConfirmation !== null,
         acknowledgedFinalizedPayment:
           isFinalizedPaymentStatus(attendanceTarget.payment_status) ||
           requiresFinalizedPaymentConfirmation,
@@ -784,14 +775,6 @@ export function ParticipantsTableV2({
 
       const responseData = result.data;
       if ("confirmRequired" in responseData && responseData.confirmRequired) {
-        if (responseData.reason === "capacity") {
-          setCapacityConfirmation({
-            capacity: responseData.capacity,
-            current: responseData.current,
-          });
-          return;
-        }
-
         if (responseData.reason === "finalized_payment") {
           setRequiresFinalizedPaymentConfirmation(true);
           return;
@@ -822,7 +805,6 @@ export function ParticipantsTableV2({
     applyLocalAttendanceStatus,
     attendancePaymentMethod,
     attendanceTarget,
-    capacityConfirmation,
     eventId,
     eventStatus,
     handleCloseAttendanceUpdate,
@@ -1123,16 +1105,6 @@ export function ParticipantsTableV2({
               </Alert>
             )}
 
-            {capacityConfirmation && (
-              <Alert>
-                <AlertTriangle className="h-4 w-4" />
-                <AlertDescription>
-                  定員（{capacityConfirmation.capacity ?? "-"}名）に達しています。現在の参加者は
-                  {capacityConfirmation.current ?? "-"}名です。定員を超えて参加にします。
-                </AlertDescription>
-              </Alert>
-            )}
-
             {attendanceErrorMessage && (
               <Alert variant="destructive">
                 <AlertDescription>{attendanceErrorMessage}</AlertDescription>
@@ -1153,7 +1125,7 @@ export function ParticipantsTableV2({
                 (attendanceChangeRequiresPaymentMethod && !attendancePaymentMethod)
               }
             >
-              {isUpdating ? "処理中..." : capacityConfirmation ? "定員超過で変更" : "変更する"}
+              {isUpdating ? "処理中..." : "変更する"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantsTableV2.tsx
+++ b/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantsTableV2.tsx
@@ -5,13 +5,18 @@ import React, { useCallback, useEffect, useMemo, useState, startTransition } fro
 import { useRouter } from "next/navigation";
 
 import { SortingState, Row } from "@tanstack/react-table";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { AlertTriangle, ChevronLeft, ChevronRight } from "lucide-react";
 
 import { useToast } from "@core/contexts/toast-context";
 import type { ActionResult } from "@core/errors/adapters/server-actions";
+import type { EventStatus, PaymentMethod } from "@core/types/statuses";
 import { conditionalSmartSort } from "@core/utils/participant-smart-sort";
 import { isPaymentUnpaid, toSimplePaymentStatus } from "@core/utils/payment-status-mapper";
-import type { ParticipantView } from "@core/validation/participant-management";
+import type {
+  AdminUpdateAttendanceConfirmation,
+  AdminUpdateAttendanceStatusResult,
+  ParticipantView,
+} from "@core/validation/participant-management";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -24,6 +29,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -84,6 +90,23 @@ type DeleteMistakenAttendanceAction = (
   input: DeleteMistakenAttendanceInput
 ) => Promise<ActionResult<{ attendanceId: string }>>;
 
+type AttendanceStatus = ParticipantView["status"];
+
+type AdminUpdateAttendanceStatusInput = {
+  eventId: string;
+  attendanceId: string;
+  status: AttendanceStatus;
+  paymentMethod?: PaymentMethod;
+  bypassCapacity?: boolean;
+  acknowledgedFinalizedPayment?: boolean;
+  acknowledgedPastEvent?: boolean;
+  notes?: string;
+};
+
+type AdminUpdateAttendanceStatusAction = (
+  input: AdminUpdateAttendanceStatusInput
+) => Promise<ActionResult<AdminUpdateAttendanceStatusResult | AdminUpdateAttendanceConfirmation>>;
+
 const MOBILE_BREAKPOINT = 768;
 const VIEW_MODE_STORAGE_KEYS = {
   mobile: "event-participants-view-mode-mobile",
@@ -134,6 +157,25 @@ function getStatusOrder(status: ParticipantView["status"]): number {
   }
 }
 
+function getAttendanceStatusLabel(status: AttendanceStatus): string {
+  switch (status) {
+    case "attending":
+      return "参加";
+    case "not_attending":
+      return "不参加";
+    case "maybe":
+      return "未定";
+  }
+}
+
+function isFinalizedPaymentStatus(status: ParticipantView["payment_status"]): boolean {
+  return status === "paid" || status === "received" || status === "waived" || status === "refunded";
+}
+
+function hasPreservedPayment(status: ParticipantView["payment_status"]): boolean {
+  return status === "paid" || status === "received" || status === "waived" || status === "refunded";
+}
+
 function toTimestamp(value: string): number {
   return new Date(value).getTime();
 }
@@ -176,9 +218,12 @@ function applyManualSort(
 export interface ParticipantsTableV2Props {
   eventId: string;
   eventFee: number;
+  eventStatus: EventStatus;
+  eventPaymentMethods: PaymentMethod[];
   allParticipants: ParticipantView[];
   query: EventManagementQuery;
   onParamsChange: (patch: EventManagementQueryPatch) => void;
+  adminUpdateAttendanceStatusAction: AdminUpdateAttendanceStatusAction;
   deleteMistakenAttendanceAction: DeleteMistakenAttendanceAction;
   updateCashStatusAction: UpdateCashStatusAction;
   bulkUpdateCashStatusAction: BulkUpdateCashStatusAction;
@@ -189,9 +234,12 @@ export interface ParticipantsTableV2Props {
 export function ParticipantsTableV2({
   eventId,
   eventFee,
+  eventStatus,
+  eventPaymentMethods,
   allParticipants,
   query,
   onParamsChange,
+  adminUpdateAttendanceStatusAction,
   deleteMistakenAttendanceAction,
   updateCashStatusAction,
   bulkUpdateCashStatusAction,
@@ -209,6 +257,19 @@ export function ParticipantsTableV2({
   const [selectedPaymentIds, setSelectedPaymentIds] = useState<string[]>([]);
   const [deleteTarget, setDeleteTarget] = useState<ParticipantView | null>(null);
   const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null);
+  const [attendanceTarget, setAttendanceTarget] = useState<ParticipantView | null>(null);
+  const [nextAttendanceStatus, setNextAttendanceStatus] = useState<AttendanceStatus>("attending");
+  const [attendancePaymentMethod, setAttendancePaymentMethod] = useState<PaymentMethod | undefined>(
+    undefined
+  );
+  const [attendanceErrorMessage, setAttendanceErrorMessage] = useState<string | null>(null);
+  const [capacityConfirmation, setCapacityConfirmation] = useState<{
+    capacity?: number | null;
+    current?: number | null;
+  } | null>(null);
+  const [requiresFinalizedPaymentConfirmation, setRequiresFinalizedPaymentConfirmation] =
+    useState(false);
+  const [requiresPastEventConfirmation, setRequiresPastEventConfirmation] = useState(false);
 
   // 端末別に初回デフォルトを決めつつ、保存済みの選択を復元する
   useEffect(() => {
@@ -345,6 +406,12 @@ export function ParticipantsTableV2({
   // =======================================================
   // ハンドラー
   // =======================================================
+  const getDefaultPaymentMethod = useCallback((): PaymentMethod | undefined => {
+    if (eventPaymentMethods.includes("cash")) return "cash";
+    if (eventPaymentMethods.includes("stripe")) return "stripe";
+    return undefined;
+  }, [eventPaymentMethods]);
+
   const applyLocal = useCallback(
     (paymentId: string, nextStatus: "received" | "waived" | "pending") => {
       setLocalParticipants((prev) =>
@@ -572,6 +639,201 @@ export function ParticipantsTableV2({
     }
   }, [deleteMistakenAttendanceAction, deleteTarget, eventId, localParticipants, router, toast]);
 
+  const requiresPaymentMethodForAttendance = useCallback(
+    (participant: ParticipantView, nextStatus: AttendanceStatus) => {
+      return (
+        eventFee > 0 &&
+        nextStatus === "attending" &&
+        participant.status !== "attending" &&
+        !hasPreservedPayment(participant.payment_status)
+      );
+    },
+    [eventFee]
+  );
+
+  const handleOpenAttendanceUpdate = useCallback(
+    (participant: ParticipantView) => {
+      const defaultNextStatus: AttendanceStatus =
+        participant.status === "attending" ? "not_attending" : "attending";
+      setAttendanceTarget(participant);
+      setNextAttendanceStatus(defaultNextStatus);
+      setAttendancePaymentMethod(
+        requiresPaymentMethodForAttendance(participant, defaultNextStatus)
+          ? getDefaultPaymentMethod()
+          : undefined
+      );
+      setAttendanceErrorMessage(null);
+      setCapacityConfirmation(null);
+      setRequiresFinalizedPaymentConfirmation(false);
+      setRequiresPastEventConfirmation(false);
+    },
+    [getDefaultPaymentMethod, requiresPaymentMethodForAttendance]
+  );
+
+  const handleCloseAttendanceUpdate = useCallback(() => {
+    setAttendanceTarget(null);
+    setAttendanceErrorMessage(null);
+    setCapacityConfirmation(null);
+    setRequiresFinalizedPaymentConfirmation(false);
+    setRequiresPastEventConfirmation(false);
+  }, []);
+
+  const handleNextAttendanceStatusChange = useCallback(
+    (value: AttendanceStatus) => {
+      setNextAttendanceStatus(value);
+      setCapacityConfirmation(null);
+      if (attendanceTarget && requiresPaymentMethodForAttendance(attendanceTarget, value)) {
+        setAttendancePaymentMethod((current) => current ?? getDefaultPaymentMethod());
+      } else {
+        setAttendancePaymentMethod(undefined);
+      }
+    },
+    [attendanceTarget, getDefaultPaymentMethod, requiresPaymentMethodForAttendance]
+  );
+
+  const applyLocalAttendanceStatus = useCallback(
+    (result: AdminUpdateAttendanceStatusResult) => {
+      const now = new Date().toISOString();
+      setLocalParticipants((current) =>
+        current.map((participant) => {
+          if (participant.attendance_id !== result.attendanceId) return participant;
+
+          const next: ParticipantView = {
+            ...participant,
+            status: result.newStatus,
+            attendance_updated_at: now,
+          };
+
+          if (result.paymentEffect === "open_payment_canceled") {
+            return {
+              ...next,
+              payment_status:
+                participant.payment_status === "pending" || participant.payment_status === "failed"
+                  ? "canceled"
+                  : participant.payment_status,
+              payment_updated_at: now,
+            };
+          }
+
+          if (
+            result.paymentEffect === "payment_created" ||
+            result.paymentEffect === "open_payment_reused"
+          ) {
+            return {
+              ...next,
+              payment_id: result.paymentId ?? participant.payment_id,
+              payment_method: result.paymentMethod ?? participant.payment_method,
+              payment_status: result.paymentStatus ?? participant.payment_status,
+              amount: eventFee,
+              payment_updated_at: now,
+            };
+          }
+
+          return next;
+        })
+      );
+    },
+    [eventFee]
+  );
+
+  const handleConfirmAttendanceUpdate = useCallback(async () => {
+    if (!attendanceTarget) return;
+
+    if (eventStatus === "canceled") {
+      setAttendanceErrorMessage("中止済みイベントの出欠は変更できません。");
+      return;
+    }
+
+    if (attendanceTarget.status === nextAttendanceStatus) {
+      handleCloseAttendanceUpdate();
+      return;
+    }
+
+    const requiresPaymentMethod = requiresPaymentMethodForAttendance(
+      attendanceTarget,
+      nextAttendanceStatus
+    );
+
+    if (requiresPaymentMethod && !attendancePaymentMethod) {
+      setAttendanceErrorMessage("有料イベントで参加に変更するには、支払い方法を選択してください。");
+      return;
+    }
+
+    setAttendanceErrorMessage(null);
+    setIsUpdating(true);
+
+    try {
+      const result = await adminUpdateAttendanceStatusAction({
+        eventId,
+        attendanceId: attendanceTarget.attendance_id,
+        status: nextAttendanceStatus,
+        ...(requiresPaymentMethod && attendancePaymentMethod
+          ? { paymentMethod: attendancePaymentMethod }
+          : {}),
+        bypassCapacity: capacityConfirmation !== null,
+        acknowledgedFinalizedPayment:
+          isFinalizedPaymentStatus(attendanceTarget.payment_status) ||
+          requiresFinalizedPaymentConfirmation,
+        acknowledgedPastEvent: eventStatus === "past" || requiresPastEventConfirmation,
+        notes: "主催者による代理出欠変更",
+      });
+
+      if (!result.success) {
+        throw new Error(result.error?.userMessage || "出欠変更に失敗しました");
+      }
+
+      const responseData = result.data;
+      if ("confirmRequired" in responseData && responseData.confirmRequired) {
+        if (responseData.reason === "capacity") {
+          setCapacityConfirmation({
+            capacity: responseData.capacity,
+            current: responseData.current,
+          });
+          return;
+        }
+
+        if (responseData.reason === "finalized_payment") {
+          setRequiresFinalizedPaymentConfirmation(true);
+          return;
+        }
+
+        if (responseData.reason === "past_event") {
+          setRequiresPastEventConfirmation(true);
+          return;
+        }
+      }
+
+      const updateResult = responseData as AdminUpdateAttendanceStatusResult;
+      applyLocalAttendanceStatus(updateResult);
+      toast({
+        title: "出欠を更新しました",
+        description: `${attendanceTarget.nickname}を「${getAttendanceStatusLabel(updateResult.newStatus)}」に変更しました。`,
+      });
+      handleCloseAttendanceUpdate();
+      startTransition(() => router.refresh());
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "出欠変更に失敗しました";
+      setAttendanceErrorMessage(errorMessage);
+    } finally {
+      setIsUpdating(false);
+    }
+  }, [
+    adminUpdateAttendanceStatusAction,
+    applyLocalAttendanceStatus,
+    attendancePaymentMethod,
+    attendanceTarget,
+    capacityConfirmation,
+    eventId,
+    eventStatus,
+    handleCloseAttendanceUpdate,
+    nextAttendanceStatus,
+    requiresFinalizedPaymentConfirmation,
+    requiresPastEventConfirmation,
+    requiresPaymentMethodForAttendance,
+    router,
+    toast,
+  ]);
+
   // columns
   const columns = useMemo(
     () =>
@@ -581,6 +843,7 @@ export function ParticipantsTableV2({
           onReceive: handleReceive,
           onCancel: handleCancel,
           onDeleteMistaken: handleOpenDeleteMistaken,
+          onUpdateAttendance: handleOpenAttendanceUpdate,
           isUpdating,
         },
         isSelectionMode,
@@ -599,6 +862,7 @@ export function ParticipantsTableV2({
       handleReceive,
       handleCancel,
       handleOpenDeleteMistaken,
+      handleOpenAttendanceUpdate,
       isFreeEvent,
       validSelectedPaymentIds,
       handleSelectPayment,
@@ -646,6 +910,14 @@ export function ParticipantsTableV2({
     [isFreeEvent]
   );
 
+  const attendanceChangeRequiresPaymentMethod =
+    attendanceTarget !== null &&
+    requiresPaymentMethodForAttendance(attendanceTarget, nextAttendanceStatus);
+  const attendanceChangeHasFinalizedPayment =
+    attendanceTarget !== null && isFinalizedPaymentStatus(attendanceTarget.payment_status);
+  const canUseCashForAttendanceChange = eventPaymentMethods.includes("cash");
+  const canUseStripeForAttendanceChange = eventPaymentMethods.includes("stripe");
+
   return (
     <Card className="overflow-hidden bg-background/78 shadow-none border-0">
       <CardHeader className="border-b border-border/25 px-4 py-3">
@@ -686,6 +958,7 @@ export function ParticipantsTableV2({
                 onReceive={handleReceive}
                 onCancel={handleCancel}
                 onDeleteMistaken={handleOpenDeleteMistaken}
+                onUpdateAttendance={handleOpenAttendanceUpdate}
                 isSelectionMode={isSelectionMode}
                 bulkSelection={
                   !isFreeEvent && isSelectionMode
@@ -773,6 +1046,118 @@ export function ParticipantsTableV2({
           isProcessing={isBulkUpdating || isUpdating}
         />
       )}
+      <Dialog
+        open={!!attendanceTarget}
+        onOpenChange={(open) => !open && handleCloseAttendanceUpdate()}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>出欠を代理変更</DialogTitle>
+            <DialogDescription>
+              <span className="block text-foreground">
+                {attendanceTarget?.nickname}の出欠を主催者として変更します。
+              </span>
+              <span className="block mt-1">
+                支払い状態の変更や返金は、この操作では行われません。
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="attendance-status-select">変更後の出欠</Label>
+              <Select
+                value={nextAttendanceStatus}
+                onValueChange={(value) =>
+                  handleNextAttendanceStatusChange(value as AttendanceStatus)
+                }
+                disabled={isUpdating}
+              >
+                <SelectTrigger id="attendance-status-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="attending">参加</SelectItem>
+                  <SelectItem value="maybe">未定</SelectItem>
+                  <SelectItem value="not_attending">不参加</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {attendanceChangeRequiresPaymentMethod && (
+              <div className="space-y-2">
+                <Label htmlFor="attendance-payment-method-select">支払い方法</Label>
+                <Select
+                  value={attendancePaymentMethod}
+                  onValueChange={(value) => setAttendancePaymentMethod(value as PaymentMethod)}
+                  disabled={isUpdating}
+                >
+                  <SelectTrigger id="attendance-payment-method-select">
+                    <SelectValue placeholder="支払い方法を選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {canUseCashForAttendanceChange && <SelectItem value="cash">現金</SelectItem>}
+                    {canUseStripeForAttendanceChange && (
+                      <SelectItem value="stripe">オンライン</SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {(eventStatus === "past" || requiresPastEventConfirmation) && (
+              <Alert>
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>イベント後の台帳修正として記録されます。</AlertDescription>
+              </Alert>
+            )}
+
+            {(attendanceChangeHasFinalizedPayment || requiresFinalizedPaymentConfirmation) && (
+              <Alert>
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  この参加者は確定済みの支払いがあります。
+                  <br />
+                  出欠のみ変更され、支払い状態は維持されます。
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {capacityConfirmation && (
+              <Alert>
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  定員（{capacityConfirmation.capacity ?? "-"}名）に達しています。現在の参加者は
+                  {capacityConfirmation.current ?? "-"}名です。定員を超えて参加にします。
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {attendanceErrorMessage && (
+              <Alert variant="destructive">
+                <AlertDescription>{attendanceErrorMessage}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCloseAttendanceUpdate} disabled={isUpdating}>
+              戻る
+            </Button>
+            <Button
+              onClick={() => void handleConfirmAttendanceUpdate()}
+              disabled={
+                isUpdating ||
+                !attendanceTarget ||
+                attendanceTarget.status === nextAttendanceStatus ||
+                (attendanceChangeRequiresPaymentMethod && !attendancePaymentMethod)
+              }
+            >
+              {isUpdating ? "処理中..." : capacityConfirmation ? "定員超過で変更" : "変更する"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <Dialog open={!!deleteTarget} onOpenChange={(open) => !open && handleCloseDeleteMistaken()}>
         <DialogContent>
           <DialogHeader>

--- a/app/(app)/events/[id]/participants/components/participants-table-v2/participant-action-visibility.ts
+++ b/app/(app)/events/[id]/participants/components/participants-table-v2/participant-action-visibility.ts
@@ -25,12 +25,15 @@ export function getParticipantActionState(
     isCashPayment &&
     (simplePaymentStatus === "paid" || simplePaymentStatus === "waived");
   const canDeleteMistakenAttendance = canShowDeleteMistakenAttendanceAction(participant);
+  const canUpdateAttendanceStatus = true;
 
   return {
     canReceiveCash,
     canCancelCashReceipt,
     canDeleteMistakenAttendance,
+    canUpdateAttendanceStatus,
     showSecondaryMenu:
-      !opts.isSelectionMode && (canCancelCashReceipt || canDeleteMistakenAttendance),
+      !opts.isSelectionMode &&
+      (canUpdateAttendanceStatus || canCancelCashReceipt || canDeleteMistakenAttendance),
   };
 }

--- a/app/(app)/events/[id]/participants/components/participants-table-v2/participants-columns.tsx
+++ b/app/(app)/events/[id]/participants/components/participants-table-v2/participants-columns.tsx
@@ -22,6 +22,7 @@ export interface ActionsCellHandlers {
   onReceive: (paymentId: string) => void;
   onCancel: (paymentId: string) => void;
   onDeleteMistaken: (participant: ParticipantView) => void;
+  onUpdateAttendance: (participant: ParticipantView) => void;
   isUpdating?: boolean;
 }
 
@@ -120,7 +121,7 @@ export function buildParticipantsColumns(opts: {
         header: "決済方法",
         cell: ({ row }) => {
           const p = row.original;
-          const showMethod = p.status === "attending" && p.payment_status !== "canceled";
+          const showMethod = p.payment_status !== "canceled";
           if (!showMethod)
             return <span className="text-muted-foreground/40 text-[13px] font-medium">-</span>;
 
@@ -154,8 +155,7 @@ export function buildParticipantsColumns(opts: {
           const p = row.original;
           const status = p.payment_status;
           const isCanceledPayment = status === "canceled";
-          const isNotAttending = p.status !== "attending";
-          if (isFreeEvent || !status || isCanceledPayment || isNotAttending)
+          if (isFreeEvent || !status || isCanceledPayment)
             return <span className="text-muted-foreground/40 text-[12px] font-medium">-</span>;
           const simple = toSimplePaymentStatus(status);
           const s = getSimplePaymentStatusStyle(simple);
@@ -178,7 +178,8 @@ export function buildParticipantsColumns(opts: {
         header: "アクション",
         cell: ({ row }) => {
           const p = row.original;
-          const { onReceive, onCancel, onDeleteMistaken, isUpdating } = opts.handlers;
+          const { onReceive, onCancel, onDeleteMistaken, onUpdateAttendance, isUpdating } =
+            opts.handlers;
           const actionState = getParticipantActionState(p, { isSelectionMode });
 
           return (
@@ -202,9 +203,11 @@ export function buildParticipantsColumns(opts: {
                   participant={p}
                   canCancel={actionState.canCancelCashReceipt}
                   canDeleteMistaken={actionState.canDeleteMistakenAttendance}
+                  canUpdateAttendance={actionState.canUpdateAttendanceStatus}
                   isUpdating={isUpdating}
                   onCancel={onCancel}
                   onDeleteMistaken={onDeleteMistaken}
+                  onUpdateAttendance={onUpdateAttendance}
                   triggerSize="icon"
                   triggerClassName="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-all duration-200"
                   triggerAriaLabel={`${p.nickname}の操作メニューを開く`}
@@ -228,7 +231,7 @@ export function buildParticipantsColumns(opts: {
       header: "アクション",
       cell: ({ row }) => {
         const p = row.original;
-        const { onCancel, onDeleteMistaken, isUpdating } = opts.handlers;
+        const { onCancel, onDeleteMistaken, onUpdateAttendance, isUpdating } = opts.handlers;
         const actionState = getParticipantActionState(p, { isSelectionMode });
         if (!actionState.showSecondaryMenu) {
           return <div className="h-8" />;
@@ -239,9 +242,11 @@ export function buildParticipantsColumns(opts: {
             participant={p}
             canCancel={false}
             canDeleteMistaken={actionState.canDeleteMistakenAttendance}
+            canUpdateAttendance={actionState.canUpdateAttendanceStatus}
             isUpdating={isUpdating}
             onCancel={onCancel}
             onDeleteMistaken={onDeleteMistaken}
+            onUpdateAttendance={onUpdateAttendance}
             triggerSize="icon"
             triggerClassName="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-all duration-200"
             triggerAriaLabel={`${p.nickname}の操作メニューを開く`}

--- a/core/validation/participant-management.ts
+++ b/core/validation/participant-management.ts
@@ -174,3 +174,67 @@ export type DeleteMistakenAttendanceInput = z.infer<typeof DeleteMistakenAttenda
 export interface DeleteMistakenAttendanceResult {
   attendanceId: string;
 }
+
+// ====================================================================
+// 主催者による代理出欠変更関連スキーマ
+// ====================================================================
+
+export const AttendanceStatusSchema = z.enum(["attending", "not_attending", "maybe"]);
+
+export const AdminUpdateAttendanceStatusInputSchema = z.object({
+  eventId: z.string().uuid(),
+  attendanceId: z.string().uuid(),
+  status: AttendanceStatusSchema,
+  paymentMethod: z.enum(["cash", "stripe"]).optional(),
+  bypassCapacity: z.boolean().optional().default(false),
+  acknowledgedFinalizedPayment: z.boolean().optional().default(false),
+  acknowledgedPastEvent: z.boolean().optional().default(false),
+  notes: z.string().max(1000).optional(),
+});
+
+export type AdminUpdateAttendanceStatusInput = z.infer<
+  typeof AdminUpdateAttendanceStatusInputSchema
+>;
+
+export type AdminUpdateAttendancePaymentEffect =
+  | "none"
+  | "open_payment_canceled"
+  | "open_payment_reused"
+  | "payment_created"
+  | "finalized_payment_preserved";
+
+export type AdminUpdateAttendanceConfirmation =
+  | {
+      confirmRequired: true;
+      reason: "capacity";
+      capacity?: number | null;
+      current?: number | null;
+    }
+  | {
+      confirmRequired: true;
+      reason: "finalized_payment";
+    }
+  | {
+      confirmRequired: true;
+      reason: "past_event";
+    };
+
+export interface AdminUpdateAttendanceStatusResult {
+  updated: boolean;
+  attendanceId: string;
+  oldStatus: z.infer<typeof AttendanceStatusSchema>;
+  newStatus: z.infer<typeof AttendanceStatusSchema>;
+  paymentEffect: AdminUpdateAttendancePaymentEffect;
+  paymentId?: string | null;
+  paymentMethod?: "cash" | "stripe" | null;
+  paymentStatus?:
+    | "pending"
+    | "paid"
+    | "failed"
+    | "received"
+    | "refunded"
+    | "waived"
+    | "canceled"
+    | null;
+  guestUrl?: string;
+}

--- a/core/validation/participant-management.ts
+++ b/core/validation/participant-management.ts
@@ -132,7 +132,6 @@ export const AdminAddAttendanceInputSchema = z
     eventId: z.string().uuid(),
     nickname: z.string().min(1, "ニックネームは必須です").max(50),
     status: z.enum(["attending", "maybe", "not_attending"]).default("attending"),
-    bypassCapacity: z.boolean().optional().default(false),
     paymentMethod: z.enum(["cash"]).optional(),
   })
   .refine(
@@ -186,7 +185,6 @@ export const AdminUpdateAttendanceStatusInputSchema = z.object({
   attendanceId: z.string().uuid(),
   status: AttendanceStatusSchema,
   paymentMethod: z.enum(["cash", "stripe"]).optional(),
-  bypassCapacity: z.boolean().optional().default(false),
   acknowledgedFinalizedPayment: z.boolean().optional().default(false),
   acknowledgedPastEvent: z.boolean().optional().default(false),
   notes: z.string().max(1000).optional(),
@@ -204,12 +202,6 @@ export type AdminUpdateAttendancePaymentEffect =
   | "finalized_payment_preserved";
 
 export type AdminUpdateAttendanceConfirmation =
-  | {
-      confirmRequired: true;
-      reason: "capacity";
-      capacity?: number | null;
-      current?: number | null;
-    }
   | {
       confirmRequired: true;
       reason: "finalized_payment";

--- a/features/events/actions/admin-add-attendance.ts
+++ b/features/events/actions/admin-add-attendance.ts
@@ -27,23 +27,17 @@ import {
 import { getOwnedEventActionContextForServerAction } from "../services/get-owned-event-context-for-community";
 
 /**
- * 主催者が手動で参加者を追加する（締切制約なし、定員は上書き可能）
+ * 主催者が手動で参加者を追加する（締切制約なし、定員制約はDBで厳格に適用）
  * - RLSポリシーベースのセキュリティアクセス制御
  * - 専用RPC関数による排他ロック付き定員チェック
  * - レースコンディション対策済み
- * - 定員超過時、bypassCapacity=false なら確認要求エラーを返す
  * - 追加完了後、ゲストURLとオンライン決済可否を返す
  */
 export async function adminAddAttendanceAction(
   input: unknown
-): Promise<
-  ActionResult<
-    AdminAddAttendanceResult | { confirmRequired: true; capacity?: number | null; current?: number }
-  >
-> {
+): Promise<ActionResult<AdminAddAttendanceResult>> {
   try {
-    const { eventId, nickname, status, bypassCapacity, paymentMethod } =
-      AdminAddAttendanceInputSchema.parse(input);
+    const { eventId, nickname, status, paymentMethod } = AdminAddAttendanceInputSchema.parse(input);
 
     // 認証済みクライアント（RLSポリシーベースのアクセス制御）
     const authenticatedClient = await createServerActionSupabaseClient();
@@ -78,30 +72,20 @@ export async function adminAddAttendanceAction(
           p_email: placeholderEmail,
           p_status: status,
           p_guest_token: guestToken,
-          p_bypass_capacity: bypassCapacity,
         })
         .returns<string>()
         .single();
 
       if (rpcError || !rpcResult) {
-        // 定員超過の場合の特別処理
         if (
-          rpcError?.message?.includes("Event capacity") &&
-          rpcError.message.includes("has been reached")
+          rpcError?.code === "P0004" ||
+          rpcError?.message?.includes("Event capacity") ||
+          rpcError?.message?.includes("このイベントは定員")
         ) {
-          // エラーメッセージから現在の参加者数と定員を抽出
-          const capacityMatch = rpcError.message.match(
-            /Event capacity \((\d+)\) has been reached\. Current attendees: (\d+)/
-          );
-          if (capacityMatch) {
-            const capacity = parseInt(capacityMatch[1], 10);
-            const current = parseInt(capacityMatch[2], 10);
-            return ok({
-              confirmRequired: true,
-              capacity,
-              current,
-            });
-          }
+          return fail("RESOURCE_CONFLICT", {
+            userMessage:
+              "定員に達しています。追加する場合は、先にイベントの定員を変更してください。",
+          });
         }
 
         return fail("DATABASE_ERROR", {
@@ -191,7 +175,6 @@ export async function adminAddAttendanceAction(
       event_id: validatedEventId,
       attendance_id: attendanceId,
       actor_id: user.id,
-      bypass_capacity: bypassCapacity,
       nickname,
       email: placeholderEmail.toLowerCase(),
       can_online_pay: eligibility.isEligible,
@@ -213,7 +196,6 @@ export async function adminAddAttendanceAction(
         nickname,
         email: placeholderEmail.toLowerCase(),
         status,
-        bypass_capacity: bypassCapacity,
         payment_id: paymentId,
       },
     });

--- a/features/events/actions/admin-update-attendance-status.ts
+++ b/features/events/actions/admin-update-attendance-status.ts
@@ -30,17 +30,6 @@ type RpcAdminUpdateAttendanceStatusResult = {
   guest_token?: string | null;
 };
 
-function parseCapacityConflict(error: { message?: string; details?: string | null }) {
-  const target = `${error.message ?? ""} ${error.details ?? ""}`;
-  const currentMatch = target.match(/Current(?: attendees)?:\s*(\d+)/i);
-  const capacityMatch = target.match(/Capacity:\s*(\d+)/i) ?? target.match(/capacity \((\d+)\)/i);
-
-  return {
-    current: currentMatch ? Number.parseInt(currentMatch[1], 10) : null,
-    capacity: capacityMatch ? Number.parseInt(capacityMatch[1], 10) : null,
-  };
-}
-
 function mapRpcResult(
   data: RpcAdminUpdateAttendanceStatusResult
 ): AdminUpdateAttendanceStatusResult {
@@ -72,7 +61,6 @@ export async function adminUpdateAttendanceStatusAction(
       attendanceId,
       status,
       paymentMethod,
-      bypassCapacity,
       acknowledgedFinalizedPayment,
       acknowledgedPastEvent,
       notes,
@@ -95,7 +83,6 @@ export async function adminUpdateAttendanceStatusAction(
       p_new_status: status,
       p_user_id: accessContext.user.id,
       p_payment_method: paymentMethod ?? undefined,
-      p_bypass_capacity: bypassCapacity,
       p_acknowledged_finalized_payment: acknowledgedFinalizedPayment,
       p_acknowledged_past_event: acknowledgedPastEvent,
       p_notes: notes ?? undefined,
@@ -103,10 +90,9 @@ export async function adminUpdateAttendanceStatusAction(
 
     if (error) {
       if (hasPostgrestCode(error, "P0004")) {
-        return ok({
-          confirmRequired: true,
-          reason: "capacity",
-          ...parseCapacityConflict(error),
+        return fail("RESOURCE_CONFLICT", {
+          userMessage:
+            "定員に達しています。参加に変更する場合は、先にイベントの定員を変更してください。",
         });
       }
 

--- a/features/events/actions/admin-update-attendance-status.ts
+++ b/features/events/actions/admin-update-attendance-status.ts
@@ -1,0 +1,177 @@
+import { revalidatePath } from "next/cache";
+
+import {
+  type ActionResult,
+  fail,
+  ok,
+  toActionResultFromAppResult,
+  zodFail,
+} from "@core/errors/adapters/server-actions";
+import { createServerActionSupabaseClient } from "@core/supabase/factory";
+import { hasPostgrestCode } from "@core/supabase/postgrest-error-guards";
+import { buildGuestUrl } from "@core/utils/guest-token";
+import {
+  AdminUpdateAttendanceStatusInputSchema,
+  type AdminUpdateAttendanceConfirmation,
+  type AdminUpdateAttendanceStatusResult,
+} from "@core/validation/participant-management";
+
+import { getOwnedEventActionContextForServerAction } from "../services/get-owned-event-context-for-community";
+
+type RpcAdminUpdateAttendanceStatusResult = {
+  updated?: boolean;
+  attendance_id?: string;
+  old_status?: AdminUpdateAttendanceStatusResult["oldStatus"];
+  new_status?: AdminUpdateAttendanceStatusResult["newStatus"];
+  payment_effect?: AdminUpdateAttendanceStatusResult["paymentEffect"];
+  payment_id?: string | null;
+  payment_method?: AdminUpdateAttendanceStatusResult["paymentMethod"];
+  payment_status?: AdminUpdateAttendanceStatusResult["paymentStatus"];
+  guest_token?: string | null;
+};
+
+function parseCapacityConflict(error: { message?: string; details?: string | null }) {
+  const target = `${error.message ?? ""} ${error.details ?? ""}`;
+  const currentMatch = target.match(/Current(?: attendees)?:\s*(\d+)/i);
+  const capacityMatch = target.match(/Capacity:\s*(\d+)/i) ?? target.match(/capacity \((\d+)\)/i);
+
+  return {
+    current: currentMatch ? Number.parseInt(currentMatch[1], 10) : null,
+    capacity: capacityMatch ? Number.parseInt(capacityMatch[1], 10) : null,
+  };
+}
+
+function mapRpcResult(
+  data: RpcAdminUpdateAttendanceStatusResult
+): AdminUpdateAttendanceStatusResult {
+  const guestToken = data.guest_token ?? null;
+  return {
+    updated: data.updated ?? false,
+    attendanceId: data.attendance_id ?? "",
+    oldStatus: data.old_status ?? "maybe",
+    newStatus: data.new_status ?? "maybe",
+    paymentEffect: data.payment_effect ?? "none",
+    paymentId: data.payment_id ?? null,
+    paymentMethod: data.payment_method ?? null,
+    paymentStatus: data.payment_status ?? null,
+    guestUrl: guestToken ? buildGuestUrl(guestToken) : undefined,
+  };
+}
+
+export async function adminUpdateAttendanceStatusAction(
+  input: unknown
+): Promise<ActionResult<AdminUpdateAttendanceStatusResult | AdminUpdateAttendanceConfirmation>> {
+  const parsed = AdminUpdateAttendanceStatusInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return zodFail(parsed.error, { userMessage: "入力データが無効です。" });
+  }
+
+  try {
+    const {
+      eventId,
+      attendanceId,
+      status,
+      paymentMethod,
+      bypassCapacity,
+      acknowledgedFinalizedPayment,
+      acknowledgedPastEvent,
+      notes,
+    } = parsed.data;
+
+    const supabase = await createServerActionSupabaseClient();
+    const accessResult = await getOwnedEventActionContextForServerAction(supabase, eventId);
+    if (!accessResult.success) {
+      return toActionResultFromAppResult(accessResult);
+    }
+
+    const accessContext = accessResult.data;
+    if (!accessContext) {
+      return fail("INTERNAL_ERROR", { userMessage: "イベント情報の取得に失敗しました。" });
+    }
+
+    const { data, error } = await supabase.rpc("rpc_admin_update_attendance_status", {
+      p_event_id: accessContext.id,
+      p_attendance_id: attendanceId,
+      p_new_status: status,
+      p_user_id: accessContext.user.id,
+      p_payment_method: paymentMethod ?? undefined,
+      p_bypass_capacity: bypassCapacity,
+      p_acknowledged_finalized_payment: acknowledgedFinalizedPayment,
+      p_acknowledged_past_event: acknowledgedPastEvent,
+      p_notes: notes ?? undefined,
+    });
+
+    if (error) {
+      if (hasPostgrestCode(error, "P0004")) {
+        return ok({
+          confirmRequired: true,
+          reason: "capacity",
+          ...parseCapacityConflict(error),
+        });
+      }
+
+      if (hasPostgrestCode(error, "P0008")) {
+        return ok({ confirmRequired: true, reason: "past_event" });
+      }
+
+      if (hasPostgrestCode(error, "P0009")) {
+        return ok({ confirmRequired: true, reason: "finalized_payment" });
+      }
+
+      if (hasPostgrestCode(error, "P0002")) {
+        return fail("ATTENDANCE_NOT_FOUND", {
+          userMessage: "参加レコードが見つかりません。",
+        });
+      }
+
+      if (hasPostgrestCode(error, "P0013")) {
+        return fail("EVENT_CANCELED", {
+          userMessage: "中止済みイベントの出欠は変更できません。",
+        });
+      }
+
+      if (hasPostgrestCode(error, "P0010")) {
+        return fail("VALIDATION_ERROR", {
+          userMessage: "有料イベントで参加に変更するには、支払い方法を選択してください。",
+          fieldErrors: { paymentMethod: ["支払い方法を選択してください。"] },
+        });
+      }
+
+      if (hasPostgrestCode(error, "P0011")) {
+        return fail("VALIDATION_ERROR", {
+          userMessage: "このイベントでは選択された支払い方法を利用できません。",
+          fieldErrors: { paymentMethod: ["利用できない支払い方法です。"] },
+        });
+      }
+
+      if (hasPostgrestCode(error, "P0012")) {
+        return fail("RESOURCE_CONFLICT", {
+          userMessage: "オンライン決済を利用するには受取先プロファイルの設定完了が必要です。",
+        });
+      }
+
+      if (hasPostgrestCode(error, "P0001")) {
+        return fail("FORBIDDEN", {
+          userMessage: "この参加を変更する権限がありません。",
+        });
+      }
+
+      return fail("DATABASE_ERROR", {
+        userMessage: "参加状況の更新に失敗しました。",
+        retryable: true,
+      });
+    }
+
+    const result = mapRpcResult((data ?? {}) as RpcAdminUpdateAttendanceStatusResult);
+
+    revalidatePath(`/events/${accessContext.id}`);
+    revalidatePath("/dashboard");
+
+    return ok(result, { message: "出欠を更新しました。" });
+  } catch (_error) {
+    return fail("INTERNAL_ERROR", {
+      userMessage: "参加状況の更新中にエラーが発生しました。",
+      retryable: true,
+    });
+  }
+}

--- a/features/events/server.ts
+++ b/features/events/server.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 export { getOwnedEventContextForCurrentCommunity } from "@core/community/get-owned-event-context-for-current-community";
 export { adminAddAttendanceAction } from "./actions/admin-add-attendance";
+export { adminUpdateAttendanceStatusAction } from "./actions/admin-update-attendance-status";
 export { cancelEventAction } from "./actions/cancel-event";
 export { createEventAction } from "./actions/create-event";
 export { deleteEventAction } from "./actions/delete-event";

--- a/local_schema.sql
+++ b/local_schema.sql
@@ -207,7 +207,7 @@ $$;
 ALTER FUNCTION "private"."_get_guest_token_from_header"() OWNER TO "postgres";
 
 
-CREATE OR REPLACE FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying, "p_bypass_capacity" boolean DEFAULT false) RETURNS "uuid"
+CREATE OR REPLACE FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying) RETURNS "uuid"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO 'pg_catalog', 'public', 'pg_temp'
     AS $$
@@ -261,7 +261,7 @@ BEGIN
     RAISE EXCEPTION 'Guest token already exists: %', LEFT(p_guest_token, 8) || '...';
   END IF;
 
-  IF p_status = 'attending' AND v_capacity IS NOT NULL AND NOT p_bypass_capacity THEN
+  IF p_status = 'attending' AND v_capacity IS NOT NULL THEN
     SELECT COUNT(*)
       INTO v_current_count
       FROM public.attendances
@@ -270,9 +270,9 @@ BEGIN
 
     IF v_current_count >= v_capacity THEN
       RAISE EXCEPTION 'Event capacity (%) has been reached. Current attendees: %', v_capacity, v_current_count
-        USING ERRCODE = 'P0001',
-              DETAIL = format('Current: %s, Capacity: %s, Bypass: %s', v_current_count, v_capacity, p_bypass_capacity),
-              HINT = 'Set bypass_capacity=true to override capacity limit';
+        USING ERRCODE = 'P0004',
+              DETAIL = format('Current attendees: %s, Capacity: %s', v_current_count, v_capacity),
+              HINT = 'Increase the event capacity before adding another attending participant';
     END IF;
   END IF;
 
@@ -285,10 +285,10 @@ END;
 $$;
 
 
-ALTER FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying, "p_bypass_capacity" boolean) OWNER TO "app_definer";
+ALTER FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying) OWNER TO "app_definer";
 
 
-COMMENT ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying, "p_bypass_capacity" boolean) IS '主催者用参加者追加（排他ロック・定員チェック・レースコンディション対策）';
+COMMENT ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying) IS '主催者用参加者追加（排他ロック・定員チェック・レースコンディション対策）';
 
 
 
@@ -535,10 +535,6 @@ DECLARE
   event_capacity integer;
   current_attending_count integer;
 BEGIN
-  IF current_setting('app.internal_attendance_capacity_bypass_7f8d2c91', true) = 'true' THEN
-    RETURN NEW;
-  END IF;
-
   IF NEW.status = 'attending'
      AND (TG_OP = 'INSERT' OR OLD.status IS DISTINCT FROM 'attending') THEN
     SELECT capacity INTO event_capacity
@@ -1603,7 +1599,7 @@ $$;
 ALTER FUNCTION "public"."rpc_admin_delete_mistaken_attendance"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_user_id" "uuid") OWNER TO "app_definer";
 
 
-CREATE OR REPLACE FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum" DEFAULT NULL::"public"."payment_method_enum", "p_bypass_capacity" boolean DEFAULT false, "p_acknowledged_finalized_payment" boolean DEFAULT false, "p_acknowledged_past_event" boolean DEFAULT false, "p_notes" "text" DEFAULT NULL::"text") RETURNS "jsonb"
+CREATE OR REPLACE FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum" DEFAULT NULL::"public"."payment_method_enum", "p_acknowledged_finalized_payment" boolean DEFAULT false, "p_acknowledged_past_event" boolean DEFAULT false, "p_notes" "text" DEFAULT NULL::"text") RETURNS "jsonb"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO 'pg_catalog', 'public', 'pg_temp'
     AS $$
@@ -1711,11 +1707,11 @@ BEGIN
          AND status = 'attending'
          AND id <> p_attendance_id;
 
-      IF v_current_attendees >= v_capacity AND NOT p_bypass_capacity THEN
+      IF v_current_attendees >= v_capacity THEN
         RAISE EXCEPTION 'Event capacity (%) has been reached. Current attendees: %', v_capacity, v_current_attendees
           USING ERRCODE = 'P0004',
-                DETAIL = format('Current: %s, Capacity: %s, Bypass: %s', v_current_attendees, v_capacity, p_bypass_capacity),
-                HINT = 'Set bypass_capacity=true to override capacity limit';
+                DETAIL = format('Current attendees: %s, Capacity: %s', v_current_attendees, v_capacity),
+                HINT = 'Increase the event capacity before changing this attendance to attending';
       END IF;
     END IF;
   END IF;
@@ -1725,7 +1721,7 @@ BEGIN
       INTO v_preserved_payment
       FROM public.payments
      WHERE attendance_id = p_attendance_id
-       AND status IN ('paid', 'received', 'waived')
+       AND status IN ('paid', 'received', 'waived', 'refunded')
      ORDER BY paid_at DESC NULLS LAST, created_at DESC, updated_at DESC
      LIMIT 1
      FOR UPDATE;
@@ -1765,8 +1761,23 @@ BEGIN
         INTO v_open_payment
         FROM public.payments
        WHERE attendance_id = p_attendance_id
-         AND status IN ('pending', 'failed')
-       ORDER BY CASE WHEN status = 'pending' THEN 0 ELSE 1 END, created_at DESC, updated_at DESC
+         AND status = 'pending'
+         AND stripe_checkout_session_id IS NULL
+         AND stripe_payment_intent_id IS NULL
+         AND stripe_charge_id IS NULL
+         AND stripe_balance_transaction_id IS NULL
+         AND stripe_customer_id IS NULL
+         AND stripe_transfer_id IS NULL
+         AND application_fee_id IS NULL
+         AND application_fee_refund_id IS NULL
+         AND webhook_event_id IS NULL
+         AND webhook_processed_at IS NULL
+         AND checkout_idempotency_key IS NULL
+         AND checkout_key_revision = 0
+         AND paid_at IS NULL
+         AND COALESCE(refunded_amount, 0) = 0
+         AND COALESCE(application_fee_refunded_amount, 0) = 0
+       ORDER BY created_at DESC, updated_at DESC
        LIMIT 1
        FOR UPDATE;
 
@@ -1799,6 +1810,13 @@ BEGIN
         v_payment_status := 'pending';
         v_payment_effect := 'open_payment_reused';
       ELSE
+        UPDATE public.payments
+           SET status = 'canceled',
+               paid_at = NULL,
+               updated_at = now()
+         WHERE attendance_id = p_attendance_id
+           AND status = 'pending';
+
         INSERT INTO public.payments (
           attendance_id,
           amount,
@@ -1839,17 +1857,9 @@ BEGIN
     END IF;
   END IF;
 
-  IF p_bypass_capacity THEN
-    PERFORM set_config('app.internal_attendance_capacity_bypass_7f8d2c91', 'true', true);
-  END IF;
-
   UPDATE public.attendances
      SET status = p_new_status
    WHERE id = p_attendance_id;
-
-  IF p_bypass_capacity THEN
-    PERFORM set_config('app.internal_attendance_capacity_bypass_7f8d2c91', 'false', true);
-  END IF;
 
   INSERT INTO public.system_logs (
     log_category,
@@ -1880,7 +1890,6 @@ BEGIN
       'payment_id', v_payment_id,
       'payment_method', v_payment_method,
       'payment_status', v_payment_status,
-      'bypass_capacity', p_bypass_capacity,
       'acknowledged_finalized_payment', p_acknowledged_finalized_payment,
       'acknowledged_past_event', p_acknowledged_past_event,
       'notes', p_notes
@@ -1902,10 +1911,10 @@ END;
 $$;
 
 
-ALTER FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") OWNER TO "app_definer";
+ALTER FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") OWNER TO "app_definer";
 
 
-COMMENT ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") IS '主催者による代理出欠変更（権限確認・定員チェック・決済副作用・監査ログをDB内で実施）';
+COMMENT ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") IS '主催者による代理出欠変更（権限確認・定員チェック・決済副作用・監査ログをDB内で実施）';
 
 
 
@@ -4507,10 +4516,9 @@ GRANT ALL ON FUNCTION "private"."_get_guest_token_from_header"() TO "authenticat
 
 
 
-REVOKE ALL ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying, "p_bypass_capacity" boolean) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying, "p_bypass_capacity" boolean) TO "anon";
-GRANT ALL ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying, "p_bypass_capacity" boolean) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying, "p_bypass_capacity" boolean) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying) FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."admin_add_attendance_with_capacity_check"("p_event_id" "uuid", "p_nickname" character varying, "p_email" character varying, "p_status" "public"."attendance_status_enum", "p_guest_token" character varying) TO "service_role";
 
 
 
@@ -4694,9 +4702,9 @@ GRANT ALL ON FUNCTION "public"."rpc_admin_delete_mistaken_attendance"("p_event_i
 
 
 
-REVOKE ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") TO "authenticated";
-GRANT ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") TO "service_role";
+REVOKE ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") TO "service_role";
 
 
 

--- a/local_schema.sql
+++ b/local_schema.sql
@@ -532,33 +532,37 @@ CREATE OR REPLACE FUNCTION "public"."check_attendance_capacity_limit"() RETURNS 
     SET "search_path" TO 'pg_catalog', 'public', 'pg_temp'
     AS $$
 DECLARE
-  event_capacity INTEGER;
-  current_attending_count INTEGER;
+  event_capacity integer;
+  current_attending_count integer;
 BEGIN
-    -- 【レースコンディション対策強化】参加状況チェック
-    IF NEW.status = 'attending' THEN
-        -- 【重要】イベント情報を排他ロック付きで取得（レースコンディション対策）
-        SELECT capacity INTO event_capacity
-        FROM public.events
-        WHERE id = NEW.event_id FOR UPDATE;
-
-        IF event_capacity IS NOT NULL THEN
-            -- 【重要】イベントが既にロックされているため、安全に参加者数をカウント
-            -- この時点で同一イベントへの他の参加登録はブロックされる
-            SELECT COUNT(*) INTO current_attending_count
-            FROM public.attendances
-            WHERE event_id = NEW.event_id AND status = 'attending';
-
-            -- 定員超過チェック
-            IF current_attending_count >= event_capacity THEN
-                RAISE EXCEPTION 'このイベントは定員（%名）に達しています', event_capacity
-                  USING ERRCODE = 'P0001',
-                        DETAIL = format('Current attendees: %s, Capacity: %s', current_attending_count, event_capacity),
-                        HINT = 'Race condition prevented by exclusive lock in trigger';
-            END IF;
-        END IF;
-    END IF;
+  IF current_setting('app.internal_attendance_capacity_bypass_7f8d2c91', true) = 'true' THEN
     RETURN NEW;
+  END IF;
+
+  IF NEW.status = 'attending'
+     AND (TG_OP = 'INSERT' OR OLD.status IS DISTINCT FROM 'attending') THEN
+    SELECT capacity INTO event_capacity
+      FROM public.events
+     WHERE id = NEW.event_id
+     FOR UPDATE;
+
+    IF event_capacity IS NOT NULL THEN
+      SELECT COUNT(*) INTO current_attending_count
+        FROM public.attendances
+       WHERE event_id = NEW.event_id
+         AND status = 'attending'
+         AND id IS DISTINCT FROM NEW.id;
+
+      IF current_attending_count >= event_capacity THEN
+        RAISE EXCEPTION 'このイベントは定員（%名）に達しています', event_capacity
+          USING ERRCODE = 'P0004',
+                DETAIL = format('Current attendees: %s, Capacity: %s', current_attending_count, event_capacity),
+                HINT = 'Capacity check is enforced by attendance trigger';
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
 END;
 $$;
 
@@ -1597,6 +1601,312 @@ $$;
 
 
 ALTER FUNCTION "public"."rpc_admin_delete_mistaken_attendance"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_user_id" "uuid") OWNER TO "app_definer";
+
+
+CREATE OR REPLACE FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum" DEFAULT NULL::"public"."payment_method_enum", "p_bypass_capacity" boolean DEFAULT false, "p_acknowledged_finalized_payment" boolean DEFAULT false, "p_acknowledged_past_event" boolean DEFAULT false, "p_notes" "text" DEFAULT NULL::"text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'pg_catalog', 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_attendance public.attendances%ROWTYPE;
+  v_event public.events%ROWTYPE;
+  v_capacity integer;
+  v_current_attendees integer;
+  v_has_finalized_payment boolean := false;
+  v_preserved_payment public.payments%ROWTYPE;
+  v_open_payment public.payments%ROWTYPE;
+  v_payment_id uuid := NULL;
+  v_payment_status public.payment_status_enum := NULL;
+  v_payment_method public.payment_method_enum := NULL;
+  v_payment_effect text := 'none';
+  v_stripe_account_id character varying := NULL;
+  v_payout_status public.stripe_account_status_enum := NULL;
+  v_payouts_enabled boolean := false;
+  v_updated_open_count integer := 0;
+BEGIN
+  IF current_setting('request.jwt.claims', true) IS NULL THEN
+    RAISE EXCEPTION 'missing jwt claims'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF ((current_setting('request.jwt.claims', true)::json->>'sub')::uuid IS DISTINCT FROM p_user_id) THEN
+    RAISE EXCEPTION 'Unauthorized: caller does not match p_user_id'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+    INTO v_event
+    FROM public.events
+   WHERE id = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Event record not found: %', p_event_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT public.is_event_community_owner(v_event.id) THEN
+    RAISE EXCEPTION 'Unauthorized: user is not the community owner'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_event.canceled_at IS NOT NULL THEN
+    RAISE EXCEPTION 'Event has been canceled: %', p_event_id
+      USING ERRCODE = 'P0013';
+  END IF;
+
+  IF v_event.date <= now() AND NOT p_acknowledged_past_event THEN
+    RAISE EXCEPTION 'Past event attendance update requires acknowledgement'
+      USING ERRCODE = 'P0008';
+  END IF;
+
+  SELECT *
+    INTO v_attendance
+    FROM public.attendances
+   WHERE id = p_attendance_id
+     AND event_id = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Attendance record not found: %', p_attendance_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_attendance.status = p_new_status THEN
+    RETURN jsonb_build_object(
+      'updated', false,
+      'attendance_id', p_attendance_id,
+      'old_status', v_attendance.status,
+      'new_status', p_new_status,
+      'payment_effect', 'none',
+      'payment_id', NULL,
+      'payment_method', NULL,
+      'payment_status', NULL,
+      'guest_token', v_attendance.guest_token
+    );
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.payments
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('paid', 'received', 'waived', 'refunded')
+  ) INTO v_has_finalized_payment;
+
+  IF v_has_finalized_payment AND NOT p_acknowledged_finalized_payment THEN
+    RAISE EXCEPTION 'Finalized payment exists and acknowledgement is required'
+      USING ERRCODE = 'P0009';
+  END IF;
+
+  IF v_attendance.status != 'attending' AND p_new_status = 'attending' THEN
+    SELECT capacity INTO v_capacity
+      FROM public.events
+     WHERE id = p_event_id
+     FOR UPDATE;
+
+    IF v_capacity IS NOT NULL THEN
+      SELECT COUNT(*) INTO v_current_attendees
+        FROM public.attendances
+       WHERE event_id = p_event_id
+         AND status = 'attending'
+         AND id <> p_attendance_id;
+
+      IF v_current_attendees >= v_capacity AND NOT p_bypass_capacity THEN
+        RAISE EXCEPTION 'Event capacity (%) has been reached. Current attendees: %', v_capacity, v_current_attendees
+          USING ERRCODE = 'P0004',
+                DETAIL = format('Current: %s, Capacity: %s, Bypass: %s', v_current_attendees, v_capacity, p_bypass_capacity),
+                HINT = 'Set bypass_capacity=true to override capacity limit';
+      END IF;
+    END IF;
+  END IF;
+
+  IF p_new_status = 'attending' AND v_event.fee > 0 THEN
+    SELECT *
+      INTO v_preserved_payment
+      FROM public.payments
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('paid', 'received', 'waived')
+     ORDER BY paid_at DESC NULLS LAST, created_at DESC, updated_at DESC
+     LIMIT 1
+     FOR UPDATE;
+
+    IF FOUND THEN
+      v_payment_id := v_preserved_payment.id;
+      v_payment_method := v_preserved_payment.method;
+      v_payment_status := v_preserved_payment.status;
+      v_payment_effect := 'finalized_payment_preserved';
+    ELSE
+      IF p_payment_method IS NULL THEN
+        RAISE EXCEPTION 'Payment method is required when changing paid event attendance to attending'
+          USING ERRCODE = 'P0010';
+      END IF;
+
+      IF p_payment_method <> ALL(v_event.payment_methods) THEN
+        RAISE EXCEPTION 'Payment method is not allowed for this event'
+          USING ERRCODE = 'P0011';
+      END IF;
+
+      IF p_payment_method = 'stripe' THEN
+        SELECT pp.stripe_account_id, pp.status, pp.payouts_enabled
+          INTO v_stripe_account_id, v_payout_status, v_payouts_enabled
+          FROM public.payout_profiles pp
+         WHERE pp.id = v_event.payout_profile_id;
+
+        IF v_event.payout_profile_id IS NULL
+           OR v_stripe_account_id IS NULL
+           OR v_payout_status != 'verified'
+           OR v_payouts_enabled IS NOT TRUE THEN
+          RAISE EXCEPTION 'Online payment is not available for this event'
+            USING ERRCODE = 'P0012';
+        END IF;
+      END IF;
+
+      SELECT *
+        INTO v_open_payment
+        FROM public.payments
+       WHERE attendance_id = p_attendance_id
+         AND status IN ('pending', 'failed')
+       ORDER BY CASE WHEN status = 'pending' THEN 0 ELSE 1 END, created_at DESC, updated_at DESC
+       LIMIT 1
+       FOR UPDATE;
+
+      IF FOUND THEN
+        UPDATE public.payments
+           SET method = p_payment_method,
+               amount = v_event.fee,
+               status = 'pending',
+               paid_at = NULL,
+               payout_profile_id = CASE WHEN p_payment_method = 'stripe' THEN v_event.payout_profile_id ELSE NULL END,
+               stripe_account_id = CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+               destination_account_id = CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+               stripe_checkout_session_id = NULL,
+               stripe_payment_intent_id = NULL,
+               stripe_charge_id = NULL,
+               stripe_balance_transaction_id = NULL,
+               stripe_customer_id = NULL,
+               stripe_transfer_id = NULL,
+               application_fee_id = NULL,
+               application_fee_refund_id = NULL,
+               webhook_event_id = NULL,
+               webhook_processed_at = NULL,
+               checkout_idempotency_key = NULL,
+               checkout_key_revision = 0,
+               updated_at = now()
+         WHERE id = v_open_payment.id;
+
+        v_payment_id := v_open_payment.id;
+        v_payment_method := p_payment_method;
+        v_payment_status := 'pending';
+        v_payment_effect := 'open_payment_reused';
+      ELSE
+        INSERT INTO public.payments (
+          attendance_id,
+          amount,
+          method,
+          status,
+          payout_profile_id,
+          stripe_account_id,
+          destination_account_id
+        )
+        VALUES (
+          p_attendance_id,
+          v_event.fee,
+          p_payment_method,
+          'pending',
+          CASE WHEN p_payment_method = 'stripe' THEN v_event.payout_profile_id ELSE NULL END,
+          CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+          CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END
+        )
+        RETURNING id, method, status
+          INTO v_payment_id, v_payment_method, v_payment_status;
+
+        v_payment_effect := 'payment_created';
+      END IF;
+    END IF;
+  ELSIF p_new_status != 'attending' THEN
+    UPDATE public.payments
+       SET status = 'canceled',
+           paid_at = NULL,
+           updated_at = now()
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('pending', 'failed');
+
+    GET DIAGNOSTICS v_updated_open_count = ROW_COUNT;
+    IF v_updated_open_count > 0 THEN
+      v_payment_effect := 'open_payment_canceled';
+    ELSIF v_has_finalized_payment THEN
+      v_payment_effect := 'finalized_payment_preserved';
+    END IF;
+  END IF;
+
+  IF p_bypass_capacity THEN
+    PERFORM set_config('app.internal_attendance_capacity_bypass_7f8d2c91', 'true', true);
+  END IF;
+
+  UPDATE public.attendances
+     SET status = p_new_status
+   WHERE id = p_attendance_id;
+
+  IF p_bypass_capacity THEN
+    PERFORM set_config('app.internal_attendance_capacity_bypass_7f8d2c91', 'false', true);
+  END IF;
+
+  INSERT INTO public.system_logs (
+    log_category,
+    action,
+    message,
+    actor_type,
+    user_id,
+    resource_type,
+    resource_id,
+    outcome,
+    metadata
+  )
+  VALUES (
+    'attendance',
+    'attendance.admin_status_update',
+    format('Admin updated attendance status from %s to %s', v_attendance.status, p_new_status),
+    'user',
+    p_user_id,
+    'attendance',
+    p_attendance_id::text,
+    'success',
+    jsonb_build_object(
+      'event_id', p_event_id,
+      'attendance_id', p_attendance_id,
+      'old_status', v_attendance.status,
+      'new_status', p_new_status,
+      'payment_effect', v_payment_effect,
+      'payment_id', v_payment_id,
+      'payment_method', v_payment_method,
+      'payment_status', v_payment_status,
+      'bypass_capacity', p_bypass_capacity,
+      'acknowledged_finalized_payment', p_acknowledged_finalized_payment,
+      'acknowledged_past_event', p_acknowledged_past_event,
+      'notes', p_notes
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'updated', true,
+    'attendance_id', p_attendance_id,
+    'old_status', v_attendance.status,
+    'new_status', p_new_status,
+    'payment_effect', v_payment_effect,
+    'payment_id', v_payment_id,
+    'payment_method', v_payment_method,
+    'payment_status', v_payment_status,
+    'guest_token', v_attendance.guest_token
+  );
+END;
+$$;
+
+
+ALTER FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") OWNER TO "app_definer";
+
+
+COMMENT ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") IS '主催者による代理出欠変更（権限確認・定員チェック・決済副作用・監査ログをDB内で実施）';
+
 
 
 CREATE OR REPLACE FUNCTION "public"."rpc_bulk_update_payment_status_safe"("p_payment_updates" "jsonb", "p_user_id" "uuid", "p_notes" "text" DEFAULT NULL::"text") RETURNS json
@@ -4381,6 +4691,12 @@ GRANT ALL ON FUNCTION "public"."register_attendance_with_payment"("p_event_id" "
 REVOKE ALL ON FUNCTION "public"."rpc_admin_delete_mistaken_attendance"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_user_id" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."rpc_admin_delete_mistaken_attendance"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_user_id" "uuid") TO "authenticated";
 GRANT ALL ON FUNCTION "public"."rpc_admin_delete_mistaken_attendance"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_user_id" "uuid") TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."rpc_admin_update_attendance_status"("p_event_id" "uuid", "p_attendance_id" "uuid", "p_new_status" "public"."attendance_status_enum", "p_user_id" "uuid", "p_payment_method" "public"."payment_method_enum", "p_bypass_capacity" boolean, "p_acknowledged_finalized_payment" boolean, "p_acknowledged_past_event" boolean, "p_notes" "text") TO "service_role";
 
 
 

--- a/supabase/migrations/20260413001639_admin_update_attendance_status.sql
+++ b/supabase/migrations/20260413001639_admin_update_attendance_status.sql
@@ -1,0 +1,430 @@
+-- 主催者による代理出欠変更
+-- - 出欠は運営台帳として主催者が補正できる
+-- - 決済証跡は出欠変更で巻き戻さない
+-- - 定員超過上書きは専用RPC内の明示フラグのみ許可する
+
+GRANT CREATE ON SCHEMA public TO app_definer;
+
+CREATE OR REPLACE FUNCTION public.check_attendance_capacity_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+DECLARE
+  event_capacity integer;
+  current_attending_count integer;
+BEGIN
+  IF current_setting('app.internal_attendance_capacity_bypass_7f8d2c91', true) = 'true' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.status = 'attending'
+     AND (TG_OP = 'INSERT' OR OLD.status IS DISTINCT FROM 'attending') THEN
+    SELECT capacity INTO event_capacity
+      FROM public.events
+     WHERE id = NEW.event_id
+     FOR UPDATE;
+
+    IF event_capacity IS NOT NULL THEN
+      SELECT COUNT(*) INTO current_attending_count
+        FROM public.attendances
+       WHERE event_id = NEW.event_id
+         AND status = 'attending'
+         AND id IS DISTINCT FROM NEW.id;
+
+      IF current_attending_count >= event_capacity THEN
+        RAISE EXCEPTION 'このイベントは定員（%名）に達しています', event_capacity
+          USING ERRCODE = 'P0004',
+                DETAIL = format('Current attendees: %s, Capacity: %s', current_attending_count, event_capacity),
+                HINT = 'Capacity check is enforced by attendance trigger';
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.check_attendance_capacity_limit() OWNER TO app_definer;
+
+CREATE OR REPLACE FUNCTION public.rpc_admin_update_attendance_status(
+  p_event_id uuid,
+  p_attendance_id uuid,
+  p_new_status public.attendance_status_enum,
+  p_user_id uuid,
+  p_payment_method public.payment_method_enum DEFAULT NULL,
+  p_bypass_capacity boolean DEFAULT false,
+  p_acknowledged_finalized_payment boolean DEFAULT false,
+  p_acknowledged_past_event boolean DEFAULT false,
+  p_notes text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_attendance public.attendances%ROWTYPE;
+  v_event public.events%ROWTYPE;
+  v_capacity integer;
+  v_current_attendees integer;
+  v_has_finalized_payment boolean := false;
+  v_preserved_payment public.payments%ROWTYPE;
+  v_open_payment public.payments%ROWTYPE;
+  v_payment_id uuid := NULL;
+  v_payment_status public.payment_status_enum := NULL;
+  v_payment_method public.payment_method_enum := NULL;
+  v_payment_effect text := 'none';
+  v_stripe_account_id character varying := NULL;
+  v_payout_status public.stripe_account_status_enum := NULL;
+  v_payouts_enabled boolean := false;
+  v_updated_open_count integer := 0;
+BEGIN
+  IF current_setting('request.jwt.claims', true) IS NULL THEN
+    RAISE EXCEPTION 'missing jwt claims'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF ((current_setting('request.jwt.claims', true)::json->>'sub')::uuid IS DISTINCT FROM p_user_id) THEN
+    RAISE EXCEPTION 'Unauthorized: caller does not match p_user_id'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+    INTO v_event
+    FROM public.events
+   WHERE id = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Event record not found: %', p_event_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT public.is_event_community_owner(v_event.id) THEN
+    RAISE EXCEPTION 'Unauthorized: user is not the community owner'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_event.canceled_at IS NOT NULL THEN
+    RAISE EXCEPTION 'Event has been canceled: %', p_event_id
+      USING ERRCODE = 'P0013';
+  END IF;
+
+  IF v_event.date <= now() AND NOT p_acknowledged_past_event THEN
+    RAISE EXCEPTION 'Past event attendance update requires acknowledgement'
+      USING ERRCODE = 'P0008';
+  END IF;
+
+  SELECT *
+    INTO v_attendance
+    FROM public.attendances
+   WHERE id = p_attendance_id
+     AND event_id = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Attendance record not found: %', p_attendance_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_attendance.status = p_new_status THEN
+    RETURN jsonb_build_object(
+      'updated', false,
+      'attendance_id', p_attendance_id,
+      'old_status', v_attendance.status,
+      'new_status', p_new_status,
+      'payment_effect', 'none',
+      'payment_id', NULL,
+      'payment_method', NULL,
+      'payment_status', NULL,
+      'guest_token', v_attendance.guest_token
+    );
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.payments
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('paid', 'received', 'waived', 'refunded')
+  ) INTO v_has_finalized_payment;
+
+  IF v_has_finalized_payment AND NOT p_acknowledged_finalized_payment THEN
+    RAISE EXCEPTION 'Finalized payment exists and acknowledgement is required'
+      USING ERRCODE = 'P0009';
+  END IF;
+
+  IF v_attendance.status != 'attending' AND p_new_status = 'attending' THEN
+    SELECT capacity INTO v_capacity
+      FROM public.events
+     WHERE id = p_event_id
+     FOR UPDATE;
+
+    IF v_capacity IS NOT NULL THEN
+      SELECT COUNT(*) INTO v_current_attendees
+        FROM public.attendances
+       WHERE event_id = p_event_id
+         AND status = 'attending'
+         AND id <> p_attendance_id;
+
+      IF v_current_attendees >= v_capacity AND NOT p_bypass_capacity THEN
+        RAISE EXCEPTION 'Event capacity (%) has been reached. Current attendees: %', v_capacity, v_current_attendees
+          USING ERRCODE = 'P0004',
+                DETAIL = format('Current: %s, Capacity: %s, Bypass: %s', v_current_attendees, v_capacity, p_bypass_capacity),
+                HINT = 'Set bypass_capacity=true to override capacity limit';
+      END IF;
+    END IF;
+  END IF;
+
+  IF p_new_status = 'attending' AND v_event.fee > 0 THEN
+    SELECT *
+      INTO v_preserved_payment
+      FROM public.payments
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('paid', 'received', 'waived', 'refunded')
+     ORDER BY paid_at DESC NULLS LAST, created_at DESC, updated_at DESC
+     LIMIT 1
+     FOR UPDATE;
+
+    IF FOUND THEN
+      v_payment_id := v_preserved_payment.id;
+      v_payment_method := v_preserved_payment.method;
+      v_payment_status := v_preserved_payment.status;
+      v_payment_effect := 'finalized_payment_preserved';
+    ELSE
+      IF p_payment_method IS NULL THEN
+        RAISE EXCEPTION 'Payment method is required when changing paid event attendance to attending'
+          USING ERRCODE = 'P0010';
+      END IF;
+
+      IF p_payment_method <> ALL(v_event.payment_methods) THEN
+        RAISE EXCEPTION 'Payment method is not allowed for this event'
+          USING ERRCODE = 'P0011';
+      END IF;
+
+      IF p_payment_method = 'stripe' THEN
+        SELECT pp.stripe_account_id, pp.status, pp.payouts_enabled
+          INTO v_stripe_account_id, v_payout_status, v_payouts_enabled
+          FROM public.payout_profiles pp
+         WHERE pp.id = v_event.payout_profile_id;
+
+        IF v_event.payout_profile_id IS NULL
+           OR v_stripe_account_id IS NULL
+           OR v_payout_status != 'verified'
+           OR v_payouts_enabled IS NOT TRUE THEN
+          RAISE EXCEPTION 'Online payment is not available for this event'
+            USING ERRCODE = 'P0012';
+        END IF;
+      END IF;
+
+      SELECT *
+        INTO v_open_payment
+        FROM public.payments
+       WHERE attendance_id = p_attendance_id
+         AND status = 'pending'
+         AND stripe_checkout_session_id IS NULL
+         AND stripe_payment_intent_id IS NULL
+         AND stripe_charge_id IS NULL
+         AND stripe_balance_transaction_id IS NULL
+         AND stripe_customer_id IS NULL
+         AND stripe_transfer_id IS NULL
+         AND application_fee_id IS NULL
+         AND application_fee_refund_id IS NULL
+         AND webhook_event_id IS NULL
+         AND webhook_processed_at IS NULL
+         AND checkout_idempotency_key IS NULL
+         AND checkout_key_revision = 0
+         AND paid_at IS NULL
+         AND COALESCE(refunded_amount, 0) = 0
+         AND COALESCE(application_fee_refunded_amount, 0) = 0
+       ORDER BY created_at DESC, updated_at DESC
+       LIMIT 1
+       FOR UPDATE;
+
+      IF FOUND THEN
+        UPDATE public.payments
+           SET method = p_payment_method,
+               amount = v_event.fee,
+               status = 'pending',
+               paid_at = NULL,
+               payout_profile_id = CASE WHEN p_payment_method = 'stripe' THEN v_event.payout_profile_id ELSE NULL END,
+               stripe_account_id = CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+               destination_account_id = CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+               stripe_checkout_session_id = NULL,
+               stripe_payment_intent_id = NULL,
+               stripe_charge_id = NULL,
+               stripe_balance_transaction_id = NULL,
+               stripe_customer_id = NULL,
+               stripe_transfer_id = NULL,
+               application_fee_id = NULL,
+               application_fee_refund_id = NULL,
+               webhook_event_id = NULL,
+               webhook_processed_at = NULL,
+               checkout_idempotency_key = NULL,
+               checkout_key_revision = 0,
+               updated_at = now()
+         WHERE id = v_open_payment.id;
+
+        v_payment_id := v_open_payment.id;
+        v_payment_method := p_payment_method;
+        v_payment_status := 'pending';
+        v_payment_effect := 'open_payment_reused';
+      ELSE
+        UPDATE public.payments
+           SET status = 'canceled',
+               paid_at = NULL,
+               updated_at = now()
+         WHERE attendance_id = p_attendance_id
+           AND status = 'pending';
+
+        INSERT INTO public.payments (
+          attendance_id,
+          amount,
+          method,
+          status,
+          payout_profile_id,
+          stripe_account_id,
+          destination_account_id
+        )
+        VALUES (
+          p_attendance_id,
+          v_event.fee,
+          p_payment_method,
+          'pending',
+          CASE WHEN p_payment_method = 'stripe' THEN v_event.payout_profile_id ELSE NULL END,
+          CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+          CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END
+        )
+        RETURNING id, method, status
+          INTO v_payment_id, v_payment_method, v_payment_status;
+
+        v_payment_effect := 'payment_created';
+      END IF;
+    END IF;
+  ELSIF p_new_status != 'attending' THEN
+    UPDATE public.payments
+       SET status = 'canceled',
+           paid_at = NULL,
+           updated_at = now()
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('pending', 'failed');
+
+    GET DIAGNOSTICS v_updated_open_count = ROW_COUNT;
+    IF v_updated_open_count > 0 THEN
+      v_payment_effect := 'open_payment_canceled';
+    ELSIF v_has_finalized_payment THEN
+      v_payment_effect := 'finalized_payment_preserved';
+    END IF;
+  END IF;
+
+  IF p_bypass_capacity THEN
+    PERFORM set_config('app.internal_attendance_capacity_bypass_7f8d2c91', 'true', true);
+  END IF;
+
+  UPDATE public.attendances
+     SET status = p_new_status
+   WHERE id = p_attendance_id;
+
+  IF p_bypass_capacity THEN
+    PERFORM set_config('app.internal_attendance_capacity_bypass_7f8d2c91', 'false', true);
+  END IF;
+
+  INSERT INTO public.system_logs (
+    log_category,
+    action,
+    message,
+    actor_type,
+    user_id,
+    resource_type,
+    resource_id,
+    outcome,
+    metadata
+  )
+  VALUES (
+    'attendance',
+    'attendance.admin_status_update',
+    format('Admin updated attendance status from %s to %s', v_attendance.status, p_new_status),
+    'user',
+    p_user_id,
+    'attendance',
+    p_attendance_id::text,
+    'success',
+    jsonb_build_object(
+      'event_id', p_event_id,
+      'attendance_id', p_attendance_id,
+      'old_status', v_attendance.status,
+      'new_status', p_new_status,
+      'payment_effect', v_payment_effect,
+      'payment_id', v_payment_id,
+      'payment_method', v_payment_method,
+      'payment_status', v_payment_status,
+      'bypass_capacity', p_bypass_capacity,
+      'acknowledged_finalized_payment', p_acknowledged_finalized_payment,
+      'acknowledged_past_event', p_acknowledged_past_event,
+      'notes', p_notes
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'updated', true,
+    'attendance_id', p_attendance_id,
+    'old_status', v_attendance.status,
+    'new_status', p_new_status,
+    'payment_effect', v_payment_effect,
+    'payment_id', v_payment_id,
+    'payment_method', v_payment_method,
+    'payment_status', v_payment_status,
+    'guest_token', v_attendance.guest_token
+  );
+END;
+$$;
+
+ALTER FUNCTION public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  boolean,
+  text
+) OWNER TO app_definer;
+
+REVOKE ALL ON FUNCTION public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  boolean,
+  text
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  boolean,
+  text
+) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  boolean,
+  text
+) IS '主催者による代理出欠変更（権限確認・定員チェック・決済副作用・監査ログをDB内で実施）';
+
+REVOKE CREATE ON SCHEMA public FROM app_definer;

--- a/supabase/migrations/20260413120000_remove_attendance_capacity_bypass.sql
+++ b/supabase/migrations/20260413120000_remove_attendance_capacity_bypass.sql
@@ -1,0 +1,549 @@
+-- 主催者操作でも定員超過を許可しない
+-- - 定員超過時はイベント定員を先に変更してから参加者追加/代理変更する
+-- - 共通トリガーを定員制約の最終防衛線として維持する
+
+GRANT CREATE ON SCHEMA public TO app_definer;
+
+DROP FUNCTION IF EXISTS public.admin_add_attendance_with_capacity_check(
+  uuid,
+  character varying,
+  character varying,
+  public.attendance_status_enum,
+  character varying,
+  boolean
+);
+
+CREATE OR REPLACE FUNCTION public.admin_add_attendance_with_capacity_check(
+  p_event_id uuid,
+  p_nickname character varying,
+  p_email character varying,
+  p_status public.attendance_status_enum,
+  p_guest_token character varying
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_attendance_id uuid;
+  v_capacity integer;
+  v_current_count integer;
+  v_current_user_id uuid;
+BEGIN
+  IF p_event_id IS NULL THEN
+    RAISE EXCEPTION 'Event ID cannot be null';
+  END IF;
+
+  IF p_nickname IS NULL OR LENGTH(TRIM(p_nickname)) = 0 THEN
+    RAISE EXCEPTION 'Nickname cannot be null or empty';
+  END IF;
+
+  IF p_email IS NULL OR LENGTH(TRIM(p_email)) = 0 THEN
+    RAISE EXCEPTION 'Email cannot be null or empty';
+  END IF;
+
+  IF p_guest_token IS NULL OR LENGTH(TRIM(p_guest_token)) = 0 THEN
+    RAISE EXCEPTION 'Guest token cannot be null or empty';
+  END IF;
+
+  BEGIN
+    v_current_user_id := (current_setting('request.jwt.claims', true)::json->>'sub')::uuid;
+  EXCEPTION WHEN OTHERS THEN
+    v_current_user_id := NULL;
+  END;
+
+  IF v_current_user_id IS NULL THEN
+    RAISE EXCEPTION 'User must be authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT capacity
+    INTO v_capacity
+    FROM public.events
+   WHERE id = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Event not found: %', p_event_id;
+  END IF;
+
+  IF NOT public.is_event_community_owner(p_event_id) THEN
+    RAISE EXCEPTION 'Only community owner can add participants' USING ERRCODE = '42501';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.attendances WHERE guest_token = p_guest_token) THEN
+    RAISE EXCEPTION 'Guest token already exists: %', LEFT(p_guest_token, 8) || '...';
+  END IF;
+
+  IF p_status = 'attending' AND v_capacity IS NOT NULL THEN
+    SELECT COUNT(*)
+      INTO v_current_count
+      FROM public.attendances
+     WHERE event_id = p_event_id
+       AND status = 'attending';
+
+    IF v_current_count >= v_capacity THEN
+      RAISE EXCEPTION 'Event capacity (%) has been reached. Current attendees: %', v_capacity, v_current_count
+        USING ERRCODE = 'P0004',
+              DETAIL = format('Current attendees: %s, Capacity: %s', v_current_count, v_capacity),
+              HINT = 'Increase the event capacity before adding another attending participant';
+    END IF;
+  END IF;
+
+  INSERT INTO public.attendances (event_id, nickname, email, status, guest_token)
+  VALUES (p_event_id, p_nickname, p_email, p_status, p_guest_token)
+  RETURNING id INTO v_attendance_id;
+
+  RETURN v_attendance_id;
+END;
+$$;
+
+ALTER FUNCTION public.admin_add_attendance_with_capacity_check(
+  uuid,
+  character varying,
+  character varying,
+  public.attendance_status_enum,
+  character varying
+) OWNER TO app_definer;
+
+REVOKE ALL ON FUNCTION public.admin_add_attendance_with_capacity_check(
+  uuid,
+  character varying,
+  character varying,
+  public.attendance_status_enum,
+  character varying
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.admin_add_attendance_with_capacity_check(
+  uuid,
+  character varying,
+  character varying,
+  public.attendance_status_enum,
+  character varying
+) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.admin_add_attendance_with_capacity_check(
+  uuid,
+  character varying,
+  character varying,
+  public.attendance_status_enum,
+  character varying
+) IS '主催者用参加者追加（排他ロック・定員チェック・レースコンディション対策）';
+
+CREATE OR REPLACE FUNCTION public.check_attendance_capacity_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+DECLARE
+  event_capacity integer;
+  current_attending_count integer;
+BEGIN
+  IF NEW.status = 'attending'
+     AND (TG_OP = 'INSERT' OR OLD.status IS DISTINCT FROM 'attending') THEN
+    SELECT capacity INTO event_capacity
+      FROM public.events
+     WHERE id = NEW.event_id
+     FOR UPDATE;
+
+    IF event_capacity IS NOT NULL THEN
+      SELECT COUNT(*) INTO current_attending_count
+        FROM public.attendances
+       WHERE event_id = NEW.event_id
+         AND status = 'attending'
+         AND id IS DISTINCT FROM NEW.id;
+
+      IF current_attending_count >= event_capacity THEN
+        RAISE EXCEPTION 'このイベントは定員（%名）に達しています', event_capacity
+          USING ERRCODE = 'P0004',
+                DETAIL = format('Current attendees: %s, Capacity: %s', current_attending_count, event_capacity),
+                HINT = 'Capacity check is enforced by attendance trigger';
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.check_attendance_capacity_limit() OWNER TO app_definer;
+
+DROP FUNCTION IF EXISTS public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  boolean,
+  text
+);
+
+CREATE OR REPLACE FUNCTION public.rpc_admin_update_attendance_status(
+  p_event_id uuid,
+  p_attendance_id uuid,
+  p_new_status public.attendance_status_enum,
+  p_user_id uuid,
+  p_payment_method public.payment_method_enum DEFAULT NULL,
+  p_acknowledged_finalized_payment boolean DEFAULT false,
+  p_acknowledged_past_event boolean DEFAULT false,
+  p_notes text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_attendance public.attendances%ROWTYPE;
+  v_event public.events%ROWTYPE;
+  v_capacity integer;
+  v_current_attendees integer;
+  v_has_finalized_payment boolean := false;
+  v_preserved_payment public.payments%ROWTYPE;
+  v_open_payment public.payments%ROWTYPE;
+  v_payment_id uuid := NULL;
+  v_payment_status public.payment_status_enum := NULL;
+  v_payment_method public.payment_method_enum := NULL;
+  v_payment_effect text := 'none';
+  v_stripe_account_id character varying := NULL;
+  v_payout_status public.stripe_account_status_enum := NULL;
+  v_payouts_enabled boolean := false;
+  v_updated_open_count integer := 0;
+BEGIN
+  IF current_setting('request.jwt.claims', true) IS NULL THEN
+    RAISE EXCEPTION 'missing jwt claims'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF ((current_setting('request.jwt.claims', true)::json->>'sub')::uuid IS DISTINCT FROM p_user_id) THEN
+    RAISE EXCEPTION 'Unauthorized: caller does not match p_user_id'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+    INTO v_event
+    FROM public.events
+   WHERE id = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Event record not found: %', p_event_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT public.is_event_community_owner(v_event.id) THEN
+    RAISE EXCEPTION 'Unauthorized: user is not the community owner'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_event.canceled_at IS NOT NULL THEN
+    RAISE EXCEPTION 'Event has been canceled: %', p_event_id
+      USING ERRCODE = 'P0013';
+  END IF;
+
+  IF v_event.date <= now() AND NOT p_acknowledged_past_event THEN
+    RAISE EXCEPTION 'Past event attendance update requires acknowledgement'
+      USING ERRCODE = 'P0008';
+  END IF;
+
+  SELECT *
+    INTO v_attendance
+    FROM public.attendances
+   WHERE id = p_attendance_id
+     AND event_id = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Attendance record not found: %', p_attendance_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_attendance.status = p_new_status THEN
+    RETURN jsonb_build_object(
+      'updated', false,
+      'attendance_id', p_attendance_id,
+      'old_status', v_attendance.status,
+      'new_status', p_new_status,
+      'payment_effect', 'none',
+      'payment_id', NULL,
+      'payment_method', NULL,
+      'payment_status', NULL,
+      'guest_token', v_attendance.guest_token
+    );
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.payments
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('paid', 'received', 'waived', 'refunded')
+  ) INTO v_has_finalized_payment;
+
+  IF v_has_finalized_payment AND NOT p_acknowledged_finalized_payment THEN
+    RAISE EXCEPTION 'Finalized payment exists and acknowledgement is required'
+      USING ERRCODE = 'P0009';
+  END IF;
+
+  IF v_attendance.status != 'attending' AND p_new_status = 'attending' THEN
+    SELECT capacity INTO v_capacity
+      FROM public.events
+     WHERE id = p_event_id
+     FOR UPDATE;
+
+    IF v_capacity IS NOT NULL THEN
+      SELECT COUNT(*) INTO v_current_attendees
+        FROM public.attendances
+       WHERE event_id = p_event_id
+         AND status = 'attending'
+         AND id <> p_attendance_id;
+
+      IF v_current_attendees >= v_capacity THEN
+        RAISE EXCEPTION 'Event capacity (%) has been reached. Current attendees: %', v_capacity, v_current_attendees
+          USING ERRCODE = 'P0004',
+                DETAIL = format('Current attendees: %s, Capacity: %s', v_current_attendees, v_capacity),
+                HINT = 'Increase the event capacity before changing this attendance to attending';
+      END IF;
+    END IF;
+  END IF;
+
+  IF p_new_status = 'attending' AND v_event.fee > 0 THEN
+    SELECT *
+      INTO v_preserved_payment
+      FROM public.payments
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('paid', 'received', 'waived', 'refunded')
+     ORDER BY paid_at DESC NULLS LAST, created_at DESC, updated_at DESC
+     LIMIT 1
+     FOR UPDATE;
+
+    IF FOUND THEN
+      v_payment_id := v_preserved_payment.id;
+      v_payment_method := v_preserved_payment.method;
+      v_payment_status := v_preserved_payment.status;
+      v_payment_effect := 'finalized_payment_preserved';
+    ELSE
+      IF p_payment_method IS NULL THEN
+        RAISE EXCEPTION 'Payment method is required when changing paid event attendance to attending'
+          USING ERRCODE = 'P0010';
+      END IF;
+
+      IF p_payment_method <> ALL(v_event.payment_methods) THEN
+        RAISE EXCEPTION 'Payment method is not allowed for this event'
+          USING ERRCODE = 'P0011';
+      END IF;
+
+      IF p_payment_method = 'stripe' THEN
+        SELECT pp.stripe_account_id, pp.status, pp.payouts_enabled
+          INTO v_stripe_account_id, v_payout_status, v_payouts_enabled
+          FROM public.payout_profiles pp
+         WHERE pp.id = v_event.payout_profile_id;
+
+        IF v_event.payout_profile_id IS NULL
+           OR v_stripe_account_id IS NULL
+           OR v_payout_status != 'verified'
+           OR v_payouts_enabled IS NOT TRUE THEN
+          RAISE EXCEPTION 'Online payment is not available for this event'
+            USING ERRCODE = 'P0012';
+        END IF;
+      END IF;
+
+      SELECT *
+        INTO v_open_payment
+        FROM public.payments
+       WHERE attendance_id = p_attendance_id
+         AND status = 'pending'
+         AND stripe_checkout_session_id IS NULL
+         AND stripe_payment_intent_id IS NULL
+         AND stripe_charge_id IS NULL
+         AND stripe_balance_transaction_id IS NULL
+         AND stripe_customer_id IS NULL
+         AND stripe_transfer_id IS NULL
+         AND application_fee_id IS NULL
+         AND application_fee_refund_id IS NULL
+         AND webhook_event_id IS NULL
+         AND webhook_processed_at IS NULL
+         AND checkout_idempotency_key IS NULL
+         AND checkout_key_revision = 0
+         AND paid_at IS NULL
+         AND COALESCE(refunded_amount, 0) = 0
+         AND COALESCE(application_fee_refunded_amount, 0) = 0
+       ORDER BY created_at DESC, updated_at DESC
+       LIMIT 1
+       FOR UPDATE;
+
+      IF FOUND THEN
+        UPDATE public.payments
+           SET method = p_payment_method,
+               amount = v_event.fee,
+               status = 'pending',
+               paid_at = NULL,
+               payout_profile_id = CASE WHEN p_payment_method = 'stripe' THEN v_event.payout_profile_id ELSE NULL END,
+               stripe_account_id = CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+               destination_account_id = CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+               stripe_checkout_session_id = NULL,
+               stripe_payment_intent_id = NULL,
+               stripe_charge_id = NULL,
+               stripe_balance_transaction_id = NULL,
+               stripe_customer_id = NULL,
+               stripe_transfer_id = NULL,
+               application_fee_id = NULL,
+               application_fee_refund_id = NULL,
+               webhook_event_id = NULL,
+               webhook_processed_at = NULL,
+               checkout_idempotency_key = NULL,
+               checkout_key_revision = 0,
+               updated_at = now()
+         WHERE id = v_open_payment.id;
+
+        v_payment_id := v_open_payment.id;
+        v_payment_method := p_payment_method;
+        v_payment_status := 'pending';
+        v_payment_effect := 'open_payment_reused';
+      ELSE
+        UPDATE public.payments
+           SET status = 'canceled',
+               paid_at = NULL,
+               updated_at = now()
+         WHERE attendance_id = p_attendance_id
+           AND status = 'pending';
+
+        INSERT INTO public.payments (
+          attendance_id,
+          amount,
+          method,
+          status,
+          payout_profile_id,
+          stripe_account_id,
+          destination_account_id
+        )
+        VALUES (
+          p_attendance_id,
+          v_event.fee,
+          p_payment_method,
+          'pending',
+          CASE WHEN p_payment_method = 'stripe' THEN v_event.payout_profile_id ELSE NULL END,
+          CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END,
+          CASE WHEN p_payment_method = 'stripe' THEN v_stripe_account_id ELSE NULL END
+        )
+        RETURNING id, method, status
+          INTO v_payment_id, v_payment_method, v_payment_status;
+
+        v_payment_effect := 'payment_created';
+      END IF;
+    END IF;
+  ELSIF p_new_status != 'attending' THEN
+    UPDATE public.payments
+       SET status = 'canceled',
+           paid_at = NULL,
+           updated_at = now()
+     WHERE attendance_id = p_attendance_id
+       AND status IN ('pending', 'failed');
+
+    GET DIAGNOSTICS v_updated_open_count = ROW_COUNT;
+    IF v_updated_open_count > 0 THEN
+      v_payment_effect := 'open_payment_canceled';
+    ELSIF v_has_finalized_payment THEN
+      v_payment_effect := 'finalized_payment_preserved';
+    END IF;
+  END IF;
+
+  UPDATE public.attendances
+     SET status = p_new_status
+   WHERE id = p_attendance_id;
+
+  INSERT INTO public.system_logs (
+    log_category,
+    action,
+    message,
+    actor_type,
+    user_id,
+    resource_type,
+    resource_id,
+    outcome,
+    metadata
+  )
+  VALUES (
+    'attendance',
+    'attendance.admin_status_update',
+    format('Admin updated attendance status from %s to %s', v_attendance.status, p_new_status),
+    'user',
+    p_user_id,
+    'attendance',
+    p_attendance_id::text,
+    'success',
+    jsonb_build_object(
+      'event_id', p_event_id,
+      'attendance_id', p_attendance_id,
+      'old_status', v_attendance.status,
+      'new_status', p_new_status,
+      'payment_effect', v_payment_effect,
+      'payment_id', v_payment_id,
+      'payment_method', v_payment_method,
+      'payment_status', v_payment_status,
+      'acknowledged_finalized_payment', p_acknowledged_finalized_payment,
+      'acknowledged_past_event', p_acknowledged_past_event,
+      'notes', p_notes
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'updated', true,
+    'attendance_id', p_attendance_id,
+    'old_status', v_attendance.status,
+    'new_status', p_new_status,
+    'payment_effect', v_payment_effect,
+    'payment_id', v_payment_id,
+    'payment_method', v_payment_method,
+    'payment_status', v_payment_status,
+    'guest_token', v_attendance.guest_token
+  );
+END;
+$$;
+
+ALTER FUNCTION public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  text
+) OWNER TO app_definer;
+
+REVOKE ALL ON FUNCTION public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  text
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  text
+) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.rpc_admin_update_attendance_status(
+  uuid,
+  uuid,
+  public.attendance_status_enum,
+  uuid,
+  public.payment_method_enum,
+  boolean,
+  boolean,
+  text
+) IS '主催者による代理出欠変更（権限確認・定員チェック・決済副作用・監査ログをDB内で実施）';
+
+REVOKE CREATE ON SCHEMA public FROM app_definer;

--- a/tests/integration/events/admin-add-attendance.integration.test.ts
+++ b/tests/integration/events/admin-add-attendance.integration.test.ts
@@ -148,7 +148,6 @@ describe("adminAddAttendanceAction integration", () => {
       eventId: fixture.event.id,
       nickname: "Rollback Participant",
       status: "attending",
-      bypassCapacity: false,
       paymentMethod: "cash",
     });
 
@@ -165,5 +164,85 @@ describe("adminAddAttendanceAction integration", () => {
 
     expect(attendanceCount.error).toBeNull();
     expect(attendanceCount.count ?? 0).toBe(0);
+  });
+
+  test("capacity reached rejects manual add without creating attendance or payment", async () => {
+    const owner = setup.users[0];
+    const authenticated = await createAuthenticatedClient(owner.email, owner.password);
+    const fixture = await createCommunityOwnedEventFixture(owner.id, {
+      fee: 1200,
+      capacity: 1,
+      payment_methods: ["cash"],
+      withPayoutProfile: false,
+      attachPayoutProfileToEvent: false,
+    });
+
+    cleanupHelper.trackEvent(fixture.event.id);
+    cleanupHelper.trackCommunity(fixture.communityId);
+    if (fixture.payoutProfileId) {
+      cleanupHelper.trackPayoutProfile(fixture.payoutProfileId);
+    }
+
+    const { data: existingAttendance, error: existingAttendanceError } = await setup.adminClient
+      .from("attendances")
+      .insert({
+        event_id: fixture.event.id,
+        email: "existing-capacity@example.com",
+        nickname: "Existing Participant",
+        status: "attending",
+        guest_token: `gst_${`${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`.padEnd(32, "a").slice(0, 32)}`,
+      })
+      .select("id")
+      .single();
+
+    expect(existingAttendanceError).toBeNull();
+    cleanupHelper.trackAttendance(existingAttendance!.id);
+
+    mockCreateServerActionSupabaseClient.mockResolvedValue(authenticated.client as never);
+    mockGetCurrentCommunityServerActionContext.mockResolvedValue(
+      okResult({
+        currentCommunity: {
+          id: fixture.communityId,
+          name: "Current Community",
+          slug: "current-community",
+          createdAt: new Date().toISOString(),
+        },
+        user: {
+          id: owner.id,
+          email: owner.email,
+          user_metadata: {},
+          app_metadata: {},
+        } as never,
+      })
+    );
+
+    const createCashPayment = jest.fn();
+    mockGetPaymentPort.mockReturnValue({
+      createCashPayment,
+    } as never);
+
+    const { adminAddAttendanceAction } =
+      await import("@/features/events/actions/admin-add-attendance");
+    const result = await adminAddAttendanceAction({
+      eventId: fixture.event.id,
+      nickname: "Over Capacity Participant",
+      status: "attending",
+      paymentMethod: "cash",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("RESOURCE_CONFLICT");
+      expect(result.error.userMessage).toContain("先にイベントの定員を変更");
+    }
+    expect(createCashPayment).not.toHaveBeenCalled();
+
+    const attendanceCount = await setup.adminClient
+      .from("attendances")
+      .select("id", { count: "exact", head: true })
+      .eq("event_id", fixture.event.id);
+
+    expect(attendanceCount.error).toBeNull();
+    expect(attendanceCount.count ?? 0).toBe(1);
   });
 });

--- a/tests/integration/events/admin-update-attendance-status.integration.test.ts
+++ b/tests/integration/events/admin-update-attendance-status.integration.test.ts
@@ -406,14 +406,10 @@ describe("adminUpdateAttendanceStatusAction integration", () => {
       paymentMethod: "cash",
     });
 
-    expect(capacityResult.success).toBe(true);
-    if (capacityResult.success) {
-      expect(capacityResult.data).toEqual(
-        expect.objectContaining({
-          confirmRequired: true,
-          reason: "capacity",
-        })
-      );
+    expect(capacityResult.success).toBe(false);
+    if (!capacityResult.success) {
+      expect(capacityResult.error.code).toBe("RESOURCE_CONFLICT");
+      expect(capacityResult.error.userMessage).toContain("先にイベントの定員を変更");
     }
     expect(await getAttendanceStatus(overCapacityTarget.id)).toBe("not_attending");
     expect(await getPayments(overCapacityTarget.id)).toHaveLength(0);

--- a/tests/integration/events/admin-update-attendance-status.integration.test.ts
+++ b/tests/integration/events/admin-update-attendance-status.integration.test.ts
@@ -1,0 +1,444 @@
+import { afterAll, afterEach, beforeAll, describe, expect, jest, test } from "@jest/globals";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { okResult } from "@core/errors/app-result";
+import { getCurrentCommunityServerActionContext } from "@core/community/current-community";
+import { createServerActionSupabaseClient } from "@core/supabase/factory";
+import { createCommunityOwnedEventFixture } from "@tests/helpers/community-owner-fixtures";
+import { setupNextCacheMocks } from "@tests/setup/common-mocks";
+import {
+  createMultiUserTestSetup,
+  createTestDataCleanupHelper,
+  type MultiUserTestSetup,
+} from "@tests/setup/common-test-setup";
+
+import type { Database } from "@/types/database";
+
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock("@core/community/current-community", () => ({
+  getCurrentCommunityServerActionContext: jest.fn(),
+}));
+
+jest.mock("@core/supabase/factory", () => ({
+  createServerActionSupabaseClient: jest.fn(),
+}));
+
+const mockGetCurrentCommunityServerActionContext =
+  getCurrentCommunityServerActionContext as jest.MockedFunction<
+    typeof getCurrentCommunityServerActionContext
+  >;
+const mockCreateServerActionSupabaseClient =
+  createServerActionSupabaseClient as jest.MockedFunction<typeof createServerActionSupabaseClient>;
+
+type AttendanceStatus = Database["public"]["Enums"]["attendance_status_enum"];
+type PaymentMethod = Database["public"]["Enums"]["payment_method_enum"];
+type PaymentStatus = Database["public"]["Enums"]["payment_status_enum"];
+
+async function createAuthenticatedClient(
+  email: string,
+  password: string
+): Promise<SupabaseClient<Database>> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+  if (!supabaseUrl || !anonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY for tests");
+  }
+
+  const client = createClient<Database>(supabaseUrl, anonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    throw new Error(`Failed to sign in test user: ${error.message}`);
+  }
+
+  return client;
+}
+
+function generateGuestToken(): string {
+  const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  let result = "gst_";
+  for (let i = 0; i < 32; i += 1) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+describe("adminUpdateAttendanceStatusAction integration", () => {
+  let setup: MultiUserTestSetup;
+  let cleanupHelper: ReturnType<typeof createTestDataCleanupHelper>;
+
+  beforeAll(async () => {
+    setupNextCacheMocks();
+    setup = await createMultiUserTestSetup({
+      testName: `admin-update-attendance-status-${Date.now()}`,
+      userCount: 2,
+      withConnect: false,
+      accessedTables: [
+        "public.users",
+        "public.communities",
+        "public.events",
+        "public.attendances",
+        "public.payments",
+        "public.system_logs",
+      ],
+    });
+    cleanupHelper = createTestDataCleanupHelper(setup.adminClient);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await cleanupHelper.cleanup();
+    cleanupHelper.reset();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  async function arrangeActionContext(userIndex: number, currentCommunityId: string) {
+    const user = setup.users[userIndex];
+    const authenticatedClient = await createAuthenticatedClient(user.email, user.password);
+
+    mockCreateServerActionSupabaseClient.mockResolvedValue(authenticatedClient as never);
+    mockGetCurrentCommunityServerActionContext.mockResolvedValue(
+      okResult({
+        currentCommunity: {
+          id: currentCommunityId,
+          name: "Current Community",
+          slug: "current-community",
+          createdAt: new Date().toISOString(),
+        },
+        user: {
+          id: user.id,
+          email: user.email,
+          user_metadata: {},
+          app_metadata: {},
+        } as never,
+      })
+    );
+  }
+
+  async function createTrackedEvent(
+    ownerId: string,
+    options: Parameters<typeof createCommunityOwnedEventFixture>[1] = {}
+  ) {
+    const fixture = await createCommunityOwnedEventFixture(ownerId, options);
+    cleanupHelper.trackEvent(fixture.event.id);
+    cleanupHelper.trackCommunity(fixture.communityId);
+    if (fixture.payoutProfileId) {
+      cleanupHelper.trackPayoutProfile(fixture.payoutProfileId);
+    }
+    return fixture;
+  }
+
+  async function createTrackedAttendance(
+    eventId: string,
+    options: {
+      email?: string;
+      nickname?: string;
+      status?: AttendanceStatus;
+    } = {}
+  ) {
+    const { data, error } = await setup.adminClient
+      .from("attendances")
+      .insert({
+        event_id: eventId,
+        email: options.email ?? `participant-${Date.now()}-${Math.random()}@example.com`,
+        nickname: options.nickname ?? `参加者-${Math.random().toString(36).slice(2, 8)}`,
+        status: options.status ?? "attending",
+        guest_token: generateGuestToken(),
+      })
+      .select("id, status")
+      .single();
+
+    expect(error).toBeNull();
+    cleanupHelper.trackAttendance(data!.id);
+    return data!;
+  }
+
+  async function createTrackedPayment(
+    attendanceId: string,
+    options: {
+      amount: number;
+      method?: PaymentMethod;
+      status?: PaymentStatus;
+    }
+  ) {
+    const { data, error } = await setup.adminClient
+      .from("payments")
+      .insert({
+        attendance_id: attendanceId,
+        amount: options.amount,
+        method: options.method ?? "cash",
+        status: options.status ?? "pending",
+        paid_at:
+          options.status === "received" || options.status === "paid"
+            ? new Date().toISOString()
+            : null,
+      })
+      .select("id, amount, method, status")
+      .single();
+
+    expect(error).toBeNull();
+    cleanupHelper.trackPayment(data!.id);
+    return data!;
+  }
+
+  async function getAttendanceStatus(attendanceId: string) {
+    const { data, error } = await setup.adminClient
+      .from("attendances")
+      .select("status")
+      .eq("id", attendanceId)
+      .single();
+
+    expect(error).toBeNull();
+    return data!.status;
+  }
+
+  async function getPayments(attendanceId: string) {
+    const { data, error } = await setup.adminClient
+      .from("payments")
+      .select("id, amount, method, status")
+      .eq("attendance_id", attendanceId)
+      .order("created_at", { ascending: true });
+
+    expect(error).toBeNull();
+    return data ?? [];
+  }
+
+  test("主催者は無料イベントの出欠を変更でき、主催者以外は変更できない", async () => {
+    const owner = setup.users[0];
+    const fixture = await createTrackedEvent(owner.id, {
+      fee: 0,
+      payment_methods: [],
+    });
+    const ownedAttendance = await createTrackedAttendance(fixture.event.id, {
+      status: "maybe",
+      nickname: "主催者変更対象",
+    });
+
+    await arrangeActionContext(0, fixture.communityId);
+    const { adminUpdateAttendanceStatusAction } =
+      await import("@/features/events/actions/admin-update-attendance-status");
+
+    const ownerResult = await adminUpdateAttendanceStatusAction({
+      eventId: fixture.event.id,
+      attendanceId: ownedAttendance.id,
+      status: "not_attending",
+    });
+
+    expect(ownerResult.success).toBe(true);
+    expect(await getAttendanceStatus(ownedAttendance.id)).toBe("not_attending");
+    expect(await getPayments(ownedAttendance.id)).toHaveLength(0);
+
+    const unauthorizedAttendance = await createTrackedAttendance(fixture.event.id, {
+      status: "maybe",
+      nickname: "権限なし変更対象",
+    });
+
+    await arrangeActionContext(1, fixture.communityId);
+    const unauthorizedResult = await adminUpdateAttendanceStatusAction({
+      eventId: fixture.event.id,
+      attendanceId: unauthorizedAttendance.id,
+      status: "attending",
+    });
+
+    expect(unauthorizedResult.success).toBe(false);
+    expect(await getAttendanceStatus(unauthorizedAttendance.id)).toBe("maybe");
+    expect(await getPayments(unauthorizedAttendance.id)).toHaveLength(0);
+  });
+
+  test("有料イベントで非参加系から参加に戻すと支払い待ちになる", async () => {
+    const owner = setup.users[0];
+    const fixture = await createTrackedEvent(owner.id, {
+      fee: 1800,
+      payment_methods: ["cash"],
+      withPayoutProfile: false,
+      attachPayoutProfileToEvent: false,
+    });
+    const attendance = await createTrackedAttendance(fixture.event.id, {
+      status: "not_attending",
+    });
+
+    await arrangeActionContext(0, fixture.communityId);
+    const { adminUpdateAttendanceStatusAction } =
+      await import("@/features/events/actions/admin-update-attendance-status");
+
+    const result = await adminUpdateAttendanceStatusAction({
+      eventId: fixture.event.id,
+      attendanceId: attendance.id,
+      status: "attending",
+      paymentMethod: "cash",
+    });
+
+    expect(result.success).toBe(true);
+    expect(await getAttendanceStatus(attendance.id)).toBe("attending");
+
+    const payments = await getPayments(attendance.id);
+    expect(payments).toHaveLength(1);
+    expect(payments[0]).toEqual(
+      expect.objectContaining({
+        amount: 1800,
+        method: "cash",
+        status: "pending",
+      })
+    );
+    cleanupHelper.trackPayment(payments[0]!.id);
+  });
+
+  test("参加から非参加系に変えると未確定支払いだけキャンセルされる", async () => {
+    const owner = setup.users[0];
+    const fixture = await createTrackedEvent(owner.id, {
+      fee: 1800,
+      payment_methods: ["cash"],
+      withPayoutProfile: false,
+      attachPayoutProfileToEvent: false,
+    });
+    const attendance = await createTrackedAttendance(fixture.event.id, {
+      status: "attending",
+    });
+    const payment = await createTrackedPayment(attendance.id, {
+      amount: 1800,
+      method: "cash",
+      status: "pending",
+    });
+
+    await arrangeActionContext(0, fixture.communityId);
+    const { adminUpdateAttendanceStatusAction } =
+      await import("@/features/events/actions/admin-update-attendance-status");
+
+    const result = await adminUpdateAttendanceStatusAction({
+      eventId: fixture.event.id,
+      attendanceId: attendance.id,
+      status: "not_attending",
+    });
+
+    expect(result.success).toBe(true);
+    expect(await getAttendanceStatus(attendance.id)).toBe("not_attending");
+
+    const payments = await getPayments(attendance.id);
+    expect(payments).toHaveLength(1);
+    expect(payments[0]).toEqual(
+      expect.objectContaining({
+        id: payment.id,
+        amount: 1800,
+        method: "cash",
+        status: "canceled",
+      })
+    );
+  });
+
+  test("確定済み支払いがある参加者は出欠だけ変更される", async () => {
+    const owner = setup.users[0];
+    const fixture = await createTrackedEvent(owner.id, {
+      fee: 1800,
+      payment_methods: ["cash"],
+      withPayoutProfile: false,
+      attachPayoutProfileToEvent: false,
+    });
+    const attendance = await createTrackedAttendance(fixture.event.id, {
+      status: "attending",
+    });
+    const payment = await createTrackedPayment(attendance.id, {
+      amount: 1800,
+      method: "cash",
+      status: "received",
+    });
+
+    await arrangeActionContext(0, fixture.communityId);
+    const { adminUpdateAttendanceStatusAction } =
+      await import("@/features/events/actions/admin-update-attendance-status");
+
+    const result = await adminUpdateAttendanceStatusAction({
+      eventId: fixture.event.id,
+      attendanceId: attendance.id,
+      status: "maybe",
+      acknowledgedFinalizedPayment: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(await getAttendanceStatus(attendance.id)).toBe("maybe");
+
+    const payments = await getPayments(attendance.id);
+    expect(payments).toHaveLength(1);
+    expect(payments[0]).toEqual(payment);
+  });
+
+  test("定員超過と中止済みイベントでは出欠も支払いも変更されない", async () => {
+    const owner = setup.users[0];
+    const fullFixture = await createTrackedEvent(owner.id, {
+      fee: 1800,
+      capacity: 1,
+      payment_methods: ["cash"],
+      withPayoutProfile: false,
+      attachPayoutProfileToEvent: false,
+    });
+    await createTrackedAttendance(fullFixture.event.id, {
+      status: "attending",
+      nickname: "既存参加者",
+    });
+    const overCapacityTarget = await createTrackedAttendance(fullFixture.event.id, {
+      status: "not_attending",
+      nickname: "定員超過対象",
+    });
+
+    await arrangeActionContext(0, fullFixture.communityId);
+    const { adminUpdateAttendanceStatusAction } =
+      await import("@/features/events/actions/admin-update-attendance-status");
+
+    const capacityResult = await adminUpdateAttendanceStatusAction({
+      eventId: fullFixture.event.id,
+      attendanceId: overCapacityTarget.id,
+      status: "attending",
+      paymentMethod: "cash",
+    });
+
+    expect(capacityResult.success).toBe(true);
+    if (capacityResult.success) {
+      expect(capacityResult.data).toEqual(
+        expect.objectContaining({
+          confirmRequired: true,
+          reason: "capacity",
+        })
+      );
+    }
+    expect(await getAttendanceStatus(overCapacityTarget.id)).toBe("not_attending");
+    expect(await getPayments(overCapacityTarget.id)).toHaveLength(0);
+
+    const canceledFixture = await createTrackedEvent(owner.id, {
+      fee: 0,
+      payment_methods: [],
+      canceled_at: new Date().toISOString(),
+    });
+    const canceledAttendance = await createTrackedAttendance(canceledFixture.event.id, {
+      status: "maybe",
+    });
+
+    await arrangeActionContext(0, canceledFixture.communityId);
+    const canceledResult = await adminUpdateAttendanceStatusAction({
+      eventId: canceledFixture.event.id,
+      attendanceId: canceledAttendance.id,
+      status: "attending",
+    });
+
+    expect(canceledResult.success).toBe(false);
+    if (!canceledResult.success) {
+      expect(canceledResult.error.code).toBe("EVENT_CANCELED");
+    }
+    expect(await getAttendanceStatus(canceledAttendance.id)).toBe("maybe");
+    expect(await getPayments(canceledAttendance.id)).toHaveLength(0);
+  });
+});

--- a/tests/unit/participants/participants-table-v2.test.tsx
+++ b/tests/unit/participants/participants-table-v2.test.tsx
@@ -4,6 +4,7 @@
 const mockUpdateCashStatus = jest.fn();
 const mockBulkUpdateCashStatus = jest.fn();
 const mockDeleteMistakenAttendance = jest.fn();
+const mockAdminUpdateAttendanceStatus = jest.fn();
 const mockToast = jest.fn();
 const mockConditionalSmartSort = jest.fn((participants) => participants);
 
@@ -138,6 +139,8 @@ describe("ParticipantsTableV2", () => {
   const defaultProps = {
     eventId: "event-1",
     eventFee: 1000,
+    eventStatus: "upcoming" as const,
+    eventPaymentMethods: ["cash", "stripe"] as const,
     allParticipants: buildParticipantsArray(),
     query: {
       tab: "participants" as const,
@@ -148,6 +151,7 @@ describe("ParticipantsTableV2", () => {
       limit: 150,
     },
     onParamsChange: jest.fn(),
+    adminUpdateAttendanceStatusAction: mockAdminUpdateAttendanceStatus,
     deleteMistakenAttendanceAction: mockDeleteMistakenAttendance,
     updateCashStatusAction: mockUpdateCashStatus,
     bulkUpdateCashStatusAction: mockBulkUpdateCashStatus,
@@ -311,10 +315,9 @@ describe("ParticipantsTableV2", () => {
       expect(screen.getByText("参加者を削除")).toBeInTheDocument();
       await user.keyboard("{Escape}"); // メニューを閉じる
 
-      // テストユーザー2: 取り消し不可、かつ他にアクションがないためメニュー自体が表示されない
-      expect(
-        screen.queryByLabelText("テストユーザー2の操作メニューを開く")
-      ).not.toBeInTheDocument();
+      // テストユーザー2: 取り消し不可でも代理出欠変更は可能。削除アクションだけ表示されない
+      await user.click(screen.getByLabelText("テストユーザー2の操作メニューを開く"));
+      expect(screen.queryByText("参加者を削除")).not.toBeInTheDocument();
     });
 
     it("参加者削除失敗時はモーダル内にエラーを表示し、失敗トーストを出さない", async () => {

--- a/types/database.ts
+++ b/types/database.ts
@@ -965,7 +965,6 @@ export type Database = {
     Functions: {
       admin_add_attendance_with_capacity_check: {
         Args: {
-          p_bypass_capacity?: boolean;
           p_email: string;
           p_event_id: string;
           p_guest_token: string;
@@ -1116,7 +1115,6 @@ export type Database = {
           p_acknowledged_finalized_payment?: boolean;
           p_acknowledged_past_event?: boolean;
           p_attendance_id: string;
-          p_bypass_capacity?: boolean;
           p_event_id: string;
           p_new_status: Database["public"]["Enums"]["attendance_status_enum"];
           p_notes?: string;

--- a/types/database.ts
+++ b/types/database.ts
@@ -1111,6 +1111,20 @@ export type Database = {
         Args: { p_attendance_id: string; p_event_id: string; p_user_id: string };
         Returns: Json;
       };
+      rpc_admin_update_attendance_status: {
+        Args: {
+          p_acknowledged_finalized_payment?: boolean;
+          p_acknowledged_past_event?: boolean;
+          p_attendance_id: string;
+          p_bypass_capacity?: boolean;
+          p_event_id: string;
+          p_new_status: Database["public"]["Enums"]["attendance_status_enum"];
+          p_notes?: string;
+          p_payment_method?: Database["public"]["Enums"]["payment_method_enum"];
+          p_user_id: string;
+        };
+        Returns: Json;
+      };
       rpc_bulk_update_payment_status_safe: {
         Args: { p_notes?: string; p_payment_updates: Json; p_user_id: string };
         Returns: Json;


### PR DESCRIPTION
## 概要

イベント参加者管理画面に、主催者が参加者の出欠を代理で変更できる機能を追加しました。
あわせて、これまで主催者操作で許可していた「定員超過 bypass」を廃止し、参加者追加・出欠変更のどちらでも定員チェックを厳格に適用するようにしました。主催者権限でもデータ整合性を重視し、定員超過を許可せず先に定員を増やしてから参加者を追加するフローに変更。

これにより、主催者は参加者一覧から出欠を安全に修正できるようになり、同時に定員管理の整合性も改善されます。

## 背景

従来は、主催者が参加者を手動追加することはできても、既存参加者の出欠を一覧画面から代理変更する仕組みがありませんでした。
また、定員超過時には主催者の手動追加や一部操作で bypass できる余地があり、イベント定員の扱いが厳密ではありませんでした。

今回の変更では、
- 主催者が参加者ごとに出欠を代理変更できるようにする
- 有料イベントにおける決済状態との整合性を保つ
- 定員超過を UI / Server Action / DB の各層で一貫して防ぐ

ことを目的に対応しています。

## 変更内容

### 1. 主催者による代理出欠変更機能を追加

参加者一覧（テーブル表示 / カード表示）の各参加者メニューに「出欠を代理変更」を追加しました。

代理変更ダイアログでは以下を操作できます。
- 変更後の出欠を `参加 / 未定 / 不参加` から選択
- 有料イベントで、非参加状態から「参加」に変更する際に必要な場合は支払い方法を選択
  - `cash`
  - `stripe`

また、次のケースでは注意喚起を表示したうえで処理します。
- 開催済みイベントの出欠修正
- 既に確定済み支払いが存在する参加者の出欠修正

なお、確定済み支払いがある場合でも、この操作で返金や決済状態の変更は行わず、出欠のみを変更します。

### 2. 出欠変更用の Server Action / RPC を追加

フロントエンドから利用する `adminUpdateAttendanceStatusAction` を追加し、
DB 側では `rpc_admin_update_attendance_status` を新設しました。

この RPC では主に以下を扱います。
- イベント所有者権限の確認
- 対象 attendance の存在確認
- 中止済みイベントの変更拒否
- 開催済みイベント変更時の確認要求
- 確定済み支払いがある場合の確認要求
- 「参加」変更時の定員チェック
- 必要に応じた payment の再利用 / 新規作成 / 未確定 payment の打ち切り
- system_logs への監査ログ記録

### 3. 定員超過 bypass を廃止

主催者の手動追加フローから `bypassCapacity` を削除しました。
これにより、定員到達時は確認ダイアログ経由で強制追加するのではなく、定員変更を促すエラーとして扱います。

同様に、代理出欠変更で「参加」に変更する場合も、定員に達していれば変更できません。
定員チェックは DB 側の関数・トリガーでも `P0004` を使って一貫して扱うように整理しています。

### 4. 参加者一覧の表示・操作まわりを調整

出欠変更機能追加に伴い、参加者一覧の表示とアクション条件も見直しました。

主な変更:
- アクションメニューに代理出欠変更を追加
- テーブル表示 / カード表示の両方から同機能を利用可能に
- 決済方法の表示条件を `status === attending` ベースではなく payment 状態ベースに調整
- 決済ステータス表示も出欠状態だけで隠さないように調整
- 二次メニューの表示条件に代理出欠変更を含めるように変更

### 5. バリデーション・型定義を追加

代理出欠変更に対応するため、以下を追加しました。
- `AttendanceStatusSchema`
- `AdminUpdateAttendanceStatusInputSchema`
- `AdminUpdateAttendanceStatusResult`
- `AdminUpdateAttendanceConfirmation`
- 支払い副作用を表す `paymentEffect` 型

一方で、手動追加側からは不要になった `bypassCapacity` を削除しています。

### 6. DB / migration を追加・更新

以下の migration / schema 更新を含みます。
- `20260413001639_admin_update_attendance_status.sql`
- `20260413120000_remove_attendance_capacity_bypass.sql`
- `local_schema.sql` の更新

主なDB変更:
- `rpc_admin_update_attendance_status` の追加
- `admin_add_attendance_with_capacity_check` から bypass 引数を削除
- attendance の定員チェックをより厳格な条件で適用
- エラーコードを `P0004` などに整理
- 監査ログ出力を追加

## 影響範囲

- イベント詳細の参加者管理画面
- 主催者による参加者の手動追加
- 有料イベントの出欠変更時の payment 取り扱い
- DB の attendance / payment 関連RPC
- 定員到達時のエラーハンドリング

## 期待される挙動

- 主催者は参加者一覧から個別に出欠を代理変更できる
- 有料イベントで「参加」に戻す場合、必要に応じて支払い方法の指定が必要になる
- 確定済み支払いがある参加者は、支払いを壊さずに出欠のみ変更される
- 開催済みイベントの修正は、台帳修正として明示的に扱われる
- 定員超過時は bypass できず、定員変更を先に行う必要がある

## テスト

以下のテストを追加 / 更新しています。
- `admin-update-attendance-status.integration.test.ts`
- `admin-add-attendance.integration.test.ts`
- `participants-table-v2.test.tsx`

代理出欠変更の正常系・確認要求・定員到達時の失敗ケース・bypass 廃止後の挙動をカバーしています。


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rytkhs/event-pay/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
