### PR TITLE
feat: 記事UI刷新、決済フィルターとStripeオンボーディング設定を調整

### DIFF
--- a/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantsTableV2.tsx
+++ b/app/(app)/events/[id]/participants/components/participants-table-v2/ParticipantsTableV2.tsx
@@ -319,7 +319,9 @@ export function ParticipantsTableV2({
     // 決済方法フィルタ
     const paymentMethod = query.paymentMethod;
     if (paymentMethod) {
-      result = result.filter((p) => p.payment_method === paymentMethod);
+      result = result.filter(
+        (p) => p.payment_method === paymentMethod && p.payment_status !== "canceled"
+      );
     }
 
     // 決済ステータスフィルタ (SimplePaymentStatus)

--- a/app/(marketing)/articles/[slug]/page.tsx
+++ b/app/(marketing)/articles/[slug]/page.tsx
@@ -81,47 +81,72 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
   }
 
   return (
-    <div className="min-h-screen bg-[#f7fbfa]">
+    <div className="min-h-screen bg-slate-50">
       <JsonLd data={generateArticleJsonLd(article)} />
 
       <article>
-        <header className="border-b border-slate-200 bg-white">
-          <div className="mx-auto w-full max-w-4xl px-4 pb-10 pt-8 sm:px-6 lg:px-8 lg:pb-14 lg:pt-12">
-            <Button asChild variant="ghost" className="-ml-3 text-slate-600">
+        {/* ヘッダー */}
+        <header className="relative overflow-hidden border-b border-slate-200 bg-gradient-to-br from-primary/8 via-white to-secondary/5">
+          {/* 背景の装飾 */}
+          <div
+            className="pointer-events-none absolute -top-20 right-0 h-72 w-72 translate-x-1/3 rounded-full bg-primary/15 blur-3xl"
+            aria-hidden="true"
+          />
+          <div
+            className="pointer-events-none absolute -bottom-12 left-0 h-56 w-56 -translate-x-1/4 rounded-full bg-secondary/15 blur-3xl"
+            aria-hidden="true"
+          />
+
+          <div className="relative mx-auto w-full max-w-3xl px-4 pb-12 pt-24 sm:px-6 lg:px-8 lg:pb-16 lg:pt-28">
+            {/* 戻るリンク */}
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="-ml-2 text-slate-500 hover:text-slate-700"
+            >
               <Link href="/articles">
-                <ArrowLeft className="h-4 w-4" />
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
                 記事一覧へ
               </Link>
             </Button>
 
-            <div className="mt-8 flex flex-wrap items-center gap-3 text-sm font-medium text-slate-500">
+            {/* メタ情報 */}
+            <div className="mt-7 flex flex-wrap items-center gap-2.5 text-sm font-medium">
               {article.category ? (
-                <span className="rounded-md bg-teal-50 px-2.5 py-1 text-teal-800">
+                <span className="rounded-full bg-primary/10 px-3.5 py-1 text-sm text-primary">
                   {article.category}
                 </span>
               ) : null}
-              <span className="inline-flex items-center gap-1.5">
-                <CalendarDays className="h-4 w-4" />
+              <span className="inline-flex items-center gap-1.5 text-slate-400">
+                <CalendarDays className="h-4 w-4" aria-hidden="true" />
                 {formatArticleDate(article.publishedAt)}
               </span>
-              <span className="inline-flex items-center gap-1.5">
-                <Clock className="h-4 w-4" />
+              <span className="inline-flex items-center gap-1.5 text-slate-400">
+                <Clock className="h-4 w-4" aria-hidden="true" />
                 {article.readingMinutes}分で読めます
               </span>
             </div>
 
-            <h1 className="mt-5 text-3xl font-bold leading-tight tracking-normal text-slate-950 sm:text-5xl">
+            {/* タイトル */}
+            <h1 className="mt-5 text-3xl font-bold leading-snug tracking-tight text-slate-900 sm:text-[2.625rem]">
               {article.title}
             </h1>
+
+            {/* ディスクリプション */}
             <p className="mt-5 text-base leading-8 text-slate-600 sm:text-lg">
               {article.description}
             </p>
 
+            {/* タグ */}
             {article.tags.length > 0 ? (
-              <div className="mt-6 flex flex-wrap items-center gap-2 text-sm text-slate-500">
-                <Tags className="h-4 w-4" />
+              <div className="mt-6 flex flex-wrap items-center gap-2">
+                <Tags className="h-4 w-4 text-slate-400" aria-hidden="true" />
                 {article.tags.map((tag) => (
-                  <span key={tag} className="rounded-md border border-slate-200 px-2.5 py-1">
+                  <span
+                    key={tag}
+                    className="rounded-full border border-slate-200 bg-white px-3 py-0.5 text-xs text-slate-500"
+                  >
                     {tag}
                   </span>
                 ))}
@@ -130,26 +155,50 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
           </div>
         </header>
 
-        <div className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+        {/* 本文エリア */}
+        <div className="mx-auto w-full max-w-3xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+          {/* Markdown 本文 */}
           <div
-            className="prose prose-slate max-w-none prose-headings:font-bold prose-headings:tracking-normal prose-h2:mt-12 prose-h2:border-l-4 prose-h2:border-teal-300 prose-h2:pl-4 prose-p:leading-8 prose-a:text-teal-700 prose-a:no-underline hover:prose-a:underline prose-li:leading-8"
+            className={[
+              "prose prose-slate max-w-none",
+              // 見出し
+              "prose-headings:font-bold prose-headings:tracking-tight",
+              "prose-h2:mt-14 prose-h2:border-l-[3px] prose-h2:border-primary prose-h2:pl-4 prose-h2:text-2xl",
+              "prose-h3:mt-8 prose-h3:text-xl",
+              // 段落・リスト
+              "prose-p:leading-8 prose-li:leading-8",
+              // リンク
+              "prose-a:font-medium prose-a:text-primary prose-a:no-underline hover:prose-a:underline",
+              // 引用
+              "prose-blockquote:border-l-primary/50 prose-blockquote:bg-primary/5 prose-blockquote:py-0.5 prose-blockquote:text-slate-600",
+              // コード
+              "prose-code:rounded prose-code:bg-slate-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-slate-800 prose-code:before:content-none prose-code:after:content-none",
+              "prose-pre:rounded-xl prose-pre:bg-slate-900 prose-pre:shadow-md",
+            ].join(" ")}
             dangerouslySetInnerHTML={{ __html: article.html }}
           />
 
-          <aside className="mt-14 rounded-lg border border-teal-200 bg-white p-6 shadow-sm">
-            <p className="text-sm font-semibold text-teal-800">みんなの集金</p>
-            <h2 className="mt-2 text-2xl font-bold tracking-normal text-slate-950">
-              次のイベントから、出欠と集金を同じ一覧で管理する。
-            </h2>
-            <p className="mt-3 text-sm leading-7 text-slate-600">
-              招待リンクを共有するだけで参加表明を集め、オンライン決済と現金集金をまとめて確認できます。
-            </p>
-            <Button asChild className="mt-5">
-              <Link href="/start-demo">
-                無料でイベントを作成する
-                <ArrowUpRight className="h-4 w-4" />
-              </Link>
-            </Button>
+          {/* 記事末 CTA */}
+          <aside className="mt-16 overflow-hidden rounded-2xl border border-primary/20 bg-gradient-to-br from-primary/8 via-white to-secondary/5 shadow-sm">
+            <div className="p-8">
+              <p className="text-xs font-bold uppercase tracking-widest text-primary">
+                みんなの集金
+              </p>
+              <h2 className="mt-3 text-2xl font-bold leading-snug tracking-tight text-slate-900">
+                次のイベントから、出欠と集金を
+                <br />
+                同じ一覧で管理する。
+              </h2>
+              <p className="mt-3 text-sm leading-7 text-slate-600">
+                招待リンクを共有するだけで参加表明を集め、オンライン決済と現金集金をまとめて確認できます。
+              </p>
+              <Button asChild className="mt-6">
+                <Link href="/start-demo">
+                  無料でイベントを作成する
+                  <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
+            </div>
           </aside>
         </div>
       </article>

--- a/app/(marketing)/articles/page.tsx
+++ b/app/(marketing)/articles/page.tsx
@@ -35,68 +35,95 @@ export default async function ArticlesPage() {
   const articles = await getPublishedArticles();
 
   return (
-    <div className="min-h-screen bg-[#f7fbfa]">
-      <section className="border-b border-slate-200 bg-white">
-        <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 pb-12 pt-14 sm:px-6 lg:grid-cols-[1.1fr_0.9fr] lg:px-8 lg:pb-16 lg:pt-20">
-          <div>
-            <div className="inline-flex items-center gap-2 rounded-md border border-teal-200 bg-teal-50 px-3 py-1 text-sm font-medium text-teal-800">
-              <BookOpenText className="h-4 w-4" />
-              集金と運営の実践ノート
+    <div className="min-h-screen bg-slate-50">
+      {/* Hero */}
+      <section className="relative overflow-hidden bg-gradient-to-br from-primary/8 via-white to-secondary/5 border-b border-slate-200">
+        {/* 背景の装飾 */}
+        <div
+          className="pointer-events-none absolute -top-24 right-0 h-80 w-80 translate-x-1/3 rounded-full bg-primary/15 blur-3xl"
+          aria-hidden="true"
+        />
+        <div
+          className="pointer-events-none absolute -bottom-16 left-0 h-64 w-64 -translate-x-1/4 rounded-full bg-secondary/15 blur-3xl"
+          aria-hidden="true"
+        />
+
+        <div className="relative mx-auto w-full max-w-7xl px-4 pb-14 pt-24 sm:px-6 lg:px-8 lg:pb-20 lg:pt-28">
+          <div className="flex flex-col items-start gap-5">
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/8 px-4 py-1.5 text-sm font-semibold text-primary">
+              <BookOpenText className="h-4 w-4" aria-hidden="true" />
+              実践ガイド
             </div>
-            <h1 className="mt-6 text-4xl font-bold tracking-normal text-slate-950 sm:text-5xl">
-              イベント集金を、手作業から仕組みに変える。
+            <h1 className="text-4xl font-bold leading-tight tracking-tight text-slate-900 sm:text-5xl">
+              コミュニティ運営を
+              <br className="hidden sm:block" />
+              もっとラクにする記事
             </h1>
-            <p className="mt-5 max-w-2xl text-base leading-8 text-slate-600 sm:text-lg">
-              サークル、勉強会、同窓会などの小規模イベントで起きやすい出欠確認・未払い管理・現金集金の悩みを、実務目線で整理します。
+            <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+              クローズドコミュニティの出欠管理・イベント集金・現金管理をラクにするための実践的なヒントをお届けします。
             </p>
-          </div>
-          <div className="self-end border-l-4 border-amber-300 bg-amber-50 px-5 py-5 text-sm leading-7 text-slate-700">
-            幹事や会計担当者が、次のイベントからすぐ見直せる運用を中心にまとめています。
-            参加者に負担をかけず、管理側の確認作業を減らすことを重視しています。
           </div>
         </div>
       </section>
 
-      <section className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+      {/* 記事一覧 */}
+      <section className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
         {articles.length > 0 ? (
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-6 md:grid-cols-2">
             {articles.map((article) => (
               <article
                 key={article.slug}
-                className="group relative rounded-lg border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-teal-300 hover:shadow-md"
+                className="group relative flex flex-col rounded-2xl border border-slate-200 bg-white p-7 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:border-primary/40 hover:shadow-md"
               >
-                <div className="flex flex-wrap items-center gap-3 text-xs font-medium text-slate-500">
+                {/* メタ情報 */}
+                <div className="flex flex-wrap items-center gap-2.5 text-xs font-medium">
                   {article.category ? (
-                    <span className="rounded-md bg-teal-50 px-2 py-1 text-teal-800">
+                    <span className="rounded-full bg-primary/10 px-3 py-1 text-primary">
                       {article.category}
                     </span>
                   ) : null}
-                  <span className="inline-flex items-center gap-1">
-                    <CalendarDays className="h-3.5 w-3.5" />
+                  <span className="inline-flex items-center gap-1 text-slate-400">
+                    <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
                     {formatArticleDate(article.publishedAt)}
                   </span>
-                  <span className="inline-flex items-center gap-1">
-                    <Clock className="h-3.5 w-3.5" />
+                  <span className="inline-flex items-center gap-1 text-slate-400">
+                    <Clock className="h-3.5 w-3.5" aria-hidden="true" />
                     {article.readingMinutes}分
                   </span>
                 </div>
-                <h2 className="mt-4 text-xl font-bold leading-8 text-slate-950">
+
+                {/* タイトル */}
+                <h2 className="mt-4 text-xl font-bold leading-snug text-slate-900">
                   <Link href={article.path} className="focus-visible:outline-none">
-                    <span className="absolute inset-0" aria-hidden="true" />
+                    {/* カード全体をクリック可能に */}
+                    <span className="absolute inset-0 rounded-2xl" aria-hidden="true" />
                     {article.title}
                   </Link>
                 </h2>
-                <p className="mt-3 text-sm leading-7 text-slate-600">{article.description}</p>
-                <div className="relative mt-5 inline-flex items-center gap-2 text-sm font-semibold text-teal-700">
+
+                {/* 概要 */}
+                <p className="mt-3 flex-1 text-sm leading-7 text-slate-500">
+                  {article.description}
+                </p>
+
+                {/* 読む CTA */}
+                <div className="relative mt-6 inline-flex items-center gap-1.5 text-sm font-semibold text-primary">
                   記事を読む
-                  <ArrowUpRight className="h-4 w-4 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                  <ArrowUpRight
+                    className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                    aria-hidden="true"
+                  />
                 </div>
               </article>
             ))}
           </div>
         ) : (
-          <div className="rounded-lg border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
-            公開中の記事はまだありません。
+          <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center">
+            <BookOpenText className="mx-auto mb-4 h-10 w-10 text-slate-300" aria-hidden="true" />
+            <p className="text-base font-medium text-slate-500">公開中の記事はまだありません。</p>
+            <p className="mt-1 text-sm text-slate-400">
+              近日公開予定です。しばらくお待ちください。
+            </p>
           </div>
         )}
       </section>

--- a/features/stripe-connect/actions/connect-account.ts
+++ b/features/stripe-connect/actions/connect-account.ts
@@ -507,7 +507,6 @@ export async function handleOnboardingRefreshAction(intent?: string): Promise<vo
       refreshUrl,
       returnUrl,
       type: "account_onboarding",
-      collectionOptions: { fields: "eventually_due" },
     });
     redirect(accountLink.url);
   } catch (error) {
@@ -716,7 +715,6 @@ export async function startOnboardingAction(
       refreshUrl,
       returnUrl,
       type: "account_onboarding",
-      collectionOptions: { fields: "eventually_due" },
     });
 
     // 6. ログ記録

--- a/features/stripe-connect/services/service.ts
+++ b/features/stripe-connect/services/service.ts
@@ -375,14 +375,17 @@ export class StripeConnectService implements IStripeConnectService {
         type: type as "account_onboarding" | "account_update",
       };
 
-      // Collection Optionsが指定されている場合は追加
-      if (validatedParams.collectionOptions) {
-        // Stripeの型定義では fields が必須のため、デフォルト値を "eventually_due" に統一（アップフロント収集）
+      // Collection Optionsが明示指定されている場合のみ追加する
+      if (
+        validatedParams.collectionOptions?.fields ||
+        validatedParams.collectionOptions?.futureRequirements
+      ) {
+        // Stripeの型定義では fields が必須のため、未指定時はStripeのデフォルトと同じ currently_due を使う
         const collectionOptions: Stripe.AccountLinkCreateParams.CollectionOptions = {
-          fields: validatedParams.collectionOptions.fields ?? "eventually_due",
+          fields: validatedParams.collectionOptions.fields ?? "currently_due",
         };
 
-        if (validatedParams.collectionOptions.futureRequirements) {
+        if (validatedParams.collectionOptions?.futureRequirements) {
           collectionOptions.future_requirements =
             validatedParams.collectionOptions.futureRequirements;
         }

--- a/tests/unit/participants/participants-table-v2.test.tsx
+++ b/tests/unit/participants/participants-table-v2.test.tsx
@@ -195,6 +195,75 @@ describe("ParticipantsTableV2", () => {
     });
   });
 
+  describe("フィルター", () => {
+    it("決済方法フィルターでは canceled の支払いを除外し、不参加でも会計処理済みの支払いは表示する", () => {
+      const participants: ParticipantView[] = [
+        {
+          ...buildParticipantsArray(2)[0],
+          attendance_id: "att-cash-pending",
+          nickname: "現金未集金",
+          payment_id: "pay-cash-pending",
+          payment_method: "cash",
+          payment_status: "pending",
+          status: "attending",
+        },
+        {
+          ...buildParticipantsArray(2)[0],
+          attendance_id: "att-cash-canceled",
+          nickname: "現金キャンセル",
+          payment_id: "pay-cash-canceled",
+          payment_method: "cash",
+          payment_status: "canceled",
+          status: "not_attending",
+        },
+        {
+          ...buildParticipantsArray(2)[0],
+          attendance_id: "att-cash-received-not-attending",
+          nickname: "不参加現金受領済み",
+          payment_id: "pay-cash-received-not-attending",
+          payment_method: "cash",
+          payment_status: "received",
+          status: "not_attending",
+        },
+      ];
+
+      render(
+        <ParticipantsTableV2
+          {...defaultProps}
+          allParticipants={participants}
+          query={{
+            ...defaultProps.query,
+            paymentMethod: "cash",
+          }}
+        />
+      );
+
+      expect(screen.getByText("2名を表示中")).toBeInTheDocument();
+      expect(screen.getByText("現金未集金")).toBeInTheDocument();
+      expect(screen.getByText("不参加現金受領済み")).toBeInTheDocument();
+      expect(screen.queryByText("現金キャンセル")).not.toBeInTheDocument();
+    });
+
+    it("決済方法フィルターなしでは canceled の支払いを持つ参加者も一覧に残す", () => {
+      const participants: ParticipantView[] = [
+        {
+          ...buildParticipantsArray(2)[0],
+          attendance_id: "att-cash-canceled",
+          nickname: "現金キャンセル",
+          payment_id: "pay-cash-canceled",
+          payment_method: "cash",
+          payment_status: "canceled",
+          status: "not_attending",
+        },
+      ];
+
+      render(<ParticipantsTableV2 {...defaultProps} allParticipants={participants} />);
+
+      expect(screen.getByText("1名を表示中")).toBeInTheDocument();
+      expect(screen.getByText("現金キャンセル")).toBeInTheDocument();
+    });
+  });
+
   describe("ソート機能", () => {
     it("ニックネーム列でソートできる", async () => {
       const user = userEvent.setup();


### PR DESCRIPTION
## 概要

記事一覧・記事詳細ページのUIを刷新し、あわせて参加者一覧の決済方法フィルターとStripe ConnectのAccount Link作成処理を調整しました。

## 変更内容

- 記事一覧ページ・記事詳細ページのデザインを刷新
  - Hero、記事カード、本文スタイル、記事末CTA、空状態のUIを改善
- 参加者一覧の決済方法フィルターを修正
  - `payment_status === "canceled"` の支払いを除外
  - 決済方法フィルター未指定時は従来通りcanceledの参加者も表示
- 上記フィルター挙動のユニットテストを追加
- Stripe Account Link作成時の`collectionOptions`指定を調整
  - `eventually_due`の明示指定を削除
  - `collectionOptions`は明示指定がある場合のみ付与
  - 未指定時のデフォルトを`currently_due`に変更

## 確認観点

- 記事一覧・記事詳細ページの表示崩れがないこと
- 決済方法フィルター適用時にcanceledの支払いが除外されること
- 決済方法フィルター未指定時にcanceledの参加者が一覧に残ること
- Stripe Connectのオンボーディングリンク作成が正常に行えること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rytkhs/event-pay/pull/443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
