### PR TITLE
fix: LINEログインキャンセル時の扱いとGA向けCSP設定を修正

### DIFF
--- a/app/auth/callback/line/route.ts
+++ b/app/auth/callback/line/route.ts
@@ -15,6 +15,8 @@ import { LineTokenResponse, LineVerifyResponse } from "@/types/line";
 
 export const dynamic = "force-dynamic";
 
+const LINE_ACCESS_DENIED_ERROR = "ACCESS_DENIED";
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
@@ -31,6 +33,10 @@ export async function GET(request: Request) {
 
   // 1. エラーハンドリングとCSRF検証
   if (error) {
+    if (error.toUpperCase() === LINE_ACCESS_DENIED_ERROR) {
+      return NextResponse.redirect(`${origin}/login?error=${LINE_ERROR_CODES.CANCELLED}`);
+    }
+
     handleServerError("LINE_LOGIN_ERROR", {
       category: "authentication",
       action: "line_auth_callback_error_param",

--- a/core/auth/line-constants.ts
+++ b/core/auth/line-constants.ts
@@ -28,6 +28,7 @@ export const LINE_OAUTH_CONFIG = {
 export const LINE_ERROR_CODES = {
   CONFIG_ERROR: "line_config_error",
   AUTH_FAILED: "line_auth_failed",
+  CANCELLED: "line_auth_cancelled",
   STATE_MISMATCH: "line_state_mismatch",
   TOKEN_FAILED: "line_token_failed",
   EMAIL_REQUIRED: "line_email_required",

--- a/core/auth/line-error-messages.ts
+++ b/core/auth/line-error-messages.ts
@@ -8,6 +8,7 @@ export const LINE_ERROR_MESSAGES: Record<string, string> = {
   [LINE_ERROR_CODES.EMAIL_REQUIRED]:
     "メールアドレスが取得できませんでした。ログインをやり直してメールアドレスの提供を許可してください。",
   [LINE_ERROR_CODES.AUTH_FAILED]: "LINE認証に失敗しました。もう一度お試しください。",
+  [LINE_ERROR_CODES.CANCELLED]: "LINEログインがキャンセルされました。",
   [LINE_ERROR_CODES.STATE_MISMATCH]: "セキュリティ検証に失敗しました。もう一度お試しください。",
   [LINE_ERROR_CODES.TOKEN_FAILED]: "LINE認証トークンの取得に失敗しました。もう一度お試しください。",
   [LINE_ERROR_CODES.SERVER_ERROR]:

--- a/core/security/csp.ts
+++ b/core/security/csp.ts
@@ -37,7 +37,11 @@ export const ALLOWED_ORIGINS = {
 
   /** Google Tag Manager / Analytics */
   gtm: ["https://*.googletagmanager.com"],
-  ga: ["https://*.google-analytics.com", "https://*.analytics.google.com"],
+  ga: [
+    "https://*.google-analytics.com",
+    "https://*.analytics.google.com",
+    "https://www.google.com",
+  ],
 
   /** Google Maps */
   maps: [

--- a/tests/unit/auth/line-login.test.ts
+++ b/tests/unit/auth/line-login.test.ts
@@ -12,11 +12,16 @@ const mockCookies = {
 const mockHeaders = {
   get: jest.fn(),
 };
+const mockHandleServerError = jest.fn();
 const originalEnv = process.env;
 
 jest.mock("next/headers", () => ({
   cookies: () => mockCookies,
   headers: () => mockHeaders,
+}));
+
+jest.mock("@core/utils/error-handler.server", () => ({
+  handleServerError: (...args: unknown[]) => mockHandleServerError(...args),
 }));
 
 // ロガーのモック
@@ -162,13 +167,31 @@ describe("LINE Login Auth Flow", () => {
       global.fetch = jest.fn();
     });
 
-    it("should redirect to error page if error param exists", async () => {
+    it("should redirect to cancelled message without error logging if access is denied", async () => {
       const request = new Request("http://localhost:3000/auth/callback/line?error=access_denied");
       const response = await authCallbackLineGet(request);
 
       expect(response.status).toBe(307);
       expect(response.headers.get("Location")).toBe(
+        "http://localhost:3000/login?error=line_auth_cancelled"
+      );
+      expect(mockHandleServerError).not.toHaveBeenCalled();
+    });
+
+    it("should redirect to error page if unexpected error param exists", async () => {
+      const request = new Request("http://localhost:3000/auth/callback/line?error=invalid_request");
+      const response = await authCallbackLineGet(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get("Location")).toBe(
         "http://localhost:3000/login?error=line_auth_failed"
+      );
+      expect(mockHandleServerError).toHaveBeenCalledWith(
+        "LINE_LOGIN_ERROR",
+        expect.objectContaining({
+          action: "line_auth_callback_error_param",
+          additionalData: { error: "invalid_request" },
+        })
       );
     });
 

--- a/tests/unit/auth/login-page.test.tsx
+++ b/tests/unit/auth/login-page.test.tsx
@@ -120,6 +120,21 @@ describe("Login Page - LINE Error Display", () => {
     ).toBeInTheDocument();
   });
 
+  it("should display LINE cancelled message", async () => {
+    mockUseSearchParams.mockReturnValue({
+      get: (key: string) => {
+        if (key === "error") return "line_auth_cancelled";
+        if (key === "redirectTo") return null;
+        return null;
+      },
+    });
+
+    const LoginPage = (await import("@/app/(auth)/login/page")).default;
+    render(<LoginPage />);
+
+    expect(await screen.findByText("LINEログインがキャンセルされました。")).toBeInTheDocument();
+  });
+
   it("should display LINE state mismatch error message", async () => {
     mockUseSearchParams.mockReturnValue({
       get: (key: string) => {

--- a/tests/unit/core/security/csp.test.ts
+++ b/tests/unit/core/security/csp.test.ts
@@ -100,6 +100,15 @@ describe("buildCsp", () => {
       expect(csp).toContain("https://maps.googleapis.com");
     });
 
+    test("Google Analyticsの送信先がconnect-srcに含まれる", () => {
+      const csp = buildCsp({ mode: "static" });
+      const connectSrc = csp.split(";").find((s) => s.trim().startsWith("connect-src "));
+
+      ALLOWED_ORIGINS.ga.forEach((origin) => {
+        expect(connectSrc).toContain(origin);
+      });
+    });
+
     test("レポート設定が含まれる", () => {
       const csp = buildCsp({ mode: "static" });
 


### PR DESCRIPTION
## 概要

LINEログインでユーザーが認可をキャンセルした場合のエラーハンドリングを改善し、通常の認証失敗とは別のメッセージを表示するようにしました。
また、Google Analytics 関連の CSP violation を解消するため、`connect-src` の許可オリジンを追加しました。

## 変更内容

* LINE認証コールバックで `ACCESS_DENIED` を検知した場合、`line_auth_cancelled` としてログイン画面へリダイレクト
* LINEログインキャンセル時の表示メッセージを追加
* 想定外のLINE認証エラーは従来どおり `LINE_LOGIN_ERROR` として記録
* Google Analytics 用の許可オリジンに `https://www.google.com` を追加
* 上記挙動を検証するユニットテストを追加

## テスト

* LINEログインキャンセル時に専用メッセージが表示されること
* `ACCESS_DENIED` の場合はサーバーエラーとして記録されないこと
* 想定外のLINE認証エラーは記録されること
* Google Analytics の送信先が CSP の `connect-src` に含まれること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rytkhs/event-pay/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
