### PR TITLE
feat: お知らせページ基盤追加とイベント作成・編集UIを改善

### DIFF
--- a/app/(app)/events/[id]/edit/components/EventDangerZone.tsx
+++ b/app/(app)/events/[id]/edit/components/EventDangerZone.tsx
@@ -73,29 +73,31 @@ export function EventDangerZone({ eventId, eventTitle, eventStatus }: EventDange
   const showCancelButton = eventStatus !== "canceled";
 
   return (
-    <Card className="border-destructive/50 bg-destructive/5">
-      <CardHeader>
+    <Card className="overflow-hidden rounded-lg border border-destructive/30 bg-destructive/5 shadow-none">
+      <CardHeader className="border-b border-destructive/20 bg-background/50 p-4 sm:p-5">
         <div className="flex items-center gap-2">
           <AlertTriangle className="h-5 w-5 text-destructive" />
-          <CardTitle className="text-destructive">イベントを中止する</CardTitle>
+          <CardTitle className="text-base font-semibold text-destructive md:text-lg">
+            危険な操作
+          </CardTitle>
         </div>
-        <CardDescription>
+        <CardDescription className="text-sm">
           以下の操作は取り消すことができません。慎重に実行してください。
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
+      <CardContent className="flex flex-col gap-3 p-4 sm:p-5">
         {showCancelButton && (
-          <div className="flex items-start justify-between gap-4 p-4 rounded-lg border border-border bg-background">
-            <div className="flex-1">
-              <h3 className="font-semibold text-sm mb-1">イベントを中止する</h3>
+          <div className="flex flex-col gap-4 rounded-lg border border-border bg-background p-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 flex-1">
+              <h3 className="mb-1 text-sm font-semibold">イベントを中止する</h3>
               <p className="text-sm text-muted-foreground">
                 参加者の決済リンクが無効になり、イベントは「キャンセル」ステータスになります。
               </p>
             </div>
             <Dialog open={isCancelDialogOpen} onOpenChange={setCancelDialogOpen}>
               <DialogTrigger asChild>
-                <Button variant="destructive" size="sm" className="flex-shrink-0">
-                  <Trash2 className="h-4 w-4 mr-1.5" />
+                <Button variant="destructive" size="sm" className="w-full flex-shrink-0 sm:w-auto">
+                  <Trash2 className="mr-1.5 h-4 w-4" />
                   中止する
                 </Button>
               </DialogTrigger>
@@ -127,9 +129,9 @@ export function EventDangerZone({ eventId, eventTitle, eventStatus }: EventDange
           </div>
         )}
 
-        <div className="flex items-start justify-between gap-4 p-4 rounded-lg border border-border bg-background">
-          <div className="flex-1">
-            <h3 className="font-semibold text-sm mb-1">イベントを削除する</h3>
+        <div className="flex flex-col gap-4 rounded-lg border border-border bg-background p-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 flex-1">
+            <h3 className="mb-1 text-sm font-semibold">イベントを削除する</h3>
             <p className="text-sm text-muted-foreground">
               イベントがデータベースから完全に削除されます。すでに参加者や決済が存在するイベントは削除できません。
             </p>
@@ -139,9 +141,9 @@ export function EventDangerZone({ eventId, eventTitle, eventStatus }: EventDange
               <Button
                 variant="outline"
                 size="sm"
-                className="flex-shrink-0 border-destructive text-destructive hover:bg-destructive hover:text-destructive-foreground"
+                className="w-full flex-shrink-0 border-destructive text-destructive hover:bg-destructive hover:text-destructive-foreground sm:w-auto"
               >
-                <Trash2 className="h-4 w-4 mr-1.5" />
+                <Trash2 className="mr-1.5 h-4 w-4" />
                 削除する
               </Button>
             </DialogTrigger>

--- a/app/(app)/events/[id]/edit/components/EventDangerZone.tsx
+++ b/app/(app)/events/[id]/edit/components/EventDangerZone.tsx
@@ -78,7 +78,7 @@ export function EventDangerZone({ eventId, eventTitle, eventStatus }: EventDange
         <div className="flex items-center gap-2">
           <AlertTriangle className="h-5 w-5 text-destructive" />
           <CardTitle className="text-base font-semibold text-destructive md:text-lg">
-            危険な操作
+            イベントの中止
           </CardTitle>
         </div>
         <CardDescription className="text-sm">

--- a/app/(app)/events/[id]/edit/page.tsx
+++ b/app/(app)/events/[id]/edit/page.tsx
@@ -148,25 +148,19 @@ export default async function EventEditPage(props: EventEditPageProps) {
   const canUseOnlinePayments = payoutResolution.isReady;
 
   return (
-    <div className="min-h-screen bg-muted/30 py-8">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-12">
-        <div className="space-y-6">
-          {/* 編集フォーム（シングルページ版） */}
-          <SinglePageEventEditForm
-            event={eventForForm}
-            attendeeCount={attendeeCount}
-            hasStripePaid={hasStripePaid}
-            canUseOnlinePayments={canUseOnlinePayments}
-            updateEventAction={updateEventAction}
-          />
+    <div className="min-h-screen bg-muted/30">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-3 pb-28 pt-3 sm:gap-6 sm:px-6 sm:pb-32 lg:px-8 lg:pt-8">
+        {/* 編集フォーム（シングルページ版） */}
+        <SinglePageEventEditForm
+          event={eventForForm}
+          attendeeCount={attendeeCount}
+          hasStripePaid={hasStripePaid}
+          canUseOnlinePayments={canUseOnlinePayments}
+          updateEventAction={updateEventAction}
+        />
 
-          {/* 危険な操作（削除・中止） */}
-          <EventDangerZone
-            eventId={eventId}
-            eventTitle={event.title}
-            eventStatus={computedStatus}
-          />
-        </div>
+        {/* 危険な操作（削除・中止） */}
+        <EventDangerZone eventId={eventId} eventTitle={event.title} eventStatus={computedStatus} />
       </div>
     </div>
   );

--- a/app/(app)/events/create/page.tsx
+++ b/app/(app)/events/create/page.tsx
@@ -31,15 +31,13 @@ export default async function CreateEventPage() {
   const canUseOnlinePayments = payoutResolution.isReady;
 
   return (
-    <div className="min-h-screen ">
-      <div className="container mx-auto">
-        <SinglePageEventForm
-          canUseOnlinePayments={canUseOnlinePayments}
-          connectStatus={connectStatus}
-          currentCommunityName={currentCommunity.name}
-          createEventAction={createEventAction}
-        />
-      </div>
+    <div className="min-h-screen bg-muted/30">
+      <SinglePageEventForm
+        canUseOnlinePayments={canUseOnlinePayments}
+        connectStatus={connectStatus}
+        currentCommunityName={currentCommunity.name}
+        createEventAction={createEventAction}
+      />
     </div>
   );
 }

--- a/app/(marketing)/_components/HeroSection.tsx
+++ b/app/(marketing)/_components/HeroSection.tsx
@@ -25,9 +25,9 @@ export const HeroSection: React.FC = () => {
           {/* Text Content */}
           <div className="md:w-5/12 text-center md:text-left">
             <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-slate-800 leading-snug mb-6">
-              出欠確認から集金まで、
+              出欠確認から<span className="">集金</span>まで、
               <br />
-              リンク1本でまとめて管理。
+              <span className="text-[#24A6B5]">リンク1本でまとめて管理。</span>
             </h1>
 
             <FadeIn delay={0.3} className="w-full">

--- a/app/(marketing)/_components/HeroSection.tsx
+++ b/app/(marketing)/_components/HeroSection.tsx
@@ -27,7 +27,11 @@ export const HeroSection: React.FC = () => {
             <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-slate-800 leading-snug mb-6">
               出欠確認から集金まで、
               <br />
-              リンク1本でまとめて管理。
+              <span className="text-[#04a6b8ef]">
+                リンク1本で
+                <br className="md:hidden" />
+                まとめて管理。
+              </span>
             </h1>
 
             <FadeIn delay={0.3} className="w-full">

--- a/app/(marketing)/_components/HeroSection.tsx
+++ b/app/(marketing)/_components/HeroSection.tsx
@@ -12,7 +12,7 @@ export const HeroSection: React.FC = () => {
     <section className="relative pt-32 pb-20 md:pt-40 md:pb-32 overflow-hidden bg-gradient-to-br from-primary/5 via-white to-secondary/5">
       {/* Decorative Background Shapes */}
       <div
-        className="absolute top-0 right-0 -translate-y-12 translate-x-1/3 w-96 h-96 bg-primary/20 rounded-full blur-3xl"
+        className="absolute top-0 right-0 -translate-y-12 translate-x-1/3 w-96 h-96 bg-primary/15 rounded-full blur-3xl"
         aria-hidden="true"
       ></div>
       <div
@@ -25,9 +25,9 @@ export const HeroSection: React.FC = () => {
           {/* Text Content */}
           <div className="md:w-5/12 text-center md:text-left">
             <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-slate-800 leading-snug mb-6">
-              出欠確認から<span className="">集金</span>まで、
+              出欠確認から集金まで、
               <br />
-              <span className="text-[#24A6B5]">リンク1本でまとめて管理。</span>
+              リンク1本でまとめて管理。
             </h1>
 
             <FadeIn delay={0.3} className="w-full">

--- a/app/(marketing)/announcements/[slug]/page.tsx
+++ b/app/(marketing)/announcements/[slug]/page.tsx
@@ -27,6 +27,7 @@ function formatAnnouncementDate(date: string): string {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "Asia/Tokyo",
   }).format(new Date(`${date}T00:00:00+09:00`));
 }
 

--- a/app/(marketing)/announcements/[slug]/page.tsx
+++ b/app/(marketing)/announcements/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { ArrowLeft, ArrowUpRight, CalendarDays, Clock, Tags } from "lucide-react";
+import { ArrowLeft, CalendarDays } from "lucide-react";
 import type { Metadata } from "next";
 
 import {
@@ -9,16 +9,10 @@ import {
   getPublishedAnnouncementBySlug,
 } from "@core/announcements/announcement.repository";
 import { generateAnnouncementJsonLd } from "@core/announcements/announcement.seo";
-import type {
-  AnnouncementAudience,
-  AnnouncementImportance,
-  AnnouncementType,
-} from "@core/announcements/announcement.types";
 import { getPublicUrl, siteName, siteOgImage } from "@core/seo/metadata";
 
 import { JsonLd } from "@components/seo/JsonLd";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 export const dynamic = "force-static";
@@ -28,45 +22,12 @@ type AnnouncementPageProps = {
   params: Promise<{ slug: string }>;
 };
 
-const announcementTypeLabels: Record<AnnouncementType, string> = {
-  pricing: "料金",
-  feature: "機能",
-  maintenance: "メンテナンス",
-  legal: "規約",
-  incident: "障害",
-  other: "その他",
-};
-
-const announcementImportanceLabels: Record<AnnouncementImportance, string> = {
-  normal: "通常",
-  important: "重要",
-  critical: "緊急",
-};
-
-const announcementAudienceLabels: Record<AnnouncementAudience, string> = {
-  organizer: "主催者",
-  participant: "参加者",
-  all: "すべてのユーザー",
-};
-
 function formatAnnouncementDate(date: string): string {
   return new Intl.DateTimeFormat("ja-JP", {
     year: "numeric",
     month: "long",
     day: "numeric",
   }).format(new Date(`${date}T00:00:00+09:00`));
-}
-
-function getImportanceBadgeVariant(importance: AnnouncementImportance) {
-  if (importance === "critical") {
-    return "destructive" as const;
-  }
-
-  if (importance === "important") {
-    return "default" as const;
-  }
-
-  return "secondary" as const;
 }
 
 export async function generateStaticParams() {
@@ -120,9 +81,8 @@ export default async function AnnouncementPage({ params }: AnnouncementPageProps
       <JsonLd data={generateAnnouncementJsonLd(announcement)} />
 
       <article>
-        <header className="relative overflow-hidden border-b border-slate-200 bg-white">
-          <div className="absolute inset-x-0 top-0 h-1 bg-primary" aria-hidden="true" />
-          <div className="relative mx-auto w-full max-w-3xl px-4 pb-12 pt-24 sm:px-6 lg:px-8 lg:pb-16 lg:pt-28">
+        <header className="border-b border-slate-200 bg-white">
+          <div className="mx-auto w-full max-w-3xl px-4 pb-10 pt-24 sm:px-6 lg:px-8 lg:pb-12 lg:pt-28">
             <Button
               asChild
               variant="ghost"
@@ -135,22 +95,12 @@ export default async function AnnouncementPage({ params }: AnnouncementPageProps
               </Link>
             </Button>
 
-            <div className="mt-7 flex flex-wrap items-center gap-2.5 text-sm font-medium">
-              <Badge variant={getImportanceBadgeVariant(announcement.importance)}>
-                {announcementImportanceLabels[announcement.importance]}
-              </Badge>
-              <Badge variant="outline">{announcementTypeLabels[announcement.type]}</Badge>
-              <span className="inline-flex items-center gap-1.5 text-slate-400">
-                <CalendarDays className="h-4 w-4" aria-hidden="true" />
-                {formatAnnouncementDate(announcement.publishedAt)}
-              </span>
-              <span className="inline-flex items-center gap-1.5 text-slate-400">
-                <Clock className="h-4 w-4" aria-hidden="true" />
-                {announcement.readingMinutes}分で読めます
-              </span>
-            </div>
+            <p className="mt-8 inline-flex items-center gap-1.5 text-sm text-slate-500">
+              <CalendarDays className="h-4 w-4" aria-hidden="true" />
+              {formatAnnouncementDate(announcement.publishedAt)}
+            </p>
 
-            <h1 className="mt-5 text-3xl font-bold leading-snug tracking-tight text-slate-900 sm:text-[2.625rem]">
+            <h1 className="mt-5 text-2xl font-semibold leading-snug tracking-tight text-slate-900 sm:text-3xl">
               {announcement.title}
             </h1>
 
@@ -158,36 +108,15 @@ export default async function AnnouncementPage({ params }: AnnouncementPageProps
               {announcement.description}
             </p>
 
-            <dl className="mt-7 grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-5 text-sm sm:grid-cols-2">
-              {announcement.effectiveAt ? (
+            {announcement.effectiveAt ? (
+              <dl className="mt-7 border-l-2 border-slate-300 pl-4 text-sm">
                 <div>
                   <dt className="font-semibold text-slate-500">適用開始日</dt>
                   <dd className="mt-1 font-medium text-slate-900">
                     {formatAnnouncementDate(announcement.effectiveAt)}
                   </dd>
                 </div>
-              ) : null}
-              {announcement.audience.length > 0 ? (
-                <div>
-                  <dt className="font-semibold text-slate-500">対象</dt>
-                  <dd className="mt-1 font-medium text-slate-900">
-                    {announcement.audience
-                      .map((audience) => announcementAudienceLabels[audience])
-                      .join("、")}
-                  </dd>
-                </div>
-              ) : null}
-            </dl>
-
-            {announcement.tags.length > 0 ? (
-              <div className="mt-6 flex flex-wrap items-center gap-2">
-                <Tags className="h-4 w-4 text-slate-400" aria-hidden="true" />
-                {announcement.tags.map((tag) => (
-                  <Badge key={tag} variant="secondary">
-                    {tag}
-                  </Badge>
-                ))}
-              </div>
+              </dl>
             ) : null}
           </div>
         </header>
@@ -207,22 +136,6 @@ export default async function AnnouncementPage({ params }: AnnouncementPageProps
             ].join(" ")}
             dangerouslySetInnerHTML={{ __html: announcement.html }}
           />
-
-          <aside className="mt-16 rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
-            <p className="text-xs font-bold uppercase tracking-widest text-primary">お問い合わせ</p>
-            <h2 className="mt-3 text-2xl font-bold leading-snug tracking-tight text-slate-900">
-              このお知らせについて確認したいことがありますか
-            </h2>
-            <p className="mt-3 text-sm leading-7 text-slate-600">
-              料金、規約、機能変更などについて不明点がある場合は、お問い合わせフォームからご連絡ください。
-            </p>
-            <Button asChild className="mt-6">
-              <Link href="/contact">
-                お問い合わせへ
-                <ArrowUpRight data-icon="inline-end" aria-hidden="true" />
-              </Link>
-            </Button>
-          </aside>
         </div>
       </article>
     </div>

--- a/app/(marketing)/announcements/[slug]/page.tsx
+++ b/app/(marketing)/announcements/[slug]/page.tsx
@@ -1,0 +1,230 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { ArrowLeft, ArrowUpRight, CalendarDays, Clock, Tags } from "lucide-react";
+import type { Metadata } from "next";
+
+import {
+  getAnnouncementStaticParams,
+  getPublishedAnnouncementBySlug,
+} from "@core/announcements/announcement.repository";
+import { generateAnnouncementJsonLd } from "@core/announcements/announcement.seo";
+import type {
+  AnnouncementAudience,
+  AnnouncementImportance,
+  AnnouncementType,
+} from "@core/announcements/announcement.types";
+import { getPublicUrl, siteName, siteOgImage } from "@core/seo/metadata";
+
+import { JsonLd } from "@components/seo/JsonLd";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export const dynamic = "force-static";
+export const dynamicParams = false;
+
+type AnnouncementPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+const announcementTypeLabels: Record<AnnouncementType, string> = {
+  pricing: "料金",
+  feature: "機能",
+  maintenance: "メンテナンス",
+  legal: "規約",
+  incident: "障害",
+  other: "その他",
+};
+
+const announcementImportanceLabels: Record<AnnouncementImportance, string> = {
+  normal: "通常",
+  important: "重要",
+  critical: "緊急",
+};
+
+const announcementAudienceLabels: Record<AnnouncementAudience, string> = {
+  organizer: "主催者",
+  participant: "参加者",
+  all: "すべてのユーザー",
+};
+
+function formatAnnouncementDate(date: string): string {
+  return new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(`${date}T00:00:00+09:00`));
+}
+
+function getImportanceBadgeVariant(importance: AnnouncementImportance) {
+  if (importance === "critical") {
+    return "destructive" as const;
+  }
+
+  if (importance === "important") {
+    return "default" as const;
+  }
+
+  return "secondary" as const;
+}
+
+export async function generateStaticParams() {
+  return getAnnouncementStaticParams();
+}
+
+export async function generateMetadata({ params }: AnnouncementPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const announcement = await getPublishedAnnouncementBySlug(slug);
+
+  if (!announcement) {
+    notFound();
+  }
+
+  return {
+    title: announcement.title,
+    description: announcement.description,
+    alternates: {
+      canonical: getPublicUrl(announcement.path),
+    },
+    openGraph: {
+      title: `${announcement.title} | ${siteName}`,
+      description: announcement.description,
+      type: "article",
+      locale: "ja_JP",
+      url: getPublicUrl(announcement.path),
+      siteName,
+      publishedTime: announcement.publishedAt,
+      modifiedTime: announcement.updatedAt ?? announcement.publishedAt,
+      images: [siteOgImage],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${announcement.title} | ${siteName}`,
+      description: announcement.description,
+      images: [siteOgImage.url],
+    },
+  };
+}
+
+export default async function AnnouncementPage({ params }: AnnouncementPageProps) {
+  const { slug } = await params;
+  const announcement = await getPublishedAnnouncementBySlug(slug);
+
+  if (!announcement) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <JsonLd data={generateAnnouncementJsonLd(announcement)} />
+
+      <article>
+        <header className="relative overflow-hidden border-b border-slate-200 bg-white">
+          <div className="absolute inset-x-0 top-0 h-1 bg-primary" aria-hidden="true" />
+          <div className="relative mx-auto w-full max-w-3xl px-4 pb-12 pt-24 sm:px-6 lg:px-8 lg:pb-16 lg:pt-28">
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="-ml-2 text-slate-500 hover:text-slate-700"
+            >
+              <Link href="/announcements">
+                <ArrowLeft data-icon="inline-start" aria-hidden="true" />
+                お知らせ一覧へ
+              </Link>
+            </Button>
+
+            <div className="mt-7 flex flex-wrap items-center gap-2.5 text-sm font-medium">
+              <Badge variant={getImportanceBadgeVariant(announcement.importance)}>
+                {announcementImportanceLabels[announcement.importance]}
+              </Badge>
+              <Badge variant="outline">{announcementTypeLabels[announcement.type]}</Badge>
+              <span className="inline-flex items-center gap-1.5 text-slate-400">
+                <CalendarDays className="h-4 w-4" aria-hidden="true" />
+                {formatAnnouncementDate(announcement.publishedAt)}
+              </span>
+              <span className="inline-flex items-center gap-1.5 text-slate-400">
+                <Clock className="h-4 w-4" aria-hidden="true" />
+                {announcement.readingMinutes}分で読めます
+              </span>
+            </div>
+
+            <h1 className="mt-5 text-3xl font-bold leading-snug tracking-tight text-slate-900 sm:text-[2.625rem]">
+              {announcement.title}
+            </h1>
+
+            <p className="mt-5 text-base leading-8 text-slate-600 sm:text-lg">
+              {announcement.description}
+            </p>
+
+            <dl className="mt-7 grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-5 text-sm sm:grid-cols-2">
+              {announcement.effectiveAt ? (
+                <div>
+                  <dt className="font-semibold text-slate-500">適用開始日</dt>
+                  <dd className="mt-1 font-medium text-slate-900">
+                    {formatAnnouncementDate(announcement.effectiveAt)}
+                  </dd>
+                </div>
+              ) : null}
+              {announcement.audience.length > 0 ? (
+                <div>
+                  <dt className="font-semibold text-slate-500">対象</dt>
+                  <dd className="mt-1 font-medium text-slate-900">
+                    {announcement.audience
+                      .map((audience) => announcementAudienceLabels[audience])
+                      .join("、")}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+
+            {announcement.tags.length > 0 ? (
+              <div className="mt-6 flex flex-wrap items-center gap-2">
+                <Tags className="h-4 w-4 text-slate-400" aria-hidden="true" />
+                {announcement.tags.map((tag) => (
+                  <Badge key={tag} variant="secondary">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </header>
+
+        <div className="mx-auto w-full max-w-3xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+          <div
+            className={[
+              "prose prose-slate max-w-none",
+              "prose-headings:font-bold prose-headings:tracking-tight",
+              "prose-h2:mt-14 prose-h2:border-l-[3px] prose-h2:border-primary prose-h2:pl-4 prose-h2:text-2xl",
+              "prose-h3:mt-8 prose-h3:text-xl",
+              "prose-p:leading-8 prose-li:leading-8",
+              "prose-a:font-medium prose-a:text-primary prose-a:no-underline hover:prose-a:underline",
+              "prose-blockquote:border-l-primary/50 prose-blockquote:bg-primary/5 prose-blockquote:py-0.5 prose-blockquote:text-slate-600",
+              "prose-code:rounded prose-code:bg-slate-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-slate-800 prose-code:before:content-none prose-code:after:content-none",
+              "prose-pre:rounded-xl prose-pre:bg-slate-900 prose-pre:shadow-md",
+            ].join(" ")}
+            dangerouslySetInnerHTML={{ __html: announcement.html }}
+          />
+
+          <aside className="mt-16 rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-widest text-primary">お問い合わせ</p>
+            <h2 className="mt-3 text-2xl font-bold leading-snug tracking-tight text-slate-900">
+              このお知らせについて確認したいことがありますか
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-slate-600">
+              料金、規約、機能変更などについて不明点がある場合は、お問い合わせフォームからご連絡ください。
+            </p>
+            <Button asChild className="mt-6">
+              <Link href="/contact">
+                お問い合わせへ
+                <ArrowUpRight data-icon="inline-end" aria-hidden="true" />
+              </Link>
+            </Button>
+          </aside>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/app/(marketing)/announcements/page.tsx
+++ b/app/(marketing)/announcements/page.tsx
@@ -1,24 +1,11 @@
 import Link from "next/link";
 
-import {
-  AlertCircle,
-  ArrowUpRight,
-  CalendarDays,
-  Clock,
-  Megaphone,
-  ShieldAlert,
-} from "lucide-react";
+import { AlertCircle, ArrowUpRight, CalendarDays, ShieldAlert } from "lucide-react";
 import type { Metadata } from "next";
 
 import { getPublishedAnnouncements } from "@core/announcements/announcement.repository";
-import type {
-  AnnouncementImportance,
-  AnnouncementSummary,
-  AnnouncementType,
-} from "@core/announcements/announcement.types";
+import type { AnnouncementSummary } from "@core/announcements/announcement.types";
 import { buildOpenGraphMetadata, getPublicUrl } from "@core/seo/metadata";
-
-import { Badge } from "@/components/ui/badge";
 
 export const dynamic = "force-static";
 
@@ -30,24 +17,9 @@ export const metadata: Metadata = {
   },
   openGraph: buildOpenGraphMetadata({
     title: "お知らせ | みんなの集金",
-    description: "みんなの集金の料金、機能、メンテナンス、規約変更などの公式なお知らせです。",
+    description: "みんなの集金のお知らせです。",
     path: "/announcements",
   }),
-};
-
-const announcementTypeLabels: Record<AnnouncementType, string> = {
-  pricing: "料金",
-  feature: "機能",
-  maintenance: "メンテナンス",
-  legal: "規約",
-  incident: "障害",
-  other: "その他",
-};
-
-const announcementImportanceLabels: Record<AnnouncementImportance, string> = {
-  normal: "通常",
-  important: "重要",
-  critical: "緊急",
 };
 
 function formatAnnouncementDate(date: string): string {
@@ -58,42 +30,18 @@ function formatAnnouncementDate(date: string): string {
   }).format(new Date(`${date}T00:00:00+09:00`));
 }
 
-function getImportanceBadgeVariant(importance: AnnouncementImportance) {
-  if (importance === "critical") {
-    return "destructive" as const;
-  }
-
-  if (importance === "important") {
-    return "default" as const;
-  }
-
-  return "secondary" as const;
-}
-
 function AnnouncementCard({ announcement }: { announcement: AnnouncementSummary }) {
-  const isCritical = announcement.importance === "critical";
-
   return (
     <article
       className={[
         "group relative flex flex-col rounded-lg border bg-white p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md",
-        isCritical ? "border-destructive/30" : "border-slate-200 hover:border-primary/35",
+        "border-slate-200 hover:border-primary/35",
       ].join(" ")}
     >
-      <div className="flex flex-wrap items-center gap-2 text-xs font-medium">
-        <Badge variant={getImportanceBadgeVariant(announcement.importance)}>
-          {announcementImportanceLabels[announcement.importance]}
-        </Badge>
-        <Badge variant="outline">{announcementTypeLabels[announcement.type]}</Badge>
-        <span className="inline-flex items-center gap-1 text-slate-400">
-          <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-          {formatAnnouncementDate(announcement.publishedAt)}
-        </span>
-        <span className="inline-flex items-center gap-1 text-slate-400">
-          <Clock className="h-3.5 w-3.5" aria-hidden="true" />
-          {announcement.readingMinutes}分
-        </span>
-      </div>
+      <p className="inline-flex items-center gap-1 text-sm text-slate-400">
+        <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+        {formatAnnouncementDate(announcement.publishedAt)}
+      </p>
 
       <h2 className="mt-4 text-xl font-bold leading-snug text-slate-900">
         <Link href={announcement.path} className="focus-visible:outline-none">
@@ -129,19 +77,13 @@ export default async function AnnouncementsPage() {
     <div className="min-h-screen bg-slate-50">
       <section className="relative overflow-hidden border-b border-slate-200 bg-white">
         <div className="absolute inset-x-0 top-0 h-1 bg-primary" aria-hidden="true" />
-        <div className="relative mx-auto w-full max-w-7xl px-4 pb-14 pt-24 sm:px-6 lg:px-8 lg:pb-20 lg:pt-28">
+        <div className="relative mx-auto w-full max-w-7xl px-4 pb-14 pt-24 sm:px-6 lg:px-8 lg:pb-14 lg:pt-32">
           <div className="flex max-w-3xl flex-col items-start gap-5">
-            <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-1.5 text-sm font-semibold text-slate-700">
-              <Megaphone className="h-4 w-4 text-primary" aria-hidden="true" />
-              公式なお知らせ
-            </div>
-            <h1 className="text-4xl font-bold leading-tight tracking-tight text-slate-900 sm:text-5xl">
-              みんなの集金からの
-              <br className="hidden sm:block" />
-              大切なお知らせ
+            <h1 className="text-2xl font-semibold leading-tight tracking-tight text-slate-900 sm:text-4xl">
+              お知らせ
             </h1>
             <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-              料金、機能、メンテナンス、規約変更など、サービス利用に関わる公式情報を掲載します。
+              料金、機能、メンテナンス、規約変更など、サービス利用に関わるお知らせを掲載します。
             </p>
           </div>
         </div>

--- a/app/(marketing)/announcements/page.tsx
+++ b/app/(marketing)/announcements/page.tsx
@@ -27,6 +27,7 @@ function formatAnnouncementDate(date: string): string {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "Asia/Tokyo",
   }).format(new Date(`${date}T00:00:00+09:00`));
 }
 

--- a/app/(marketing)/announcements/page.tsx
+++ b/app/(marketing)/announcements/page.tsx
@@ -1,0 +1,171 @@
+import Link from "next/link";
+
+import {
+  AlertCircle,
+  ArrowUpRight,
+  CalendarDays,
+  Clock,
+  Megaphone,
+  ShieldAlert,
+} from "lucide-react";
+import type { Metadata } from "next";
+
+import { getPublishedAnnouncements } from "@core/announcements/announcement.repository";
+import type {
+  AnnouncementImportance,
+  AnnouncementSummary,
+  AnnouncementType,
+} from "@core/announcements/announcement.types";
+import { buildOpenGraphMetadata, getPublicUrl } from "@core/seo/metadata";
+
+import { Badge } from "@/components/ui/badge";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+  title: "お知らせ",
+  description: "みんなの集金の料金、機能、メンテナンス、規約変更などの公式なお知らせです。",
+  alternates: {
+    canonical: getPublicUrl("/announcements"),
+  },
+  openGraph: buildOpenGraphMetadata({
+    title: "お知らせ | みんなの集金",
+    description: "みんなの集金の料金、機能、メンテナンス、規約変更などの公式なお知らせです。",
+    path: "/announcements",
+  }),
+};
+
+const announcementTypeLabels: Record<AnnouncementType, string> = {
+  pricing: "料金",
+  feature: "機能",
+  maintenance: "メンテナンス",
+  legal: "規約",
+  incident: "障害",
+  other: "その他",
+};
+
+const announcementImportanceLabels: Record<AnnouncementImportance, string> = {
+  normal: "通常",
+  important: "重要",
+  critical: "緊急",
+};
+
+function formatAnnouncementDate(date: string): string {
+  return new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(`${date}T00:00:00+09:00`));
+}
+
+function getImportanceBadgeVariant(importance: AnnouncementImportance) {
+  if (importance === "critical") {
+    return "destructive" as const;
+  }
+
+  if (importance === "important") {
+    return "default" as const;
+  }
+
+  return "secondary" as const;
+}
+
+function AnnouncementCard({ announcement }: { announcement: AnnouncementSummary }) {
+  const isCritical = announcement.importance === "critical";
+
+  return (
+    <article
+      className={[
+        "group relative flex flex-col rounded-lg border bg-white p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md",
+        isCritical ? "border-destructive/30" : "border-slate-200 hover:border-primary/35",
+      ].join(" ")}
+    >
+      <div className="flex flex-wrap items-center gap-2 text-xs font-medium">
+        <Badge variant={getImportanceBadgeVariant(announcement.importance)}>
+          {announcementImportanceLabels[announcement.importance]}
+        </Badge>
+        <Badge variant="outline">{announcementTypeLabels[announcement.type]}</Badge>
+        <span className="inline-flex items-center gap-1 text-slate-400">
+          <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+          {formatAnnouncementDate(announcement.publishedAt)}
+        </span>
+        <span className="inline-flex items-center gap-1 text-slate-400">
+          <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+          {announcement.readingMinutes}分
+        </span>
+      </div>
+
+      <h2 className="mt-4 text-xl font-bold leading-snug text-slate-900">
+        <Link href={announcement.path} className="focus-visible:outline-none">
+          <span className="absolute inset-0 rounded-lg" aria-hidden="true" />
+          {announcement.title}
+        </Link>
+      </h2>
+
+      <p className="mt-3 flex-1 text-sm leading-7 text-slate-500">{announcement.description}</p>
+
+      {announcement.effectiveAt ? (
+        <p className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-slate-600">
+          <AlertCircle className="h-4 w-4 text-primary" aria-hidden="true" />
+          適用開始日: {formatAnnouncementDate(announcement.effectiveAt)}
+        </p>
+      ) : null}
+
+      <div className="relative mt-6 inline-flex items-center gap-1.5 text-sm font-semibold text-primary">
+        詳細を確認する
+        <ArrowUpRight
+          className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+          aria-hidden="true"
+        />
+      </div>
+    </article>
+  );
+}
+
+export default async function AnnouncementsPage() {
+  const announcements = await getPublishedAnnouncements();
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <section className="relative overflow-hidden border-b border-slate-200 bg-white">
+        <div className="absolute inset-x-0 top-0 h-1 bg-primary" aria-hidden="true" />
+        <div className="relative mx-auto w-full max-w-7xl px-4 pb-14 pt-24 sm:px-6 lg:px-8 lg:pb-20 lg:pt-28">
+          <div className="flex max-w-3xl flex-col items-start gap-5">
+            <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-1.5 text-sm font-semibold text-slate-700">
+              <Megaphone className="h-4 w-4 text-primary" aria-hidden="true" />
+              公式なお知らせ
+            </div>
+            <h1 className="text-4xl font-bold leading-tight tracking-tight text-slate-900 sm:text-5xl">
+              みんなの集金からの
+              <br className="hidden sm:block" />
+              大切なお知らせ
+            </h1>
+            <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+              料金、機能、メンテナンス、規約変更など、サービス利用に関わる公式情報を掲載します。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+        {announcements.length > 0 ? (
+          <div className="grid gap-5 md:grid-cols-2">
+            {announcements.map((announcement) => (
+              <AnnouncementCard key={announcement.slug} announcement={announcement} />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center">
+            <ShieldAlert className="mx-auto mb-4 h-10 w-10 text-slate-300" aria-hidden="true" />
+            <p className="text-base font-medium text-slate-500">
+              公開中のお知らせはまだありません。
+            </p>
+            <p className="mt-1 text-sm text-slate-400">
+              料金や機能に関わる重要なお知らせは、こちらに掲載します。
+            </p>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/(marketing)/articles/[slug]/page.tsx
+++ b/app/(marketing)/articles/[slug]/page.tsx
@@ -27,6 +27,7 @@ function formatArticleDate(date: string): string {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "Asia/Tokyo",
   }).format(new Date(`${date}T00:00:00+09:00`));
 }
 

--- a/app/(marketing)/articles/[slug]/page.tsx
+++ b/app/(marketing)/articles/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { ArrowLeft, ArrowUpRight, CalendarDays, Clock, Tags } from "lucide-react";
+import { ArrowLeft, ArrowUpRight, CalendarDays, Tags } from "lucide-react";
 import type { Metadata } from "next";
 
 import {
@@ -121,10 +121,6 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
               <span className="inline-flex items-center gap-1.5 text-slate-400">
                 <CalendarDays className="h-4 w-4" aria-hidden="true" />
                 {formatArticleDate(article.publishedAt)}
-              </span>
-              <span className="inline-flex items-center gap-1.5 text-slate-400">
-                <Clock className="h-4 w-4" aria-hidden="true" />
-                {article.readingMinutes}分で読めます
               </span>
             </div>
 

--- a/app/(marketing)/articles/page.tsx
+++ b/app/(marketing)/articles/page.tsx
@@ -28,6 +28,7 @@ function formatArticleDate(date: string): string {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "Asia/Tokyo",
   }).format(new Date(`${date}T00:00:00+09:00`));
 }
 

--- a/app/(marketing)/articles/page.tsx
+++ b/app/(marketing)/articles/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { ArrowUpRight, BookOpenText, CalendarDays, Clock } from "lucide-react";
+import { ArrowUpRight, BookOpenText, CalendarDays } from "lucide-react";
 import type { Metadata } from "next";
 
 import { getPublishedArticles } from "@core/articles/article.repository";
@@ -85,10 +85,6 @@ export default async function ArticlesPage() {
                   <span className="inline-flex items-center gap-1 text-slate-400">
                     <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
                     {formatArticleDate(article.publishedAt)}
-                  </span>
-                  <span className="inline-flex items-center gap-1 text-slate-400">
-                    <Clock className="h-3.5 w-3.5" aria-hidden="true" />
-                    {article.readingMinutes}分
                   </span>
                 </div>
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,11 @@
 import type { MetadataRoute } from "next";
 
+import { getPublishedAnnouncements } from "@core/announcements/announcement.repository";
 import { getPublishedArticles } from "@core/articles/article.repository";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const announcements = await getPublishedAnnouncements();
   const articles = await getPublishedArticles();
 
   return [
@@ -43,6 +45,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.6,
     },
+    {
+      url: `${appUrl}/announcements`,
+      lastModified: "2026-05-05",
+      changeFrequency: "weekly",
+      priority: 0.5,
+    },
+    ...announcements.map((announcement) => ({
+      url: `${appUrl}${announcement.path}`,
+      lastModified: announcement.updatedAt ?? announcement.publishedAt,
+      changeFrequency: "monthly" as const,
+      priority: 0.4,
+    })),
     ...articles.map((article) => ({
       url: `${appUrl}${article.path}`,
       lastModified: article.updatedAt ?? article.publishedAt,

--- a/components/layout/GlobalFooter/FooterLinks.tsx
+++ b/components/layout/GlobalFooter/FooterLinks.tsx
@@ -39,10 +39,9 @@ export function FooterLinks({
           <h3 className="font-bold text-foreground text-xs tracking-[0.15em]">{group.title}</h3>
           <ul className="flex flex-col gap-3.5">
             {group.links.map((link) => {
-              const isFeedback = link.label === "フィードバック";
               const linkStyles = cn(
                 "text-sm relative group w-fit flex items-center gap-1.5 transition-all duration-300",
-                isFeedback
+                link.featured
                   ? "text-primary font-semibold hover:text-primary/80"
                   : "text-muted-foreground hover:text-primary",
                 "focus:outline-none focus:ring-2 focus:ring-primary/20 rounded-sm"
@@ -59,12 +58,12 @@ export function FooterLinks({
                       rel="noopener noreferrer"
                     >
                       <span className="relative flex items-center gap-1.5">
-                        {isFeedback && <MessageSquare className="w-3.5 h-3.5" />}
+                        {link.featured && <MessageSquare className="w-3.5 h-3.5" />}
                         {link.label}
                         <span
                           className={cn(
                             "absolute -bottom-1 left-0 w-0 h-[1.5px] transition-all duration-300 group-hover:w-full",
-                            isFeedback ? "bg-primary/40" : "bg-primary/60"
+                            link.featured ? "bg-primary/40" : "bg-primary/60"
                           )}
                         />
                       </span>
@@ -77,12 +76,12 @@ export function FooterLinks({
                       aria-label={link.ariaLabel}
                     >
                       <span className="relative flex items-center gap-1.5">
-                        {isFeedback && <MessageSquare className="w-3.5 h-3.5" />}
+                        {link.featured && <MessageSquare className="w-3.5 h-3.5" />}
                         {link.label}
                         <span
                           className={cn(
                             "absolute -bottom-1 left-0 w-0 h-[1.5px] transition-all duration-300 group-hover:w-full",
-                            isFeedback ? "bg-primary/40" : "bg-primary/60"
+                            link.featured ? "bg-primary/40" : "bg-primary/60"
                           )}
                         />
                       </span>

--- a/components/layout/GlobalFooter/navigation-config.ts
+++ b/components/layout/GlobalFooter/navigation-config.ts
@@ -17,16 +17,10 @@ export const footerNavigationGroups: FooterLinkGroup[] = [
         href: "/#pricing",
         ariaLabel: "みんなの集金の料金を見る",
       },
-      {
-        label: "デモ",
-        href: `${process.env.NEXT_PUBLIC_DEMO_URL || "https://demo.minnano-shukin.com"}/start-demo`,
-        external: true,
-        ariaLabel: "みんなの集金のデモを試す",
-      },
     ],
   },
   {
-    title: "ガイド",
+    title: "使い方",
     links: [
       {
         label: "主催者のはじめ方",
@@ -48,36 +42,36 @@ export const footerNavigationGroups: FooterLinkGroup[] = [
         href: "/guide/pricing-and-fees",
         ariaLabel: "料金と手数料の詳細を確認する",
       },
-      {
-        label: "よくある質問",
-        href: "/#faq",
-        ariaLabel: "よくある質問を確認する",
-      },
     ],
   },
   {
     title: "サポート",
     links: [
       {
+        label: "よくある質問",
+        href: "/#faq",
+        ariaLabel: "よくある質問を確認する",
+      },
+      {
+        label: "お知らせ",
+        href: "/announcements",
+        ariaLabel: "みんなの集金のお知らせを見る",
+      },
+      {
         label: "フィードバック",
         href: "/feedback",
         ariaLabel: "みんなの集金へのフィードバックフォーム",
+        featured: true,
       },
       {
         label: "お問い合わせ",
         href: "/contact",
         ariaLabel: "みんなの集金へのお問い合わせフォーム",
       },
-      {
-        label: "運営元",
-        href: "https://project.tklab.workers.dev/",
-        external: true,
-        ariaLabel: "みんなの集金の運営元を確認する",
-      },
     ],
   },
   {
-    title: "法的情報",
+    title: "運営・法務",
     links: [
       {
         label: "利用規約",
@@ -93,6 +87,12 @@ export const footerNavigationGroups: FooterLinkGroup[] = [
         label: "特定商取引法に基づく表記",
         href: "/tokushoho/platform",
         ariaLabel: "みんなの集金プラットフォームの特定商取引法に基づく表記",
+      },
+      {
+        label: "運営元",
+        href: "https://project.tklab.workers.dev/",
+        external: true,
+        ariaLabel: "みんなの集金の運営元を確認する",
       },
     ],
   },

--- a/components/layout/GlobalFooter/types.ts
+++ b/components/layout/GlobalFooter/types.ts
@@ -16,6 +16,8 @@ export interface FooterLink {
   ariaLabel?: string;
   /** アイコン（オプション） */
   icon?: React.ComponentType<{ className?: string }>;
+  /** フッター内で強調表示するかどうか */
+  featured?: boolean;
 }
 
 /**

--- a/components/layout/GlobalHeader/navigation-config.ts
+++ b/components/layout/GlobalHeader/navigation-config.ts
@@ -23,11 +23,6 @@ export const navigationConfig: NavigationConfig = {
       href: "/#pricing",
       exactMatch: false,
     },
-    {
-      label: "デモ",
-      href: `${process.env.NEXT_PUBLIC_DEMO_URL || "https://demo.minnano-shukin.com"}/start-demo`,
-      exactMatch: false,
-    },
   ],
 
   /**

--- a/components/ui/date-time-picker.tsx
+++ b/components/ui/date-time-picker.tsx
@@ -257,9 +257,6 @@ export function DateTimePicker({
           </div>
         </PopoverContent>
       </Popover>
-      {selectedDate && (
-        <p className="text-sm text-muted-foreground">選択中: {formatDisplayDate(selectedDate)}</p>
-      )}
     </div>
   );
 }

--- a/core/announcements/announcement.markdown.ts
+++ b/core/announcements/announcement.markdown.ts
@@ -1,0 +1,44 @@
+import matter from "@11ty/gray-matter";
+import rehypeSanitize from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+
+import { parseAnnouncementFrontmatter } from "./announcement.schema";
+
+function estimateReadingMinutes(markdown: string): number {
+  const plainText = markdown
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/<[^>]*>/g, "")
+    .replace(/[#>*_`[\]()!-]/g, "")
+    .replace(/\s+/g, "");
+
+  return Math.max(1, Math.ceil(plainText.length / 600));
+}
+
+export async function parseAnnouncementMarkdown({
+  fileSlug,
+  content,
+}: {
+  fileSlug: string;
+  content: string;
+}) {
+  const parsed = matter(content);
+  const frontmatter = parseAnnouncementFrontmatter(parsed.data || {}, fileSlug);
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeSanitize)
+    .use(rehypeStringify);
+
+  const file = await processor.process(parsed.content);
+
+  return {
+    frontmatter,
+    html: String(file.value),
+    readingMinutes: estimateReadingMinutes(parsed.content),
+  };
+}

--- a/core/announcements/announcement.markdown.ts
+++ b/core/announcements/announcement.markdown.ts
@@ -8,16 +8,6 @@ import { unified } from "unified";
 
 import { parseAnnouncementFrontmatter } from "./announcement.schema";
 
-function estimateReadingMinutes(markdown: string): number {
-  const plainText = markdown
-    .replace(/```[\s\S]*?```/g, "")
-    .replace(/<[^>]*>/g, "")
-    .replace(/[#>*_`[\]()!-]/g, "")
-    .replace(/\s+/g, "");
-
-  return Math.max(1, Math.ceil(plainText.length / 600));
-}
-
 export async function parseAnnouncementMarkdown({
   fileSlug,
   content,
@@ -39,6 +29,5 @@ export async function parseAnnouncementMarkdown({
   return {
     frontmatter,
     html: String(file.value),
-    readingMinutes: estimateReadingMinutes(parsed.content),
   };
 }

--- a/core/announcements/announcement.repository.ts
+++ b/core/announcements/announcement.repository.ts
@@ -1,0 +1,76 @@
+import "server-only";
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { cache } from "react";
+
+import { parseAnnouncementMarkdown } from "./announcement.markdown";
+import type { Announcement, AnnouncementSummary } from "./announcement.types";
+import { isAnnouncementPublished } from "./publication";
+
+const ANNOUNCEMENTS_DIR = path.join(process.cwd(), "content/announcements");
+const ANNOUNCEMENT_EXTENSION = ".md";
+
+function getSlugFromFileName(fileName: string): string {
+  return fileName.slice(0, -ANNOUNCEMENT_EXTENSION.length);
+}
+
+function buildAnnouncementPath(slug: string): `/announcements/${string}` {
+  return `/announcements/${slug}`;
+}
+
+function sortByPublishedAtDesc(a: AnnouncementSummary, b: AnnouncementSummary): number {
+  return b.publishedAt.localeCompare(a.publishedAt);
+}
+
+export const getAllAnnouncements = cache(async (): Promise<Announcement[]> => {
+  const fileNames = (await fs.readdir(ANNOUNCEMENTS_DIR))
+    .filter((fileName) => fileName.endsWith(ANNOUNCEMENT_EXTENSION))
+    .sort();
+
+  const announcements = await Promise.all(
+    fileNames.map(async (fileName) => {
+      const fileSlug = getSlugFromFileName(fileName);
+      const content = await fs.readFile(path.join(ANNOUNCEMENTS_DIR, fileName), "utf8");
+      const parsed = await parseAnnouncementMarkdown({ fileSlug, content });
+
+      return {
+        ...parsed.frontmatter,
+        html: parsed.html,
+        path: buildAnnouncementPath(parsed.frontmatter.slug),
+        readingMinutes: parsed.readingMinutes,
+      };
+    })
+  );
+
+  return announcements.sort(sortByPublishedAtDesc);
+});
+
+export async function getPublishedAnnouncements(now = new Date()): Promise<AnnouncementSummary[]> {
+  const announcements = await getAllAnnouncements();
+  return announcements
+    .filter((announcement) => isAnnouncementPublished(announcement, now))
+    .map(toAnnouncementSummary);
+}
+
+export async function getPublishedAnnouncementBySlug(slug: string): Promise<Announcement | null> {
+  const announcements = await getAllAnnouncements();
+  const announcement = announcements.find((item) => item.slug === slug);
+
+  if (!announcement || !isAnnouncementPublished(announcement)) {
+    return null;
+  }
+
+  return announcement;
+}
+
+export async function getAnnouncementStaticParams(): Promise<Array<{ slug: string }>> {
+  const announcements = await getPublishedAnnouncements();
+  return announcements.map((announcement) => ({ slug: announcement.slug }));
+}
+
+function toAnnouncementSummary(announcement: Announcement): AnnouncementSummary {
+  const { html: _html, ...summary } = announcement;
+  return summary;
+}

--- a/core/announcements/announcement.repository.ts
+++ b/core/announcements/announcement.repository.ts
@@ -39,7 +39,6 @@ export const getAllAnnouncements = cache(async (): Promise<Announcement[]> => {
         ...parsed.frontmatter,
         html: parsed.html,
         path: buildAnnouncementPath(parsed.frontmatter.slug),
-        readingMinutes: parsed.readingMinutes,
       };
     })
   );

--- a/core/announcements/announcement.schema.ts
+++ b/core/announcements/announcement.schema.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+const dateStringSchema = z.preprocess(
+  (value) => {
+    if (value instanceof Date) {
+      return value.toISOString().slice(0, 10);
+    }
+    return value;
+  },
+  z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD形式で指定してください")
+);
+
+export const announcementStatusSchema = z.enum(["draft", "published"]);
+export const announcementTypeSchema = z.enum([
+  "pricing",
+  "feature",
+  "maintenance",
+  "legal",
+  "incident",
+  "other",
+]);
+export const announcementImportanceSchema = z.enum(["normal", "important", "critical"]);
+export const announcementAudienceSchema = z.enum(["organizer", "participant", "all"]);
+
+export const announcementFrontmatterSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1).max(180),
+  slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  publishedAt: dateStringSchema,
+  updatedAt: dateStringSchema.optional(),
+  effectiveAt: dateStringSchema.optional(),
+  status: announcementStatusSchema,
+  type: announcementTypeSchema,
+  importance: announcementImportanceSchema,
+  audience: z.array(announcementAudienceSchema).default([]),
+  tags: z.array(z.string().min(1)).default([]),
+});
+
+export function parseAnnouncementFrontmatter(data: unknown, expectedSlug: string) {
+  const frontmatter = announcementFrontmatterSchema.parse(data);
+
+  if (frontmatter.slug !== expectedSlug) {
+    throw new Error(
+      `Announcement slug mismatch: frontmatter slug "${frontmatter.slug}" must match file name "${expectedSlug}"`
+    );
+  }
+
+  return frontmatter;
+}

--- a/core/announcements/announcement.schema.ts
+++ b/core/announcements/announcement.schema.ts
@@ -11,30 +11,18 @@ const dateStringSchema = z.preprocess(
 );
 
 export const announcementStatusSchema = z.enum(["draft", "published"]);
-export const announcementTypeSchema = z.enum([
-  "pricing",
-  "feature",
-  "maintenance",
-  "legal",
-  "incident",
-  "other",
-]);
-export const announcementImportanceSchema = z.enum(["normal", "important", "critical"]);
-export const announcementAudienceSchema = z.enum(["organizer", "participant", "all"]);
 
-export const announcementFrontmatterSchema = z.object({
-  title: z.string().min(1),
-  description: z.string().min(1).max(180),
-  slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
-  publishedAt: dateStringSchema,
-  updatedAt: dateStringSchema.optional(),
-  effectiveAt: dateStringSchema.optional(),
-  status: announcementStatusSchema,
-  type: announcementTypeSchema,
-  importance: announcementImportanceSchema,
-  audience: z.array(announcementAudienceSchema).default([]),
-  tags: z.array(z.string().min(1)).default([]),
-});
+export const announcementFrontmatterSchema = z
+  .object({
+    title: z.string().min(1),
+    description: z.string().min(1).max(180),
+    slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+    publishedAt: dateStringSchema,
+    updatedAt: dateStringSchema.optional(),
+    effectiveAt: dateStringSchema.optional(),
+    status: announcementStatusSchema,
+  })
+  .strict();
 
 export function parseAnnouncementFrontmatter(data: unknown, expectedSlug: string) {
   const frontmatter = announcementFrontmatterSchema.parse(data);

--- a/core/announcements/announcement.seo.ts
+++ b/core/announcements/announcement.seo.ts
@@ -1,0 +1,31 @@
+import type { Article, WithContext } from "schema-dts";
+
+import { getPublicUrl, siteName, siteOgImage } from "@core/seo/metadata";
+
+import type { Announcement } from "./announcement.types";
+
+export function generateAnnouncementJsonLd(announcement: Announcement): WithContext<Article> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: announcement.title,
+    description: announcement.description,
+    url: getPublicUrl(announcement.path),
+    datePublished: announcement.publishedAt,
+    dateModified: announcement.updatedAt ?? announcement.publishedAt,
+    inLanguage: "ja",
+    image: getPublicUrl(siteOgImage.url),
+    author: {
+      "@type": "Organization",
+      name: siteName,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: siteName,
+      logo: {
+        "@type": "ImageObject",
+        url: getPublicUrl("/icon-512.png"),
+      },
+    },
+  };
+}

--- a/core/announcements/announcement.types.ts
+++ b/core/announcements/announcement.types.ts
@@ -1,22 +1,15 @@
 import type { z } from "zod";
 
 import type {
-  announcementAudienceSchema,
   announcementFrontmatterSchema,
-  announcementImportanceSchema,
   announcementStatusSchema,
-  announcementTypeSchema,
 } from "./announcement.schema";
 
 export type AnnouncementStatus = z.infer<typeof announcementStatusSchema>;
-export type AnnouncementType = z.infer<typeof announcementTypeSchema>;
-export type AnnouncementImportance = z.infer<typeof announcementImportanceSchema>;
-export type AnnouncementAudience = z.infer<typeof announcementAudienceSchema>;
 export type AnnouncementFrontmatter = z.infer<typeof announcementFrontmatterSchema>;
 
 export type AnnouncementSummary = AnnouncementFrontmatter & {
   path: `/announcements/${string}`;
-  readingMinutes: number;
 };
 
 export type Announcement = AnnouncementSummary & {

--- a/core/announcements/announcement.types.ts
+++ b/core/announcements/announcement.types.ts
@@ -1,0 +1,24 @@
+import type { z } from "zod";
+
+import type {
+  announcementAudienceSchema,
+  announcementFrontmatterSchema,
+  announcementImportanceSchema,
+  announcementStatusSchema,
+  announcementTypeSchema,
+} from "./announcement.schema";
+
+export type AnnouncementStatus = z.infer<typeof announcementStatusSchema>;
+export type AnnouncementType = z.infer<typeof announcementTypeSchema>;
+export type AnnouncementImportance = z.infer<typeof announcementImportanceSchema>;
+export type AnnouncementAudience = z.infer<typeof announcementAudienceSchema>;
+export type AnnouncementFrontmatter = z.infer<typeof announcementFrontmatterSchema>;
+
+export type AnnouncementSummary = AnnouncementFrontmatter & {
+  path: `/announcements/${string}`;
+  readingMinutes: number;
+};
+
+export type Announcement = AnnouncementSummary & {
+  html: string;
+};

--- a/core/announcements/publication.ts
+++ b/core/announcements/publication.ts
@@ -1,0 +1,18 @@
+import { formatInTimeZone } from "date-fns-tz";
+
+import type { AnnouncementFrontmatter } from "./announcement.types";
+
+export const ANNOUNCEMENT_TIME_ZONE = "Asia/Tokyo";
+
+export function getAnnouncementDateToday(now = new Date()): string {
+  return formatInTimeZone(now, ANNOUNCEMENT_TIME_ZONE, "yyyy-MM-dd");
+}
+
+export function isAnnouncementPublished(
+  announcement: AnnouncementFrontmatter,
+  now = new Date()
+): boolean {
+  return (
+    announcement.status === "published" && announcement.publishedAt <= getAnnouncementDateToday(now)
+  );
+}

--- a/core/articles/article.markdown.ts
+++ b/core/articles/article.markdown.ts
@@ -8,16 +8,6 @@ import { unified } from "unified";
 
 import { parseArticleFrontmatter } from "./article.schema";
 
-function estimateReadingMinutes(markdown: string): number {
-  const plainText = markdown
-    .replace(/```[\s\S]*?```/g, "")
-    .replace(/<[^>]*>/g, "")
-    .replace(/[#>*_`[\]()!-]/g, "")
-    .replace(/\s+/g, "");
-
-  return Math.max(1, Math.ceil(plainText.length / 600));
-}
-
 export async function parseArticleMarkdown({
   fileSlug,
   content,
@@ -39,6 +29,5 @@ export async function parseArticleMarkdown({
   return {
     frontmatter,
     html: String(file.value),
-    readingMinutes: estimateReadingMinutes(parsed.content),
   };
 }

--- a/core/articles/article.repository.ts
+++ b/core/articles/article.repository.ts
@@ -39,7 +39,6 @@ export const getAllArticles = cache(async (): Promise<Article[]> => {
         ...parsed.frontmatter,
         html: parsed.html,
         path: buildArticlePath(parsed.frontmatter.slug),
-        readingMinutes: parsed.readingMinutes,
       };
     })
   );

--- a/core/articles/article.types.ts
+++ b/core/articles/article.types.ts
@@ -7,7 +7,6 @@ export type ArticleFrontmatter = z.infer<typeof articleFrontmatterSchema>;
 
 export type ArticleSummary = ArticleFrontmatter & {
   path: `/articles/${string}`;
-  readingMinutes: number;
 };
 
 export type Article = ArticleSummary & {

--- a/docs/conventions/announcement-content-operations.md
+++ b/docs/conventions/announcement-content-operations.md
@@ -25,8 +25,6 @@ description: "2026年6月1日からの料金体系改定について、対象と
 slug: "pricing-revision-2026-06"
 publishedAt: "2026-05-01"
 status: "published"
-type: "pricing"
-importance: "important"
 ---
 ```
 
@@ -35,11 +33,6 @@ importance: "important"
 ```yaml
 updatedAt: "2026-05-10"
 effectiveAt: "2026-06-01"
-audience:
-  - "organizer"
-tags:
-  - "料金"
-  - "手数料"
 ```
 
 ## 値のルール
@@ -47,9 +40,6 @@ tags:
 - `slug` は英小文字・数字・ハイフンのみを使う。
 - `publishedAt`, `updatedAt`, `effectiveAt` は `YYYY-MM-DD` 形式にする。
 - `status` は `draft` または `published`。
-- `type` は `pricing`, `feature`, `maintenance`, `legal`, `incident`, `other`。
-- `importance` は `normal`, `important`, `critical`。
-- `audience` は `organizer`, `participant`, `all`。
 
 ## 公開条件
 
@@ -68,13 +58,13 @@ tags:
 
 - 本文内では `#` を使わず、ページタイトルは `<h1>` に任せる。
 - 本文の大見出しは `##` から始める。
-- 料金改定や規約変更では、適用開始日、対象、既存イベントへの影響、問い合わせ先を明記する。
+- 料金改定や規約変更では、適用開始日、対象、既存イベントへの影響を本文内で明記する。
 - 生HTML、外部スクリプト、iframe は使わない。
 
 ## 追加・更新手順
 
 1. `content/announcements/{slug}.md` を追加または編集する。
-2. frontmatter の `slug`, `publishedAt`, `status`, `type`, `importance` を確認する。
+2. frontmatter の `slug`, `publishedAt`, `status` を確認する。
 3. 本文内の見出しが `##` から始まっていることを確認する。
 4. 検証コマンドを実行する。
 

--- a/docs/conventions/announcement-content-operations.md
+++ b/docs/conventions/announcement-content-operations.md
@@ -1,0 +1,92 @@
+# お知らせコンテンツ運用ルール
+
+`/announcements` 配下の公式告知は、Markdown + frontmatter で管理する。料金改定、規約変更、メンテナンス、障害、機能追加など、ユーザーの利用判断に関わる情報を掲載する。
+
+集客記事は `/articles`、公式告知は `/announcements` に分ける。記事本文のSEO都合で、お知らせの公開条件や分類を変更しない。
+
+## ファイル配置
+
+告知ファイルは次の場所に置く。
+
+```txt
+content/announcements/{slug}.md
+```
+
+`slug` はファイル名と frontmatter の `slug` を必ず一致させる。一致しない場合はビルド時にエラーにする。
+
+## Frontmatter
+
+必須項目:
+
+```yaml
+---
+title: "料金体系改定のお知らせ"
+description: "2026年6月1日からの料金体系改定について、対象となるユーザーと適用開始日をお知らせします。"
+slug: "pricing-revision-2026-06"
+publishedAt: "2026-05-01"
+status: "published"
+type: "pricing"
+importance: "important"
+---
+```
+
+任意項目:
+
+```yaml
+updatedAt: "2026-05-10"
+effectiveAt: "2026-06-01"
+audience:
+  - "organizer"
+tags:
+  - "料金"
+  - "手数料"
+```
+
+## 値のルール
+
+- `slug` は英小文字・数字・ハイフンのみを使う。
+- `publishedAt`, `updatedAt`, `effectiveAt` は `YYYY-MM-DD` 形式にする。
+- `status` は `draft` または `published`。
+- `type` は `pricing`, `feature`, `maintenance`, `legal`, `incident`, `other`。
+- `importance` は `normal`, `important`, `critical`。
+- `audience` は `organizer`, `participant`, `all`。
+
+## 公開条件
+
+告知が公開される条件:
+
+- `status: "published"` である。
+- `publishedAt` が今日以前の日付である。
+- frontmatter が schema に通る。
+- ファイル名の slug と frontmatter の `slug` が一致している。
+
+未来日公開をしたい場合も、現時点では公開日に Pull Request を反映する運用にする。アプリ内バナー、メール配信、管理画面、CMS はこの基盤には含めない。
+
+## 本文ルール
+
+本文は通常の Markdown で書く。GFM に対応しているため、表・リスト・リンクは使える。
+
+- 本文内では `#` を使わず、ページタイトルは `<h1>` に任せる。
+- 本文の大見出しは `##` から始める。
+- 料金改定や規約変更では、適用開始日、対象、既存イベントへの影響、問い合わせ先を明記する。
+- 生HTML、外部スクリプト、iframe は使わない。
+
+## 追加・更新手順
+
+1. `content/announcements/{slug}.md` を追加または編集する。
+2. frontmatter の `slug`, `publishedAt`, `status`, `type`, `importance` を確認する。
+3. 本文内の見出しが `##` から始まっていることを確認する。
+4. 検証コマンドを実行する。
+
+```bash
+npm run typecheck
+npm run lint
+npm run test:unit tests/unit/core/announcements
+```
+
+ローカル確認URL:
+
+```txt
+http://localhost:3000/announcements
+http://localhost:3000/announcements/{slug}
+```

--- a/docs/conventions/article-content-operations.md
+++ b/docs/conventions/article-content-operations.md
@@ -2,6 +2,8 @@
 
 `/articles` 配下の集客記事は、Markdown + frontmatter で管理する。記事は `content/articles/*.md` に1記事1ファイルで追加し、公開記事だけが一覧・詳細・sitemap・静的生成対象に含まれる。
 
+公式告知は `/announcements` に分け、`docs/conventions/announcement-content-operations.md` の運用ルールに従う。記事側のSEO項目やタグ運用を、お知らせの frontmatter に持ち込まない。
+
 ## ファイル配置
 
 記事ファイルは次の場所に置く。

--- a/features/events/components/SinglePageEventEditForm.tsx
+++ b/features/events/components/SinglePageEventEditForm.tsx
@@ -21,6 +21,7 @@ import type { Event } from "@core/types/event";
 
 import { useMobileBottomOverlay } from "@/components/layout/mobile-chrome-context";
 import { cn } from "@/components/ui/_lib/cn";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardTitle, CardDescription } from "@/components/ui/card";
@@ -66,31 +67,37 @@ function FormSection({ title, description, icon, children, className }: FormSect
   return (
     <Card
       className={cn(
-        "border-0 shadow-lg shadow-slate-200/40 ring-1 ring-slate-100 overflow-hidden",
+        "overflow-hidden rounded-lg border border-border/70 bg-card shadow-none",
         className
       )}
     >
-      <div className="bg-gradient-to-r from-slate-50 to-white border-b border-slate-100 p-4 md:p-6">
-        <div className="flex items-start gap-4">
+      <div className="border-b border-border/70 bg-muted/20 p-4 sm:p-5">
+        <div className="flex items-start gap-3 sm:gap-4">
           {icon && (
-            <div className="p-2.5 bg-white shadow-sm ring-1 ring-slate-200/50 rounded-xl text-primary shrink-0">
+            <div className="hidden size-10 shrink-0 items-center justify-center rounded-md border border-border bg-background text-primary sm:flex">
               {icon}
             </div>
           )}
           <div>
-            <CardTitle className="text-base md:text-lg font-bold text-slate-900 tracking-tight">
+            <CardTitle className="text-base font-semibold tracking-tight text-foreground md:text-lg">
               {title}
             </CardTitle>
             {description && (
-              <CardDescription className="mt-1.5 text-slate-500">{description}</CardDescription>
+              <CardDescription className="mt-1 text-sm text-muted-foreground">
+                {description}
+              </CardDescription>
             )}
           </div>
         </div>
       </div>
-      <CardContent className="p-4 md:p-6 space-y-6">{children}</CardContent>
+      <CardContent className="flex flex-col gap-5 p-4 sm:gap-6 sm:p-5">{children}</CardContent>
     </Card>
   );
 }
+
+const changedBadgeClass =
+  "border-primary/20 bg-primary/5 text-xs font-medium text-primary hover:bg-primary/5";
+const changedFieldClass = "border-primary/40 bg-primary/5";
 
 // =====================================================
 // SinglePageEventEditForm - 編集用メインフォームコンポーネント
@@ -265,9 +272,24 @@ export function SinglePageEventEditForm({
         onCancel={() => setShowConfirmDialog(false)}
         isLoading={isPending}
       />
-      <div className="w-full max-w-7xl mx-auto pb-8">
+      <div className="w-full">
+        <header className="mb-5 flex flex-col gap-3 border-b border-border/70 pb-4 sm:mb-6 sm:gap-4 sm:pb-5 md:flex-row md:items-end md:justify-between">
+          <div className="flex min-w-0 flex-col gap-2">
+            <p className="truncate text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground sm:tracking-[0.16em]">
+              {event.title}
+            </p>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+              イベント編集
+            </h1>
+          </div>
+          <div className="inline-flex w-fit max-w-full items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-xs font-medium text-muted-foreground">
+            <span className="size-2 rounded-full bg-muted-foreground/40" />
+            参加者 {attendeeCount}人
+          </div>
+        </header>
+
         {/* 統合制限通知 */}
-        <div className="mb-6">
+        <div className="mb-5 sm:mb-6">
           <UnifiedRestrictionNoticeV2
             restrictions={restrictionContext}
             formData={formDataSnapshot}
@@ -277,9 +299,9 @@ export function SinglePageEventEditForm({
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-0" noValidate>
-            <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
+            <div className="grid grid-cols-1 items-start gap-5 sm:gap-6 lg:grid-cols-12 lg:gap-8">
               {/* 左カラム: 入力フォーム */}
-              <div className="lg:col-span-7 xl:col-span-8 space-y-8">
+              <div className="flex flex-col gap-5 sm:gap-6 lg:col-span-7 xl:col-span-8">
                 {/* ============================================= */}
                 {/* Section 1: 基本情報 */}
                 {/* ============================================= */}
@@ -298,10 +320,7 @@ export function SinglePageEventEditForm({
                             イベント名 <span className="text-red-500">*</span>
                           </FormLabel>
                           {isChanged("title") && (
-                            <Badge
-                              variant="outline"
-                              className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                            >
+                            <Badge variant="outline" className={changedBadgeClass}>
                               変更あり
                             </Badge>
                           )}
@@ -313,8 +332,8 @@ export function SinglePageEventEditForm({
                             disabled={isPending || !restrictions.isFieldEditable("title")}
                             maxLength={100}
                             className={cn(
-                              "h-12",
-                              isChanged("title") && "bg-orange-50/30 border-orange-300"
+                              "h-11 bg-background",
+                              isChanged("title") && changedFieldClass
                             )}
                           />
                         </FormControl>
@@ -331,10 +350,7 @@ export function SinglePageEventEditForm({
                         <div className="flex items-center gap-2">
                           <FormLabel className="text-sm font-medium">説明・備考（任意）</FormLabel>
                           {isChanged("description") && (
-                            <Badge
-                              variant="outline"
-                              className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                            >
+                            <Badge variant="outline" className={changedBadgeClass}>
                               変更あり
                             </Badge>
                           )}
@@ -347,8 +363,8 @@ export function SinglePageEventEditForm({
                             rows={4}
                             maxLength={1000}
                             className={cn(
-                              "resize-none",
-                              isChanged("description") && "bg-orange-50/30 border-orange-300"
+                              "min-h-28 resize-none bg-background",
+                              isChanged("description") && changedFieldClass
                             )}
                           />
                         </FormControl>
@@ -365,25 +381,22 @@ export function SinglePageEventEditForm({
                         <div className="flex items-center gap-2">
                           <FormLabel className="text-sm font-medium">開催場所（任意）</FormLabel>
                           {isChanged("location") && (
-                            <Badge
-                              variant="outline"
-                              className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                            >
+                            <Badge variant="outline" className={changedBadgeClass}>
                               変更あり
                             </Badge>
                           )}
                         </div>
                         <FormControl>
                           <div className="relative">
-                            <MapPinIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                            <MapPinIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                             <Input
                               {...field}
                               placeholder="例：〇〇会議室、〇〇居酒屋など"
                               disabled={isPending || !restrictions.isFieldEditable("location")}
                               maxLength={200}
                               className={cn(
-                                "h-12 pl-10",
-                                isChanged("location") && "bg-orange-50/30 border-orange-300"
+                                "h-11 bg-background pl-10",
+                                isChanged("location") && changedFieldClass
                               )}
                             />
                           </div>
@@ -401,17 +414,14 @@ export function SinglePageEventEditForm({
                         <div className="flex items-center gap-2">
                           <FormLabel className="text-sm font-medium">定員（任意）</FormLabel>
                           {isChanged("capacity") && (
-                            <Badge
-                              variant="outline"
-                              className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                            >
+                            <Badge variant="outline" className={changedBadgeClass}>
                               変更あり
                             </Badge>
                           )}
                         </div>
                         <FormControl>
-                          <div className="relative max-w-xs">
-                            <UsersIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                          <div className="relative w-full sm:max-w-xs">
+                            <UsersIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                             <Input
                               {...field}
                               type="number"
@@ -420,11 +430,11 @@ export function SinglePageEventEditForm({
                               min={hasAttendees ? attendeeCount : 1}
                               max="10000"
                               className={cn(
-                                "h-12 pl-10 pr-10",
-                                isChanged("capacity") && "bg-orange-50/30 border-orange-300"
+                                "h-11 bg-background pl-10 pr-10",
+                                isChanged("capacity") && changedFieldClass
                               )}
                             />
-                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">
+                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
                               人
                             </span>
                           </div>
@@ -448,7 +458,7 @@ export function SinglePageEventEditForm({
                   description="開催日時と出欠確認の締め切りを編集します"
                   icon={<ClockIcon className="w-5 h-5" />}
                 >
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="grid grid-cols-1 gap-5 md:grid-cols-2 md:gap-6">
                     <FormField
                       control={form.control}
                       name="date"
@@ -459,10 +469,7 @@ export function SinglePageEventEditForm({
                               開催日時 <span className="text-red-500">*</span>
                             </FormLabel>
                             {isChanged("date") && (
-                              <Badge
-                                variant="outline"
-                                className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                              >
+                              <Badge variant="outline" className={changedBadgeClass}>
                                 変更あり
                               </Badge>
                             )}
@@ -480,9 +487,7 @@ export function SinglePageEventEditForm({
                               }}
                               placeholder="開催日時を選択"
                               disabled={isPending || !restrictions.isFieldEditable("date")}
-                              className={cn(
-                                isChanged("date") && "bg-orange-50/30 border-orange-300"
-                              )}
+                              className={cn(isChanged("date") && changedFieldClass)}
                             />
                           </FormControl>
                           <FormMessage />
@@ -500,10 +505,7 @@ export function SinglePageEventEditForm({
                               参加申込締切 <span className="text-red-500">*</span>
                             </FormLabel>
                             {isChanged("registration_deadline") && (
-                              <Badge
-                                variant="outline"
-                                className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                              >
+                              <Badge variant="outline" className={changedBadgeClass}>
                                 変更あり
                               </Badge>
                             )}
@@ -524,8 +526,7 @@ export function SinglePageEventEditForm({
                                 isPending || !restrictions.isFieldEditable("registration_deadline")
                               }
                               className={cn(
-                                isChanged("registration_deadline") &&
-                                  "bg-orange-50/30 border-orange-300"
+                                isChanged("registration_deadline") && changedFieldClass
                               )}
                             />
                           </FormControl>
@@ -555,16 +556,13 @@ export function SinglePageEventEditForm({
                             参加費 <span className="text-red-500">*</span>
                           </FormLabel>
                           {isChanged("fee") && (
-                            <Badge
-                              variant="outline"
-                              className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                            >
+                            <Badge variant="outline" className={changedBadgeClass}>
                               変更あり
                             </Badge>
                           )}
                         </div>
                         <FormControl>
-                          <div className="relative max-w-xs">
+                          <div className="relative w-full sm:max-w-xs">
                             <Input
                               {...field}
                               type="number"
@@ -573,11 +571,11 @@ export function SinglePageEventEditForm({
                               min="0"
                               max="1000000"
                               className={cn(
-                                "h-12 pr-10",
-                                isChanged("fee") && "bg-orange-50/30 border-orange-300"
+                                "h-11 bg-background pr-10",
+                                isChanged("fee") && changedFieldClass
                               )}
                             />
-                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">
+                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
                               円
                             </span>
                           </div>
@@ -614,27 +612,24 @@ export function SinglePageEventEditForm({
                               集金方法を選択 <span className="text-red-500">*</span>
                             </FormLabel>
                             {isChanged("payment_methods") && (
-                              <Badge
-                                variant="outline"
-                                className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                              >
+                              <Badge variant="outline" className={changedBadgeClass}>
                                 変更あり
                               </Badge>
                             )}
                           </div>
 
                           <div
-                            className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3"
+                            className="mt-3 flex flex-col gap-3 sm:grid sm:grid-cols-2"
                             data-testid="payment-methods"
                           >
                             {/* 現金払い */}
                             <label
                               className={cn(
-                                "relative flex items-center p-4 rounded-xl border-2 transition-all",
+                                "relative flex min-h-[5.25rem] items-center rounded-lg border p-4 transition-colors sm:min-h-24",
                                 isPending ? "opacity-70 cursor-not-allowed" : "cursor-pointer",
                                 Array.isArray(field.value) && field.value.includes("cash")
-                                  ? "border-primary bg-primary/5"
-                                  : "border-slate-200 hover:border-slate-300 bg-white"
+                                  ? "border-primary/50 bg-primary/5"
+                                  : "border-border bg-background hover:border-primary/30"
                               )}
                             >
                               <input
@@ -659,28 +654,28 @@ export function SinglePageEventEditForm({
                                   isPending || !restrictions.isFieldEditable("payment_methods")
                                 }
                               />
-                              <div className="flex items-center gap-3">
+                              <div className="flex items-center gap-3 pr-8">
                                 <div
                                   className={cn(
-                                    "p-2 rounded-lg",
+                                    "flex size-10 items-center justify-center rounded-md border",
                                     Array.isArray(field.value) && field.value.includes("cash")
-                                      ? "bg-primary/20 text-primary"
-                                      : "bg-slate-100 text-slate-500"
+                                      ? "border-primary/20 bg-primary/10 text-primary"
+                                      : "border-border bg-muted/40 text-muted-foreground"
                                   )}
                                 >
                                   <WalletIcon className="w-5 h-5" />
                                 </div>
                                 <div>
-                                  <span className="block font-semibold text-sm text-slate-900">
+                                  <span className="block text-sm font-semibold text-foreground">
                                     現金
                                   </span>
-                                  <span className="block text-xs text-slate-500">
+                                  <span className="mt-0.5 block text-xs text-muted-foreground">
                                     当日現地などで集金
                                   </span>
                                 </div>
                               </div>
                               {Array.isArray(field.value) && field.value.includes("cash") && (
-                                <div className="absolute top-3 right-3 h-5 w-5 bg-primary rounded-full flex items-center justify-center text-white animate-in zoom-in-50 duration-200">
+                                <div className="absolute right-3 top-3 flex size-5 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground duration-200 zoom-in-50">
                                   <CheckIcon className="w-3.5 h-3.5 stroke-[3]" />
                                 </div>
                               )}
@@ -689,13 +684,13 @@ export function SinglePageEventEditForm({
                             {/* オンライン決済 */}
                             <label
                               className={cn(
-                                "relative flex items-center p-4 rounded-xl border-2 transition-all",
+                                "relative flex min-h-[5.25rem] items-center rounded-lg border p-4 transition-colors sm:min-h-24",
                                 !canUseOnlinePayments || isPending
                                   ? "opacity-60 cursor-not-allowed"
                                   : "cursor-pointer",
                                 Array.isArray(field.value) && field.value.includes("stripe")
-                                  ? "border-primary bg-primary/5"
-                                  : "border-slate-200 hover:border-slate-300 bg-white"
+                                  ? "border-primary/50 bg-primary/5"
+                                  : "border-border bg-background hover:border-primary/30"
                               )}
                             >
                               <input
@@ -724,28 +719,28 @@ export function SinglePageEventEditForm({
                                   !restrictions.isFieldEditable("payment_methods")
                                 }
                               />
-                              <div className="flex items-center gap-3">
+                              <div className="flex items-center gap-3 pr-8">
                                 <div
                                   className={cn(
-                                    "p-2 rounded-lg",
+                                    "flex size-10 items-center justify-center rounded-md border",
                                     Array.isArray(field.value) && field.value.includes("stripe")
-                                      ? "bg-primary/20 text-primary"
-                                      : "bg-slate-100 text-slate-500"
+                                      ? "border-primary/20 bg-primary/10 text-primary"
+                                      : "border-border bg-muted/40 text-muted-foreground"
                                   )}
                                 >
                                   <CreditCardIcon className="w-5 h-5" />
                                 </div>
                                 <div>
-                                  <span className="block font-semibold text-sm text-slate-900">
+                                  <span className="block text-sm font-semibold text-foreground">
                                     オンライン
                                   </span>
-                                  <span className="block text-xs text-slate-500">
+                                  <span className="mt-0.5 block text-xs text-muted-foreground">
                                     クレジットカード、Apple Pay、Google Payなど
                                   </span>
                                 </div>
                               </div>
                               {Array.isArray(field.value) && field.value.includes("stripe") && (
-                                <div className="absolute top-3 right-3 h-5 w-5 bg-primary rounded-full flex items-center justify-center text-white animate-in zoom-in-50 duration-200">
+                                <div className="absolute right-3 top-3 flex size-5 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground duration-200 zoom-in-50">
                                   <CheckIcon className="w-3.5 h-3.5 stroke-[3]" />
                                 </div>
                               )}
@@ -753,15 +748,18 @@ export function SinglePageEventEditForm({
                           </div>
 
                           {!canUseOnlinePayments && (
-                            <p className="text-xs text-muted-foreground mt-2">
+                            <p className="mt-2 text-xs text-muted-foreground">
                               「オンライン」を選択するにはオンライン集金設定が必要です。
-                              <Link href="/settings/payments" className="underline ml-1">
+                              <Link
+                                href="/settings/payments"
+                                className="ml-1 font-medium underline underline-offset-4"
+                              >
                                 設定に進む
                               </Link>
                             </p>
                           )}
                           {!restrictions.isFieldEditable("payment_methods") && (
-                            <p className="text-xs text-amber-600 mt-2">
+                            <p className="mt-2 text-xs text-amber-600">
                               参加者がいるため、集金方法の解除はできません
                             </p>
                           )}
@@ -770,22 +768,29 @@ export function SinglePageEventEditForm({
                       )}
                     />
                   ) : (
-                    <div className="bg-gradient-to-r from-blue-50 to-green-50 border border-blue-200 text-blue-800 px-6 py-4 rounded-lg">
-                      <p className="font-medium">✓ 参加費が0円のため、決済方法の設定は不要です</p>
-                    </div>
+                    <Alert
+                      variant="success"
+                      className="border-primary/20 bg-primary/5 text-foreground"
+                    >
+                      <CheckIcon className="size-4" />
+                      <AlertTitle>参加費が0円のため、決済方法の設定は不要です</AlertTitle>
+                      <AlertDescription className="text-muted-foreground">
+                        参加者は無料でイベントに参加できます
+                      </AlertDescription>
+                    </Alert>
                   )}
 
                   {/* オンライン決済設定（Stripe選択時のみ表示） */}
                   {!isFreeEvent && isOnlineSelected && (
                     <div
                       className={cn(
-                        "border border-blue-200 rounded-lg p-6 bg-blue-50/30 space-y-6",
-                        "transition-all duration-300 ease-in-out"
+                        "flex flex-col gap-6 rounded-lg border border-primary/20 bg-primary/5 p-4 md:p-5",
+                        "transition-all duration-300 ease-in-out animate-in fade-in slide-in-from-top-1"
                       )}
                     >
-                      <div className="flex items-start gap-2 mb-3">
-                        <InfoIcon className="w-4 h-4 text-blue-500 mt-0.5" />
-                        <p className="text-xs text-blue-700">
+                      <div className="flex items-start gap-2">
+                        <InfoIcon className="mt-0.5 h-4 w-4 text-primary" />
+                        <p className="text-xs text-muted-foreground">
                           オンライン集金を選択した場合、決済期限を設定できます。
                         </p>
                       </div>
@@ -801,10 +806,7 @@ export function SinglePageEventEditForm({
                                 オンライン決済締切 <span className="text-red-500">*</span>
                               </FormLabel>
                               {isChanged("payment_deadline") && (
-                                <Badge
-                                  variant="outline"
-                                  className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                                >
+                                <Badge variant="outline" className={changedBadgeClass}>
                                   変更あり
                                 </Badge>
                               )}
@@ -824,10 +826,7 @@ export function SinglePageEventEditForm({
                                 disabled={
                                   isPending || !restrictions.isFieldEditable("payment_deadline")
                                 }
-                                className={cn(
-                                  isChanged("payment_deadline") &&
-                                    "bg-orange-50/30 border-orange-300"
-                                )}
+                                className={cn(isChanged("payment_deadline") && changedFieldClass)}
                               />
                             </FormControl>
                             <FormDescription>（後払いも可能）</FormDescription>
@@ -837,22 +836,19 @@ export function SinglePageEventEditForm({
                       />
 
                       {/* 締切後決済許可設定 */}
-                      <div className="border border-gray-200 rounded-lg p-5 bg-white">
+                      <div className="rounded-lg border border-border bg-background p-4 md:p-5">
                         <FormField
                           control={form.control}
                           name="allow_payment_after_deadline"
                           render={({ field }) => (
-                            <FormItem className="flex flex-row items-center justify-between space-x-3 space-y-0">
-                              <div className="space-y-1 leading-none">
+                            <FormItem className="flex flex-row items-center justify-between gap-4 space-y-0">
+                              <div className="flex flex-col gap-1 leading-none">
                                 <div className="flex items-center gap-2">
                                   <FormLabel className="text-sm font-medium">
                                     締切後も決済を許可
                                   </FormLabel>
                                   {isChanged("allow_payment_after_deadline") && (
-                                    <Badge
-                                      variant="outline"
-                                      className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                                    >
+                                    <Badge variant="outline" className={changedBadgeClass}>
                                       変更あり
                                     </Badge>
                                   )}
@@ -876,7 +872,7 @@ export function SinglePageEventEditForm({
                         />
 
                         {form.watch("allow_payment_after_deadline") && (
-                          <div className="mt-4">
+                          <div className="mt-4 border-t border-border pt-4">
                             <FormField
                               control={form.control}
                               name="grace_period_days"
@@ -887,10 +883,7 @@ export function SinglePageEventEditForm({
                                       猶予期間（日）
                                     </FormLabel>
                                     {isChanged("grace_period_days") && (
-                                      <Badge
-                                        variant="outline"
-                                        className="text-xs bg-orange-50 text-orange-700 border-orange-200"
-                                      >
+                                      <Badge variant="outline" className={changedBadgeClass}>
                                         変更あり
                                       </Badge>
                                     )}
@@ -909,9 +902,8 @@ export function SinglePageEventEditForm({
                                         !restrictions.isFieldEditable("grace_period_days")
                                       }
                                       className={cn(
-                                        "h-12 max-w-xs",
-                                        isChanged("grace_period_days") &&
-                                          "bg-orange-50/30 border-orange-300"
+                                        "h-11 w-full bg-background sm:max-w-xs",
+                                        isChanged("grace_period_days") && changedFieldClass
                                       )}
                                       onChange={(e) => {
                                         const v = e.target.value;
@@ -933,54 +925,66 @@ export function SinglePageEventEditForm({
                     </div>
                   )}
                 </FormSection>
+
+                {/* モバイル用: 決済締切まで入力した後にタイムライン表示 */}
+                <div className="lg:hidden">
+                  {watchedDate && (
+                    <div className="animate-in fade-in slide-in-from-top-2 duration-300">
+                      {TimelinePreview}
+                    </div>
+                  )}
+                </div>
               </div>
 
               {/* 右カラム: タイムライン & 補足情報 */}
-              <div className="hidden lg:block lg:col-span-5 xl:col-span-4 space-y-6 sticky top-24">
+              <div className="sticky top-24 hidden flex-col gap-4 lg:col-span-5 lg:flex xl:col-span-4">
                 {/* タイムラインプレビュー (デスクトップ) */}
                 {watchedDate && (
-                  <div className="transition-all duration-500 ease-in-out">{TimelinePreview}</div>
+                  <div className="animate-in fade-in slide-in-from-right-3 duration-300">
+                    {TimelinePreview}
+                  </div>
                 )}
               </div>
-
-              {/* モバイル用: フォーム下部へのタイムライン表示 */}
-              <div className="lg:hidden col-span-1 mt-8">{watchedDate && TimelinePreview}</div>
             </div>
 
             {/* 全体のエラーメッセージ */}
             {form.formState.errors.root && (
-              <div className="mt-8 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg flex items-center gap-3">
-                <div className="w-2 h-2 bg-red-500 rounded-full" />
-                {form.formState.errors.root.message}
-              </div>
+              <Alert variant="destructive" className="mt-6">
+                <AlertDescription>{form.formState.errors.root.message}</AlertDescription>
+              </Alert>
             )}
 
             {/* Footer Actions */}
-            <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-slate-200 bg-white px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-4 md:left-[var(--sidebar-width)]">
-              <div className="max-w-7xl mx-auto flex items-center justify-end gap-4">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => window.history.back()}
-                  disabled={isPending}
-                  className="text-slate-500 hover:text-slate-800 hover:bg-slate-100"
-                >
-                  キャンセル
-                </Button>
-                <Button
-                  type="submit"
-                  disabled={isPending || !changes.hasChanges}
-                  className="h-12 px-8 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 shadow-lg shadow-blue-500/20 text-sm md:text-base font-semibold transition-all hover:scale-[1.02] active:scale-[0.98]"
-                >
-                  {isPending ? (
-                    <>
-                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2" />
-                      更新中...
-                    </>
-                  ) : (
-                    "変更を保存"
-                  )}
-                </Button>
+            <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background/95 px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pt-3 shadow-[0_-8px_24px_-20px_hsl(var(--foreground)/0.35)] backdrop-blur sm:px-4 sm:pb-[calc(1rem+env(safe-area-inset-bottom))] md:left-[var(--sidebar-width)]">
+              <div className="mx-auto flex max-w-7xl items-center justify-between gap-3">
+                <p className="hidden text-xs text-muted-foreground sm:block">
+                  変更内容を確認してイベントを更新します。
+                </p>
+                <div className="ml-auto grid w-full grid-cols-[6.5rem_1fr] items-center gap-2 sm:flex sm:w-auto sm:gap-3">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => window.history.back()}
+                    disabled={isPending}
+                    className="h-11 text-muted-foreground"
+                  >
+                    キャンセル
+                  </Button>
+                  <Button
+                    type="submit"
+                    disabled={isPending || !changes.hasChanges}
+                    className="h-11 min-w-0 rounded-md px-4 text-sm font-semibold transition-transform active:scale-[0.98] sm:min-w-36 sm:px-6"
+                  >
+                    {isPending ? (
+                      <>
+                        <div className="mr-2 size-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-b-primary-foreground" />
+                        更新中...
+                      </>
+                    ) : (
+                      "変更を保存"
+                    )}
+                  </Button>
+                </div>
               </div>
             </div>
           </form>

--- a/features/events/components/SinglePageEventForm.tsx
+++ b/features/events/components/SinglePageEventForm.tsx
@@ -20,6 +20,7 @@ import { getCurrentJstTime } from "@core/utils/timezone";
 
 import { useMobileBottomOverlay } from "@/components/layout/mobile-chrome-context";
 import { cn } from "@/components/ui/_lib/cn";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardTitle, CardDescription } from "@/components/ui/card";
 import { DateTimePicker } from "@/components/ui/date-time-picker";
@@ -53,28 +54,30 @@ function FormSection({ title, description, icon, children, className }: FormSect
   return (
     <Card
       className={cn(
-        "border-0 shadow-lg shadow-slate-200/40 ring-1 ring-slate-100 overflow-hidden",
+        "overflow-hidden rounded-lg border border-border/70 bg-card shadow-none",
         className
       )}
     >
-      <div className="bg-gradient-to-r from-slate-50 to-white border-b border-slate-100 p-4 md:p-6">
-        <div className="flex items-start gap-4">
+      <div className="border-b border-border/70 bg-muted/20 p-4 sm:p-5">
+        <div className="flex items-start gap-3 sm:gap-4">
           {icon && (
-            <div className="p-2.5 bg-white shadow-sm ring-1 ring-slate-200/50 rounded-xl text-primary shrink-0">
+            <div className="hidden size-10 shrink-0 items-center justify-center rounded-md border border-border bg-background text-primary sm:flex">
               {icon}
             </div>
           )}
           <div>
-            <CardTitle className="text-base md:text-lg font-bold text-slate-900 tracking-tight">
+            <CardTitle className="text-base font-semibold tracking-tight text-foreground md:text-lg">
               {title}
             </CardTitle>
             {description && (
-              <CardDescription className="mt-1.5 text-slate-500">{description}</CardDescription>
+              <CardDescription className="mt-1 text-sm text-muted-foreground">
+                {description}
+              </CardDescription>
             )}
           </div>
         </div>
       </div>
-      <CardContent className="p-4 md:p-6 space-y-6">{children}</CardContent>
+      <CardContent className="flex flex-col gap-5 p-4 sm:gap-6 sm:p-5">{children}</CardContent>
     </Card>
   );
 }
@@ -139,20 +142,41 @@ function SinglePageEventForm({
   );
 
   return (
-    <div className="w-full max-w-7xl mx-auto p-4 mb-32">
-      {/* Header */}
-      <header className="mb-6">
-        <h1 className="text-xl md:text-2xl font-bold text-slate-900 tracking-tight">
-          新しいイベントを作成
-        </h1>
-        <p className="mt-2 text-sm text-slate-500">{currentCommunityName} のイベントを作成します</p>
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-3 pb-28 pt-3 sm:gap-6 sm:px-6 sm:pb-32 lg:px-8 lg:pt-8">
+      <header className="flex flex-col gap-3 border-b border-border/70 pb-4 sm:gap-4 sm:pb-5 md:flex-row md:items-end md:justify-between">
+        <div className="flex flex-col gap-2">
+          <p className="truncate text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground sm:tracking-[0.16em]">
+            {currentCommunityName}
+          </p>
+          <div className="flex flex-col gap-1">
+            <h1 className="text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+              新しいイベントを作成
+            </h1>
+          </div>
+        </div>
+        <div
+          className={cn(
+            "inline-flex w-fit max-w-full items-center gap-2 rounded-md border px-3 py-2 text-xs font-medium",
+            canUseOnlinePayments
+              ? "border-primary/20 bg-primary/5 text-primary"
+              : "border-border bg-background text-muted-foreground"
+          )}
+        >
+          <span
+            className={cn(
+              "size-2 rounded-full",
+              canUseOnlinePayments ? "bg-primary" : "bg-muted-foreground/40"
+            )}
+          />
+          {canUseOnlinePayments ? "オンライン集金 利用可" : "オンライン集金 未設定"}
+        </div>
       </header>
 
       <Form {...form}>
         <form onSubmit={onSubmit} className="space-y-0" noValidate>
-          <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
+          <div className="grid grid-cols-1 items-start gap-5 sm:gap-6 lg:grid-cols-12 lg:gap-8">
             {/* 左カラム: 入力フォーム */}
-            <div className="lg:col-span-7 xl:col-span-8 space-y-8">
+            <div className="flex flex-col gap-5 sm:gap-6 lg:col-span-7 xl:col-span-8">
               {/* ============================================= */}
               {/* Section 1: 基本情報 */}
               {/* ============================================= */}
@@ -175,7 +199,7 @@ function SinglePageEventForm({
                           placeholder="例：勉強会、夏合宿、会費の集金など"
                           disabled={isPending}
                           maxLength={100}
-                          className="h-12"
+                          className="h-11 bg-background"
                         />
                       </FormControl>
                       <FormMessage />
@@ -196,7 +220,7 @@ function SinglePageEventForm({
                           disabled={isPending}
                           rows={4}
                           maxLength={1000}
-                          className="resize-none"
+                          className="min-h-28 resize-none bg-background"
                         />
                       </FormControl>
                       <FormMessage />
@@ -218,7 +242,7 @@ function SinglePageEventForm({
                             placeholder="例：〇〇会議室、〇〇居酒屋など"
                             disabled={isPending}
                             maxLength={200}
-                            className="h-12 pl-10"
+                            className="h-11 bg-background pl-10"
                           />
                         </div>
                       </FormControl>
@@ -234,7 +258,7 @@ function SinglePageEventForm({
                     <FormItem>
                       <FormLabel className="text-sm font-medium">定員（任意）</FormLabel>
                       <FormControl>
-                        <div className="relative max-w-xs">
+                        <div className="relative w-full sm:max-w-xs">
                           <UsersIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
                           <Input
                             {...field}
@@ -243,7 +267,7 @@ function SinglePageEventForm({
                             disabled={isPending}
                             min="1"
                             max="10000"
-                            className="h-12 pl-10 pr-10"
+                            className="h-11 bg-background pl-10 pr-10"
                           />
                           <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">
                             人
@@ -344,7 +368,7 @@ function SinglePageEventForm({
                         参加費 <span className="text-red-500">*</span>
                       </FormLabel>
                       <FormControl>
-                        <div className="relative max-w-xs">
+                        <div className="relative w-full sm:max-w-xs">
                           <Input
                             {...field}
                             type="number"
@@ -352,7 +376,7 @@ function SinglePageEventForm({
                             disabled={isPending}
                             min="0"
                             max="1000000"
-                            className="h-12 pr-10"
+                            className="h-11 bg-background pr-10"
                           />
                           <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">
                             円
@@ -384,17 +408,17 @@ function SinglePageEventForm({
                         </FormLabel>
 
                         <div
-                          className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3"
+                          className="mt-3 flex flex-col gap-3 sm:grid sm:grid-cols-2"
                           data-testid="payment-methods"
                         >
                           {/* 現金払い */}
                           <label
                             className={cn(
-                              "relative flex items-center p-4 rounded-xl border-2 transition-all",
+                              "relative flex min-h-[5.25rem] items-center rounded-lg border p-4 transition-colors sm:min-h-24",
                               isPending ? "opacity-70 cursor-not-allowed" : "cursor-pointer",
                               Array.isArray(field.value) && field.value.includes("cash")
-                                ? "border-primary bg-primary/5"
-                                : "border-slate-200 hover:border-slate-300 bg-white"
+                                ? "border-primary/50 bg-primary/5"
+                                : "border-border bg-background hover:border-primary/30"
                             )}
                           >
                             <input
@@ -410,28 +434,28 @@ function SinglePageEventForm({
                               }}
                               disabled={isPending}
                             />
-                            <div className="flex items-center gap-3">
+                            <div className="flex items-center gap-3 pr-8">
                               <div
                                 className={cn(
-                                  "p-2 rounded-lg",
+                                  "flex size-10 items-center justify-center rounded-md border",
                                   Array.isArray(field.value) && field.value.includes("cash")
-                                    ? "bg-primary/20 text-primary"
-                                    : "bg-slate-100 text-slate-500"
+                                    ? "border-primary/20 bg-primary/10 text-primary"
+                                    : "border-border bg-muted/40 text-muted-foreground"
                                 )}
                               >
                                 <WalletIcon className="w-5 h-5" />
                               </div>
                               <div>
-                                <span className="block font-semibold text-sm text-slate-900">
+                                <span className="block text-sm font-semibold text-foreground">
                                   現金
                                 </span>
-                                <span className="block text-xs text-slate-500">
+                                <span className="mt-0.5 block text-xs text-muted-foreground">
                                   当日現地などで集金
                                 </span>
                               </div>
                             </div>
                             {Array.isArray(field.value) && field.value.includes("cash") && (
-                              <div className="absolute top-3 right-3 h-5 w-5 bg-primary rounded-full flex items-center justify-center text-white animate-in zoom-in-50 duration-200">
+                              <div className="absolute right-3 top-3 flex size-5 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground duration-200 zoom-in-50">
                                 <CheckIcon className="w-3.5 h-3.5 stroke-[3]" />
                               </div>
                             )}
@@ -440,13 +464,13 @@ function SinglePageEventForm({
                           {/* オンライン決済 */}
                           <label
                             className={cn(
-                              "relative flex items-center p-4 rounded-xl border-2 transition-all",
+                              "relative flex min-h-[5.25rem] items-center rounded-lg border p-4 transition-colors sm:min-h-24",
                               !canUseOnlinePayments || isPending
                                 ? "opacity-60 cursor-not-allowed"
                                 : "cursor-pointer",
                               Array.isArray(field.value) && field.value.includes("stripe")
-                                ? "border-primary bg-primary/5"
-                                : "border-slate-200 hover:border-slate-300 bg-white"
+                                ? "border-primary/50 bg-primary/5"
+                                : "border-border bg-background hover:border-primary/30"
                             )}
                           >
                             <input
@@ -462,28 +486,28 @@ function SinglePageEventForm({
                               }}
                               disabled={isPending || !canUseOnlinePayments}
                             />
-                            <div className="flex items-center gap-3">
+                            <div className="flex items-center gap-3 pr-8">
                               <div
                                 className={cn(
-                                  "p-2 rounded-lg",
+                                  "flex size-10 items-center justify-center rounded-md border",
                                   Array.isArray(field.value) && field.value.includes("stripe")
-                                    ? "bg-primary/20 text-primary"
-                                    : "bg-slate-100 text-slate-500"
+                                    ? "border-primary/20 bg-primary/10 text-primary"
+                                    : "border-border bg-muted/40 text-muted-foreground"
                                 )}
                               >
                                 <CreditCardIcon className="w-5 h-5" />
                               </div>
                               <div>
-                                <span className="block font-semibold text-sm text-slate-900">
+                                <span className="block text-sm font-semibold text-foreground">
                                   オンライン
                                 </span>
-                                <span className="block text-xs text-slate-500">
+                                <span className="mt-0.5 block text-xs text-muted-foreground">
                                   クレジットカード、Apple Pay、Google Payなど
                                 </span>
                               </div>
                             </div>
                             {Array.isArray(field.value) && field.value.includes("stripe") && (
-                              <div className="absolute top-3 right-3 h-5 w-5 bg-primary rounded-full flex items-center justify-center text-white animate-in zoom-in-50 duration-200">
+                              <div className="absolute right-3 top-3 flex size-5 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground duration-200 zoom-in-50">
                                 <CheckIcon className="w-3.5 h-3.5 stroke-[3]" />
                               </div>
                             )}
@@ -491,11 +515,11 @@ function SinglePageEventForm({
                         </div>
 
                         {!canUseOnlinePayments && (
-                          <p className="text-xs text-muted-foreground mt-2">
-                            「オンライン」を選択するにはオンライン集金設定が必要です。
+                          <p className="mt-2 text-xs text-muted-foreground">
+                            「オンライン決済」を選択するにはオンライン集金設定が必要です。
                             <Link
                               href={connectStatus?.actionUrl ?? "/settings/payments"}
-                              className="underline ml-1"
+                              className="ml-1 font-medium underline underline-offset-4"
                             >
                               設定に進む
                             </Link>
@@ -506,25 +530,29 @@ function SinglePageEventForm({
                     )}
                   />
                 ) : (
-                  <div className="bg-gradient-to-r from-blue-50 to-green-50 border border-blue-200 text-blue-800 px-6 py-4 rounded-lg">
-                    <p className="font-medium">✓ 参加費が0円のため、決済方法の設定は不要です</p>
-                    <p className="text-sm mt-1 text-blue-700">
+                  <Alert
+                    variant="success"
+                    className="border-primary/20 bg-primary/5 text-foreground"
+                  >
+                    <CheckIcon className="size-4" />
+                    <AlertTitle>参加費が0円のため、決済方法の設定は不要です</AlertTitle>
+                    <AlertDescription className="text-muted-foreground">
                       参加者は無料でイベントに参加できます
-                    </p>
-                  </div>
+                    </AlertDescription>
+                  </Alert>
                 )}
 
                 {/* オンライン決済設定（Stripe選択時のみ表示） */}
                 {!isFreeEvent && isOnlineSelected && (
                   <div
                     className={cn(
-                      "border border-blue-200 rounded-lg p-6 bg-blue-50/30 space-y-6",
-                      "transition-all duration-300 ease-in-out"
+                      "flex flex-col gap-6 rounded-lg border border-primary/20 bg-primary/5 p-4 md:p-5",
+                      "transition-all duration-300 ease-in-out animate-in fade-in slide-in-from-top-1"
                     )}
                   >
-                    <div className="flex items-start gap-2 mb-3">
-                      <InfoIcon className="w-4 h-4 text-blue-500 mt-0.5" />
-                      <p className="text-xs text-blue-700">
+                    <div className="flex items-start gap-2">
+                      <InfoIcon className="mt-0.5 h-4 w-4 text-primary" />
+                      <p className="text-xs text-muted-foreground">
                         オンライン集金を選択した場合、決済期限を設定できます。
                       </p>
                     </div>
@@ -560,13 +588,13 @@ function SinglePageEventForm({
                     />
 
                     {/* 締切後決済許可設定 */}
-                    <div className="border border-gray-200 rounded-lg p-5 bg-white">
+                    <div className="rounded-lg border border-border bg-background p-4 md:p-5">
                       <FormField
                         control={form.control}
                         name="allow_payment_after_deadline"
                         render={({ field }) => (
-                          <FormItem className="flex flex-row items-center justify-between space-x-3 space-y-0">
-                            <div className="space-y-1 leading-none">
+                          <FormItem className="flex flex-row items-center justify-between gap-4 space-y-0">
+                            <div className="flex flex-col gap-1 leading-none">
                               <FormLabel className="text-sm font-medium">
                                 締切後も決済を許可
                               </FormLabel>
@@ -586,7 +614,7 @@ function SinglePageEventForm({
                       />
 
                       {form.watch("allow_payment_after_deadline") && (
-                        <div className="mt-4">
+                        <div className="mt-4 border-t border-border pt-4">
                           <FormField
                             control={form.control}
                             name="grace_period_days"
@@ -605,7 +633,7 @@ function SinglePageEventForm({
                                     step="1"
                                     placeholder="7"
                                     disabled={isPending}
-                                    className="h-12 max-w-xs"
+                                    className="h-11 w-full bg-background sm:max-w-xs"
                                     onChange={(e) => {
                                       const v = e.target.value;
                                       field.onChange(v);
@@ -626,23 +654,32 @@ function SinglePageEventForm({
                   </div>
                 )}
               </FormSection>
+
+              {/* モバイル用: 決済締切まで入力した後にタイムライン表示 */}
+              <div className="lg:hidden">
+                {watchedDate && (
+                  <div className="animate-in fade-in slide-in-from-top-2 duration-300">
+                    {TimelinePreview}
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* 右カラム: タイムライン & 補足情報 */}
-            <div className="hidden lg:block lg:col-span-5 xl:col-span-4 space-y-6 sticky top-24">
+            <div className="sticky top-24 hidden flex-col gap-4 lg:col-span-5 lg:flex xl:col-span-4">
               {/* タイムラインプレビュー (デスクトップ) */}
               {watchedDate && (
-                <div className="transition-all duration-500 ease-in-out animate-in fade-in slide-in-from-right-4">
+                <div className="animate-in fade-in slide-in-from-right-3 duration-300">
                   {TimelinePreview}
                 </div>
               )}
 
               {/* Tipsなどをここに配置可能 */}
               {!watchedDate && (
-                <Card className="border-dashed border-2 border-slate-200 bg-slate-50/50 shadow-none">
-                  <CardContent className="flex flex-col items-center justify-center p-12 text-center text-slate-400">
-                    <ClockIcon className="w-12 h-12 mb-4 opacity-20" />
-                    <p className="text-sm font-medium">
+                <Card className="rounded-lg border border-dashed border-border bg-background/70 shadow-none">
+                  <CardContent className="flex min-h-64 flex-col items-center justify-center p-8 text-center text-muted-foreground">
+                    <ClockIcon className="mb-4 h-10 w-10 opacity-30" />
+                    <p className="text-sm font-medium leading-6">
                       日時を入力すると
                       <br />
                       タイムラインプレビューが表示されます
@@ -651,45 +688,46 @@ function SinglePageEventForm({
                 </Card>
               )}
             </div>
-
-            {/* モバイル用: フォーム下部へのタイムライン表示 */}
-            <div className="lg:hidden col-span-1 mt-8">{watchedDate && TimelinePreview}</div>
           </div>
 
           {/* 全体のエラーメッセージ */}
           {form.formState.errors.root && (
-            <div className="mt-8 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg flex items-center gap-3">
-              <div className="w-2 h-2 bg-red-500 rounded-full" />
-              {form.formState.errors.root.message}
-            </div>
+            <Alert variant="destructive" className="mt-6">
+              <AlertDescription>{form.formState.errors.root.message}</AlertDescription>
+            </Alert>
           )}
 
           {/* Footer Actions */}
-          <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-slate-200 bg-white px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-4 md:left-[var(--sidebar-width)]">
-            <div className="max-w-7xl mx-auto flex items-center justify-end gap-4">
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => (window.location.href = "/dashboard")}
-                disabled={isPending}
-                className="text-slate-500 hover:text-slate-800 hover:bg-slate-100"
-              >
-                キャンセル
-              </Button>
-              <Button
-                type="submit"
-                disabled={isPending}
-                className="h-12 px-8 rounded-xl bg-secondary text-white hover:bg-secondary/90 shadow-lg shadow-blue-500/20 text-sm md:text-base font-semibold transition-all hover:scale-[1.02] active:scale-[0.98]"
-              >
-                {isPending ? (
-                  <>
-                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2" />
-                    作成中...
-                  </>
-                ) : (
-                  "イベントを作成"
-                )}
-              </Button>
+          <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background/95 px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pt-3 shadow-[0_-8px_24px_-20px_hsl(var(--foreground)/0.35)] backdrop-blur sm:px-4 sm:pb-[calc(1rem+env(safe-area-inset-bottom))] md:left-[var(--sidebar-width)]">
+            <div className="mx-auto flex max-w-7xl items-center justify-between gap-3">
+              <p className="hidden text-xs text-muted-foreground sm:block">
+                入力内容を確認してイベントを作成します。
+              </p>
+              <div className="ml-auto grid w-full grid-cols-[6.5rem_1fr] items-center gap-2 sm:flex sm:w-auto sm:gap-3">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => (window.location.href = "/events")}
+                  disabled={isPending}
+                  className="h-11 text-muted-foreground"
+                >
+                  キャンセル
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isPending}
+                  className="h-11 min-w-0 rounded-md px-4 text-sm font-semibold transition-transform active:scale-[0.98] sm:min-w-36 sm:px-6"
+                >
+                  {isPending ? (
+                    <>
+                      <div className="mr-2 size-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-b-primary-foreground" />
+                      作成中...
+                    </>
+                  ) : (
+                    "イベントを作成"
+                  )}
+                </Button>
+              </div>
             </div>
           </div>
         </form>

--- a/tests/e2e/event-creation.spec.ts
+++ b/tests/e2e/event-creation.spec.ts
@@ -154,7 +154,7 @@ test.describe("イベント作成（E2E）", () => {
     // オンライン決済のラベルを取得
     const paymentMethodsContainer = page.getByTestId("payment-methods");
     const onlinePaymentLabel = paymentMethodsContainer.locator("label").filter({
-      hasText: "オンライン決済",
+      hasText: "オンライン",
     });
 
     // オンライン決済が有効な場合のフロー
@@ -177,7 +177,7 @@ test.describe("イベント作成（E2E）", () => {
     } else {
       // オンライン決済が無効な場合は現金を選択
       const cashPaymentLabel = paymentMethodsContainer.locator("label").filter({
-        hasText: "現金払い",
+        hasText: "現金",
       });
       await cashPaymentLabel.click();
     }

--- a/tests/unit/components/layout/MarketingHeader.test.tsx
+++ b/tests/unit/components/layout/MarketingHeader.test.tsx
@@ -41,10 +41,7 @@ describe("MarketingHeader", () => {
     expect(screen.getByRole("link", { name: "みんなの集金" })).toHaveAttribute("href", "/");
     expect(screen.getByRole("link", { name: "機能" })).toHaveAttribute("href", "/#features");
     expect(screen.getByRole("link", { name: "料金" })).toHaveAttribute("href", "/#pricing");
-    expect(screen.getByRole("link", { name: "デモ" })).toHaveAttribute(
-      "href",
-      "https://demo.minnano-shukin.com/start-demo"
-    );
+    expect(screen.queryByRole("link", { name: "デモ" })).not.toBeInTheDocument();
     screen
       .getAllByRole("link", { name: "ログイン" })
       .forEach((link) => expect(link).toHaveAttribute("href", "/login"));

--- a/tests/unit/core/announcements/announcement.schema.test.ts
+++ b/tests/unit/core/announcements/announcement.schema.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { parseAnnouncementFrontmatter } from "@core/announcements/announcement.schema";
+
+describe("parseAnnouncementFrontmatter", () => {
+  it("validates frontmatter and requires the slug to match the file name", () => {
+    const frontmatter = parseAnnouncementFrontmatter(
+      {
+        title: "料金体系改定のお知らせ",
+        description: "料金体系改定の対象と適用開始日をお知らせします。",
+        slug: "pricing-revision-2026-06",
+        publishedAt: "2026-05-01",
+        effectiveAt: "2026-06-01",
+        status: "published",
+        type: "pricing",
+        importance: "important",
+        audience: ["organizer"],
+        tags: ["料金", "手数料"],
+      },
+      "pricing-revision-2026-06"
+    );
+
+    expect(frontmatter.effectiveAt).toBe("2026-06-01");
+    expect(frontmatter.audience).toEqual(["organizer"]);
+    expect(frontmatter.tags).toEqual(["料金", "手数料"]);
+  });
+
+  it("defaults audience and tags to empty arrays", () => {
+    const frontmatter = parseAnnouncementFrontmatter(
+      {
+        title: "メンテナンスのお知らせ",
+        description: "メンテナンス予定についてお知らせします。",
+        slug: "maintenance-2026-05",
+        publishedAt: "2026-05-01",
+        status: "published",
+        type: "maintenance",
+        importance: "normal",
+      },
+      "maintenance-2026-05"
+    );
+
+    expect(frontmatter.audience).toEqual([]);
+    expect(frontmatter.tags).toEqual([]);
+  });
+
+  it("throws when the slug does not match the file name", () => {
+    expect(() =>
+      parseAnnouncementFrontmatter(
+        {
+          title: "料金体系改定のお知らせ",
+          description: "料金体系改定の対象と適用開始日をお知らせします。",
+          slug: "different-slug",
+          publishedAt: "2026-05-01",
+          status: "published",
+          type: "pricing",
+          importance: "important",
+        },
+        "pricing-revision-2026-06"
+      )
+    ).toThrow(/slug mismatch/);
+  });
+
+  it("throws for invalid type and importance", () => {
+    expect(() =>
+      parseAnnouncementFrontmatter(
+        {
+          title: "不正なお知らせ",
+          description: "不正な分類を持つお知らせです。",
+          slug: "invalid-announcement",
+          publishedAt: "2026-05-01",
+          status: "published",
+          type: "campaign",
+          importance: "urgent",
+        },
+        "invalid-announcement"
+      )
+    ).toThrow();
+  });
+});

--- a/tests/unit/core/announcements/announcement.schema.test.ts
+++ b/tests/unit/core/announcements/announcement.schema.test.ts
@@ -12,35 +12,11 @@ describe("parseAnnouncementFrontmatter", () => {
         publishedAt: "2026-05-01",
         effectiveAt: "2026-06-01",
         status: "published",
-        type: "pricing",
-        importance: "important",
-        audience: ["organizer"],
-        tags: ["料金", "手数料"],
       },
       "pricing-revision-2026-06"
     );
 
     expect(frontmatter.effectiveAt).toBe("2026-06-01");
-    expect(frontmatter.audience).toEqual(["organizer"]);
-    expect(frontmatter.tags).toEqual(["料金", "手数料"]);
-  });
-
-  it("defaults audience and tags to empty arrays", () => {
-    const frontmatter = parseAnnouncementFrontmatter(
-      {
-        title: "メンテナンスのお知らせ",
-        description: "メンテナンス予定についてお知らせします。",
-        slug: "maintenance-2026-05",
-        publishedAt: "2026-05-01",
-        status: "published",
-        type: "maintenance",
-        importance: "normal",
-      },
-      "maintenance-2026-05"
-    );
-
-    expect(frontmatter.audience).toEqual([]);
-    expect(frontmatter.tags).toEqual([]);
   });
 
   it("throws when the slug does not match the file name", () => {
@@ -52,27 +28,39 @@ describe("parseAnnouncementFrontmatter", () => {
           slug: "different-slug",
           publishedAt: "2026-05-01",
           status: "published",
-          type: "pricing",
-          importance: "important",
         },
         "pricing-revision-2026-06"
       )
     ).toThrow(/slug mismatch/);
   });
 
-  it("throws for invalid type and importance", () => {
+  it("throws for an invalid publish status", () => {
     expect(() =>
       parseAnnouncementFrontmatter(
         {
           title: "不正なお知らせ",
-          description: "不正な分類を持つお知らせです。",
+          description: "不正な公開状態を持つお知らせです。",
           slug: "invalid-announcement",
           publishedAt: "2026-05-01",
-          status: "published",
-          type: "campaign",
-          importance: "urgent",
+          status: "ready",
         },
         "invalid-announcement"
+      )
+    ).toThrow();
+  });
+
+  it("throws for unsupported metadata fields", () => {
+    expect(() =>
+      parseAnnouncementFrontmatter(
+        {
+          title: "料金体系改定のお知らせ",
+          description: "料金体系改定の対象と適用開始日をお知らせします。",
+          slug: "pricing-revision-2026-06",
+          publishedAt: "2026-05-01",
+          status: "published",
+          type: "pricing",
+        },
+        "pricing-revision-2026-06"
       )
     ).toThrow();
   });

--- a/tests/unit/core/announcements/publication.test.ts
+++ b/tests/unit/core/announcements/publication.test.ts
@@ -9,10 +9,6 @@ const baseAnnouncement: AnnouncementFrontmatter = {
   slug: "pricing-revision-2026-06",
   publishedAt: "2026-05-01",
   status: "published",
-  type: "pricing",
-  importance: "important",
-  audience: [],
-  tags: [],
 };
 
 describe("isAnnouncementPublished", () => {

--- a/tests/unit/core/announcements/publication.test.ts
+++ b/tests/unit/core/announcements/publication.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { AnnouncementFrontmatter } from "@core/announcements/announcement.types";
+import { isAnnouncementPublished } from "@core/announcements/publication";
+
+const baseAnnouncement: AnnouncementFrontmatter = {
+  title: "料金体系改定のお知らせ",
+  description: "料金体系改定の対象と適用開始日をお知らせします。",
+  slug: "pricing-revision-2026-06",
+  publishedAt: "2026-05-01",
+  status: "published",
+  type: "pricing",
+  importance: "important",
+  audience: [],
+  tags: [],
+};
+
+describe("isAnnouncementPublished", () => {
+  it("returns true for a published announcement whose publish date has passed", () => {
+    expect(isAnnouncementPublished(baseAnnouncement, new Date("2026-05-01T00:00:00+09:00"))).toBe(
+      true
+    );
+  });
+
+  it("returns false for draft announcements and future publish dates", () => {
+    expect(isAnnouncementPublished({ ...baseAnnouncement, status: "draft" })).toBe(false);
+    expect(isAnnouncementPublished(baseAnnouncement, new Date("2026-04-30T23:59:59+09:00"))).toBe(
+      false
+    );
+  });
+
+  it("uses Asia/Tokyo as the current-date boundary", () => {
+    expect(isAnnouncementPublished(baseAnnouncement, new Date("2026-04-30T15:00:00Z"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要
お知らせ機能の基盤と一覧・詳細ページを追加し、イベント作成・編集画面のUIを改善しました。

## 変更内容
- `/announcements` の一覧・詳細ページを追加
- Markdown frontmatter ベースのお知らせ管理基盤を追加
- お知らせのSEO/JSON-LD/sitemap対応を追加
- イベント作成・編集フォームのレイアウトとモバイル表示を改善
- フッター導線を整理し、お知らせリンクを追加
- 記事ページから読了時間表示を削除