### PR TITLE
fix: 認証セッション不整合と制御例外ログ修正

### DIFF
--- a/app/(app)/events/[id]/page.tsx
+++ b/app/(app)/events/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
 import type { ActionResult } from "@core/errors/adapters/server-actions";
 import { createCachedActions } from "@core/utils/cache-helpers";
 import { handleServerError } from "@core/utils/error-handler.server";
+import { isNextNavigationError } from "@core/utils/next";
 import type {
   CollectionProgressSummary,
   GetParticipantsResponse,
@@ -132,6 +133,10 @@ export default async function EventDetailPage(props: {
       />
     );
   } catch (error) {
+    if (isNextNavigationError(error)) {
+      throw error;
+    }
+
     handleServerError(error, {
       category: "event_management",
       action: "event_page_view",

--- a/core/auth/auth-utils.ts
+++ b/core/auth/auth-utils.ts
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 
 import type { User } from "@supabase/supabase-js";
 
-import { isMissingAuthSessionError } from "@core/supabase/auth-guards";
+import { isUnauthenticatedAuthError } from "@core/supabase/auth-guards";
 import {
   createServerActionSupabaseClient,
   createServerComponentSupabaseClient,
@@ -59,7 +59,7 @@ function isUnauthenticatedLookupResult(result: UserLookupResult): boolean {
     return true;
   }
 
-  return !result.user && isMissingAuthSessionError(result.authError);
+  return !result.user && isUnauthenticatedAuthError(result.authError);
 }
 
 function resolveRequiredUser(result: UserLookupResult, context: AuthLookupContext): User {

--- a/core/community/app-workspace.ts
+++ b/core/community/app-workspace.ts
@@ -45,10 +45,8 @@ function buildAppWorkspaceContext(
 }
 
 const getCachedAppWorkspaceForServerComponent = cache(async (): Promise<AppWorkspaceContext> => {
-  const [currentUser, currentCommunityResolution] = await Promise.all([
-    requireCurrentAppUserForServerComponent(),
-    resolveCurrentCommunityForServerComponent(),
-  ]);
+  const currentUser = await requireCurrentAppUserForServerComponent();
+  const currentCommunityResolution = await resolveCurrentCommunityForServerComponent(currentUser);
 
   return buildAppWorkspaceContext(currentUser, currentCommunityResolution);
 });

--- a/core/community/current-community.ts
+++ b/core/community/current-community.ts
@@ -43,6 +43,8 @@ export type CurrentCommunityServerActionContext = {
   user: User;
 };
 
+type CurrentCommunityUserRef = Pick<User, "id">;
+
 type ResolveCurrentCommunityContextParams = {
   userId: string;
   supabase: AppSupabaseClient;
@@ -182,8 +184,8 @@ export async function resolveCurrentCommunityContext({
 }
 
 const getCachedCurrentCommunityForServerComponent = cache(
-  async (): Promise<CurrentCommunityResolution> => {
-    const user = await requireCurrentUserForServerComponent();
+  async (userOverride?: CurrentCommunityUserRef): Promise<CurrentCommunityResolution> => {
+    const user = userOverride ?? (await requireCurrentUserForServerComponent());
     const supabase = await createServerComponentSupabaseClient();
     const requestedCommunityId = await readCurrentCommunityCookie();
 
@@ -208,8 +210,10 @@ const getCachedCurrentCommunityForServerComponent = cache(
   }
 );
 
-export async function resolveCurrentCommunityForServerComponent(): Promise<CurrentCommunityResolution> {
-  return await getCachedCurrentCommunityForServerComponent();
+export async function resolveCurrentCommunityForServerComponent(
+  userOverride?: CurrentCommunityUserRef
+): Promise<CurrentCommunityResolution> {
+  return await getCachedCurrentCommunityForServerComponent(userOverride);
 }
 
 export async function resolveCurrentCommunityForServerAction(

--- a/core/supabase/auth-guards.ts
+++ b/core/supabase/auth-guards.ts
@@ -44,6 +44,21 @@ export function isMissingAuthSessionError(error: unknown): boolean {
 }
 
 /**
+ * 認証セッションが無効で、再ログインへ戻せる認証エラーかどうかを判定する
+ */
+export function isUnauthenticatedAuthError(error: unknown): boolean {
+  if (isMissingAuthSessionError(error)) {
+    return true;
+  }
+
+  if (hasAuthErrorCode(error, "user_not_found")) {
+    return true;
+  }
+
+  return getAuthErrorMessage(error) === "User from sub claim in JWT does not exist";
+}
+
+/**
  * resetPasswordForEmailの戻り値型ガード
  */
 export function isResetPasswordResult(value: unknown): value is {

--- a/core/utils/next.ts
+++ b/core/utils/next.ts
@@ -16,7 +16,32 @@ export function isNextRedirectError(err: unknown): boolean {
       return true;
     }
     const message = err instanceof Error ? err.message : String(err);
-    return message === "NEXT_REDIRECT";
+    return message.startsWith("NEXT_REDIRECT");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Next.js ナビゲーション（redirect/notFound等）が投げる制御例外の検知ユーティリティ
+ */
+export function isNextNavigationError(err: unknown): boolean {
+  try {
+    const digest = toErrorLike(err).digest;
+    if (
+      typeof digest === "string" &&
+      (digest.startsWith("NEXT_REDIRECT") ||
+        digest.startsWith("NEXT_NOT_FOUND") ||
+        digest.startsWith("NEXT_HTTP_ERROR_FALLBACK"))
+    ) {
+      return true;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return (
+      message.startsWith("NEXT_REDIRECT") ||
+      message.startsWith("NEXT_NOT_FOUND") ||
+      message.startsWith("NEXT_HTTP_ERROR_FALLBACK")
+    );
   } catch {
     return false;
   }

--- a/tests/unit/app/events/detail-page.test.tsx
+++ b/tests/unit/app/events/detail-page.test.tsx
@@ -77,6 +77,65 @@ describe("EventDetailPage", () => {
     expect(getEventDetailAction).toHaveBeenCalledWith("event-1", "community-1");
     expect(getEventStatsAction).not.toHaveBeenCalled();
     expect(getEventParticipantsAction).not.toHaveBeenCalled();
+    expect(handleServerError).not.toHaveBeenCalled();
+  });
+
+  it("notFound の制御例外は error log しない", async () => {
+    requireNonEmptyCommunityWorkspaceForServerComponent.mockResolvedValue({
+      currentCommunity: { id: "community-1", name: "A" },
+    });
+    getEventDetailAction.mockResolvedValue({
+      success: false,
+      error: {
+        code: "EVENT_NOT_FOUND",
+        userMessage: "not found",
+        correlationId: "corr-1",
+        retryable: false,
+      },
+    });
+
+    const EventDetailPage = (await import("../../../../app/(app)/events/[id]/page")).default;
+
+    await expect(
+      EventDetailPage({
+        params: Promise.resolve({ id: "event-1" }),
+        searchParams: Promise.resolve({}),
+      })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(handleServerError).not.toHaveBeenCalled();
+  });
+
+  it("通常例外は event_page_view として error log する", async () => {
+    requireNonEmptyCommunityWorkspaceForServerComponent.mockResolvedValue({
+      currentCommunity: { id: "community-1", name: "A" },
+    });
+    getEventDetailAction.mockResolvedValue({
+      success: false,
+      error: {
+        code: "DATABASE_ERROR",
+        userMessage: "failed",
+        correlationId: "corr-1",
+        retryable: true,
+      },
+    });
+
+    const EventDetailPage = (await import("../../../../app/(app)/events/[id]/page")).default;
+
+    await expect(
+      EventDetailPage({
+        params: Promise.resolve({ id: "event-1" }),
+        searchParams: Promise.resolve({}),
+      })
+    ).rejects.toThrow("failed");
+
+    expect(handleServerError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        action: "event_page_view",
+        eventId: "event-1",
+      })
+    );
   });
 
   it("metadata は current community 不一致時に汎用タイトルへフォールバックする", async () => {

--- a/tests/unit/core/auth/auth-utils.test.ts
+++ b/tests/unit/core/auth/auth-utils.test.ts
@@ -1,5 +1,5 @@
 import { jest } from "@jest/globals";
-import { AuthSessionMissingError } from "@supabase/supabase-js";
+import { AuthApiError, AuthSessionMissingError } from "@supabase/supabase-js";
 
 const mockCreateServerActionSupabaseClient = jest.fn();
 const mockCreateServerComponentSupabaseClient = jest.fn();
@@ -162,6 +162,24 @@ describe("core/auth/auth-utils", () => {
     expect(mockHandleServerError).not.toHaveBeenCalled();
   });
 
+  it("JWT sub の user が存在しない場合は requireCurrentUserForServerComponent が /login に redirect する", async () => {
+    const { client } = createLookupClient({
+      authError: new AuthApiError(
+        "User from sub claim in JWT does not exist",
+        403,
+        "user_not_found"
+      ),
+      user: null,
+    });
+    mockCreateServerComponentSupabaseClient.mockResolvedValue(client);
+
+    const { requireCurrentUserForServerComponent } = await loadAuthUtils();
+
+    await expect(requireCurrentUserForServerComponent()).rejects.toThrow("NEXT_REDIRECT:/login");
+    expect(mockRedirect).toHaveBeenCalledWith("/login");
+    expect(mockHandleServerError).not.toHaveBeenCalled();
+  });
+
   it("未認証時は requireCurrentAppUserForServerComponent が /login に redirect する", async () => {
     const { client } = createLookupClient({
       user: null,
@@ -211,6 +229,23 @@ describe("core/auth/auth-utils", () => {
   it("getOptionalCurrentUserForServerComponent はセッション欠如を null として扱う", async () => {
     const { client } = createLookupClient({
       authError: new AuthSessionMissingError(),
+      user: null,
+    });
+    mockCreateServerComponentSupabaseClient.mockResolvedValue(client);
+
+    const { getOptionalCurrentUserForServerComponent } = await loadAuthUtils();
+
+    await expect(getOptionalCurrentUserForServerComponent()).resolves.toBeNull();
+    expect(mockHandleServerError).not.toHaveBeenCalled();
+  });
+
+  it("getOptionalCurrentUserForServerComponent は JWT sub の user 不在を null として扱う", async () => {
+    const { client } = createLookupClient({
+      authError: new AuthApiError(
+        "User from sub claim in JWT does not exist",
+        403,
+        "user_not_found"
+      ),
       user: null,
     });
     mockCreateServerComponentSupabaseClient.mockResolvedValue(client);

--- a/tests/unit/core/community/app-workspace.test.ts
+++ b/tests/unit/core/community/app-workspace.test.ts
@@ -110,6 +110,11 @@ describe("core/community/app-workspace", () => {
         resolvedBy: "cookie",
       },
     });
+    expect(resolveCurrentCommunityForServerComponent).toHaveBeenCalledWith({
+      id: "user-1",
+      email: "owner@example.com",
+      name: "集金 太郎",
+    });
   });
 
   it("owned community が 0 件なら空状態フラグを返し shell data へ内部情報を漏らさない", async () => {

--- a/tests/unit/core/community/current-community.test.ts
+++ b/tests/unit/core/community/current-community.test.ts
@@ -381,4 +381,33 @@ describe("core/community/current-community", () => {
     expect(mockRequireCurrentUserForServerComponent).toHaveBeenCalledTimes(1);
     expect(mockCreateServerComponentSupabaseClient).toHaveBeenCalledTimes(1);
   });
+
+  it("resolveCurrentCommunityForServerComponent は user override があれば認証ユーザーを再解決しない", async () => {
+    const { client } = createSupabaseClientForCommunities({
+      data: [
+        {
+          created_at: "2026-03-10T00:00:00.000Z",
+          id: "community-1",
+          name: "A",
+          slug: "a",
+        },
+      ],
+    });
+    const cookieStore = createCookieStore("community-1");
+
+    mockCreateServerComponentSupabaseClient.mockResolvedValue(client);
+    mockCookies.mockResolvedValue(cookieStore);
+
+    const { resolveCurrentCommunityForServerComponent } = await loadCurrentCommunityModule();
+
+    await expect(
+      resolveCurrentCommunityForServerComponent({ id: "user-1" })
+    ).resolves.toMatchObject({
+      currentCommunity: { id: "community-1" },
+      resolvedBy: "cookie",
+    });
+
+    expect(mockRequireCurrentUserForServerComponent).not.toHaveBeenCalled();
+    expect(mockCreateServerComponentSupabaseClient).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## 概要

* JWT上のユーザーが存在しない認証エラーを未認証扱いにし、ログ出力せず `/login` へ戻すよう修正
* `redirect` / `notFound` などのNext.js制御例外を通常エラーとしてログ出力しないよう修正
* workspace初期化時に認証ユーザーを再解決しないよう、current community解決へuser overrideを渡すよう変更
* 関連ユニットテストを追加・更新

## 確認

* 認証エラー時のredirect挙動
* event detail pageの`notFound`/通常例外のログ挙動
* current community解決時の認証ユーザー再取得抑制

 
