### PR TITLE
fix: イベント編集の差分確認と集金方法制限を改善

### DIFF
--- a/components/ui/change-confirmation-dialog.tsx
+++ b/components/ui/change-confirmation-dialog.tsx
@@ -147,18 +147,18 @@ export function ChangeConfirmationDialog({
                   >
                     <div className="font-medium text-sm text-foreground">{change.fieldName}</div>
                     <div className="mt-1 text-sm grid grid-cols-[auto_1fr] gap-x-2 gap-y-1">
-                      <span className="text-muted-foreground text-xs uppercase tracking-wider self-center">
-                        Before
+                      <span className="text-muted-foreground text-xs self-center">
+                        変更前
                       </span>
-                      <span className="font-mono text-muted-foreground line-through decoration-destructive/30 decoration-2">
-                        {change.oldValue || "(未設定)"}
+                      <span className="text-muted-foreground line-through decoration-destructive/30 decoration-2">
+                        {change.oldValue}
                       </span>
 
-                      <span className="text-primary text-xs uppercase tracking-wider self-center font-bold">
-                        After
+                      <span className="text-primary text-xs self-center font-bold">
+                        変更後
                       </span>
-                      <span className="font-mono font-medium text-foreground">
-                        {change.newValue || "(未設定)"}
+                      <span className="font-medium text-foreground">
+                        {change.newValue}
                       </span>
                     </div>
                   </div>

--- a/core/domain/event-edit-restrictions/rules.ts
+++ b/core/domain/event-edit-restrictions/rules.ts
@@ -131,6 +131,14 @@ export const ATTENDEE_PAYMENT_METHODS_RESTRICTION: RestrictionRule = {
     // 1. まず実際の違反チェック（削除しようとしたか？）
     const original = new Set((context.originalEvent.payment_methods || []) as string[]);
     const next = new Set((formData.payment_methods || []) as string[]);
+    const originalFee = context.originalEvent.fee ?? 0;
+    const nextFee = safeParseNumber(formData.fee);
+    const isChangingToFree = originalFee > 0 && nextFee === 0;
+    const hasRemovedPaymentMethod = Array.from(original).some((method) => !next.has(method));
+
+    if (hasRemovedPaymentMethod && isChangingToFree && !context.hasStripePaid) {
+      return createEvaluation(false, "制限なし");
+    }
 
     // 追加は許可、既存の解除のみ制限
     for (const method of original) {

--- a/core/validation/event.ts
+++ b/core/validation/event.ts
@@ -448,22 +448,9 @@ export const updateEventSchema = z
       message: "有料イベントでは決済方法の選択が必要です",
       path: ["payment_methods"],
     }
-  )
-  .refine(
-    (data) => {
-      // 同一リクエストでStripe有効化する場合はオンライン支払い期限も同時に必須
-      if (Array.isArray(data.payment_methods) && data.payment_methods.includes("stripe")) {
-        return typeof data.payment_deadline === "string" && data.payment_deadline.trim() !== "";
-      }
-      return true;
-    },
-    {
-      message: "オンライン集金を選択した場合、オンライン支払い期限は必須です",
-      path: ["payment_deadline"],
-    }
   );
 // 更新時は部分更新を考慮し、payment_deadline必須チェックはアクション本体で統合実施
-// Zodスキーマでは基本的なバリデーションのみ行う（上記は補助的な早期チェック）
+// Zodスキーマでは基本的なバリデーションのみ行う
 
 // Eventsフォーム入力契約のSoT
 export interface EventFormData {

--- a/features/events/actions/update-event.ts
+++ b/features/events/actions/update-event.ts
@@ -370,7 +370,10 @@ export async function updateEventAction(
 
     // 更新データが空の場合は既存データを返す（変更なし）
     if (Object.keys(updateData).length === 0) {
-      return ok(existingEvent, { message: "変更はありませんでした" });
+      return ok(existingEvent, {
+        message: "変更はありませんでした",
+        redirectUrl: `/events/${validatedEventId}`,
+      });
     }
 
     // データベース更新
@@ -411,7 +414,10 @@ export async function updateEventAction(
     revalidatePath("/dashboard");
     revalidatePath(`/events/${validatedEventId}`);
 
-    return ok(updatedEvent, { message: "イベントが正常に更新されました" });
+    return ok(updatedEvent, {
+      message: "イベントが正常に更新されました",
+      redirectUrl: `/events/${validatedEventId}`,
+    });
   } catch (error) {
     if (error instanceof z.ZodError) {
       return zodFail(error);

--- a/features/events/components/FeeCalculatorDisplay.tsx
+++ b/features/events/components/FeeCalculatorDisplay.tsx
@@ -31,7 +31,7 @@ export function FeeCalculatorDisplay({
   return (
     <Card className={`p-4 bg-gradient-to-br from-blue-50/50 to-purple-50/50 ${className}`}>
       <div className="space-y-2">
-        <h4 className="text-sm font-semibold text-gray-700">オンライン集金時の予想手取り</h4>
+        <h4 className="text-sm font-semibold text-gray-700">オンライン集金時の受取予定額</h4>
         <div className="space-y-1 text-sm">
           <div className="flex justify-between items-center">
             <span className="text-gray-600">参加費</span>

--- a/features/events/components/SinglePageEventEditForm.tsx
+++ b/features/events/components/SinglePageEventEditForm.tsx
@@ -242,20 +242,27 @@ export function SinglePageEventEditForm({
 
       // 2. 統一制限システムによるバリデーション
       const field = change.field as RestrictableField;
-      const restrictionMessage = r.getFieldMessage(field);
-      const restrictionLevel = r.getFieldRestrictionLevel(field);
+      const activeRestrictions = r.getFieldActiveRestrictions(field);
 
-      if (
-        r.isFieldRestricted(field) &&
-        restrictionMessage &&
-        (restrictionLevel === "structural" || restrictionLevel === "conditional")
-      ) {
-        blockingErrors.push(`${change.fieldName}: ${restrictionMessage}`);
-      } else if (restrictionMessage && restrictionLevel === "advisory") {
-        if (!advisoryWarnings.includes(restrictionMessage)) {
-          advisoryWarnings.push(restrictionMessage);
+      activeRestrictions.forEach((restriction) => {
+        const message = restriction.evaluation.message;
+        if (
+          restriction.evaluation.isRestricted &&
+          (restriction.rule.level === "structural" || restriction.rule.level === "conditional")
+        ) {
+          const blockingMessage = `${change.fieldName}: ${message}`;
+          if (!blockingErrors.includes(blockingMessage)) {
+            blockingErrors.push(blockingMessage);
+          }
+          return;
         }
-      }
+
+        if (restriction.evaluation.status === "warning" && !restriction.evaluation.isRestricted) {
+          if (!advisoryWarnings.includes(message)) {
+            advisoryWarnings.push(message);
+          }
+        }
+      });
 
       normalChanges.push(change);
     });

--- a/features/events/components/SinglePageEventEditForm.tsx
+++ b/features/events/components/SinglePageEventEditForm.tsx
@@ -164,6 +164,10 @@ export function SinglePageEventEditForm({
   // 決済方法の選択状態
   const paymentMethods = form.watch("payment_methods");
   const isOnlineSelected = Array.isArray(paymentMethods) && paymentMethods.includes("stripe");
+  const originalPaymentMethods = event.payment_methods || [];
+  const hasOriginalCash = originalPaymentMethods.includes("cash");
+  const hasOriginalStripe = originalPaymentMethods.includes("stripe");
+  const hasLockedPaymentMethod = hasAttendees && originalPaymentMethods.length > 0;
 
   // 参加費を監視（手取り表示用）
   const watchedFee = form.watch("fee");
@@ -441,8 +445,8 @@ export function SinglePageEventEditForm({
                               {...field}
                               type="number"
                               placeholder="例：50"
-                              disabled={isPending || !restrictions.isFieldEditable("capacity")}
-                              min={hasAttendees ? attendeeCount : 1}
+                              disabled={isPending}
+                              min={1}
                               max="10000"
                               className={cn(
                                 "h-11 bg-background pl-10 pr-10",
@@ -454,7 +458,7 @@ export function SinglePageEventEditForm({
                             </span>
                           </div>
                         </FormControl>
-                        {!restrictions.isFieldEditable("capacity") && (
+                        {hasAttendees && (
                           <FormDescription className="text-xs text-amber-600">
                             現在の参加者数より少なく設定することはできません
                           </FormDescription>
@@ -694,167 +698,184 @@ export function SinglePageEventEditForm({
                     <FormField
                       control={form.control}
                       name="payment_methods"
-                      render={({ field }) => (
-                        <FormItem>
-                          <div className="flex items-center gap-2">
-                            <FormLabel className="text-sm font-medium">
-                              集金方法を選択 <span className="text-red-500">*</span>
-                            </FormLabel>
-                            {isChanged("payment_methods") && (
-                              <Badge variant="outline" className={changedBadgeClass}>
-                                変更あり
-                              </Badge>
-                            )}
-                          </div>
+                      render={({ field }) => {
+                        const selectedMethods = Array.isArray(field.value) ? field.value : [];
+                        const isCashSelected = selectedMethods.includes("cash");
+                        const isStripeSelected = selectedMethods.includes("stripe");
+                        const isCashRemovalLocked =
+                          hasAttendees && hasOriginalCash && isCashSelected;
+                        const isStripeRemovalLocked =
+                          hasAttendees && hasOriginalStripe && isStripeSelected;
+                        const isStripeAddDisabled =
+                          !canUseOnlinePayments && !hasOriginalStripe && !isStripeSelected;
+                        const isCashDisabled = isPending || isCashRemovalLocked;
+                        const isStripeDisabled =
+                          isPending || isStripeAddDisabled || isStripeRemovalLocked;
 
-                          <div
-                            className="mt-3 flex flex-col gap-3 sm:grid sm:grid-cols-2"
-                            data-testid="payment-methods"
-                          >
-                            {/* 現金払い */}
-                            <label
-                              className={cn(
-                                "relative flex min-h-[5.25rem] items-center rounded-lg border p-4 transition-colors sm:min-h-24",
-                                isPending ? "opacity-70 cursor-not-allowed" : "cursor-pointer",
-                                Array.isArray(field.value) && field.value.includes("cash")
-                                  ? "border-primary/50 bg-primary/5"
-                                  : "border-border bg-background hover:border-primary/30"
+                        return (
+                          <FormItem>
+                            <div className="flex items-center gap-2">
+                              <FormLabel className="text-sm font-medium">
+                                集金方法を選択 <span className="text-red-500">*</span>
+                              </FormLabel>
+                              {isChanged("payment_methods") && (
+                                <Badge variant="outline" className={changedBadgeClass}>
+                                  変更あり
+                                </Badge>
                               )}
+                            </div>
+
+                            <div
+                              className="mt-3 flex flex-col gap-3 sm:grid sm:grid-cols-2"
+                              data-testid="payment-methods"
                             >
-                              <input
-                                type="checkbox"
-                                className="absolute opacity-0 w-0 h-0"
-                                checked={Array.isArray(field.value) && field.value.includes("cash")}
-                                onChange={(e) => {
-                                  const current = Array.isArray(field.value) ? field.value : [];
-                                  if (e.target.checked) {
-                                    const next = Array.from(new Set([...current, "cash"]));
-                                    field.onChange(next);
-                                  } else {
-                                    // 参加者がいる場合、既存の決済方法は解除できない
-                                    if (hasAttendees && event.payment_methods?.includes("cash")) {
-                                      return;
-                                    }
-                                    const next = current.filter((m) => m !== "cash");
-                                    field.onChange(next);
-                                  }
-                                }}
-                                disabled={
-                                  isPending || !restrictions.isFieldEditable("payment_methods")
-                                }
-                              />
-                              <div className="flex items-center gap-3 pr-8">
-                                <div
-                                  className={cn(
-                                    "flex size-10 items-center justify-center rounded-md border",
-                                    Array.isArray(field.value) && field.value.includes("cash")
-                                      ? "border-primary/20 bg-primary/10 text-primary"
-                                      : "border-border bg-muted/40 text-muted-foreground"
-                                  )}
-                                >
-                                  <WalletIcon className="w-5 h-5" />
-                                </div>
-                                <div>
-                                  <span className="block text-sm font-semibold text-foreground">
-                                    現金
-                                  </span>
-                                  <span className="mt-0.5 block text-xs text-muted-foreground">
-                                    当日現地などで集金
-                                  </span>
-                                </div>
-                              </div>
-                              {Array.isArray(field.value) && field.value.includes("cash") && (
-                                <div className="absolute right-3 top-3 flex size-5 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground duration-200 zoom-in-50">
-                                  <CheckIcon className="w-3.5 h-3.5 stroke-[3]" />
-                                </div>
-                              )}
-                            </label>
-
-                            {/* オンライン決済 */}
-                            <label
-                              className={cn(
-                                "relative flex min-h-[5.25rem] items-center rounded-lg border p-4 transition-colors sm:min-h-24",
-                                !canUseOnlinePayments || isPending
-                                  ? "opacity-60 cursor-not-allowed"
-                                  : "cursor-pointer",
-                                Array.isArray(field.value) && field.value.includes("stripe")
-                                  ? "border-primary/50 bg-primary/5"
-                                  : "border-border bg-background hover:border-primary/30"
-                              )}
-                            >
-                              <input
-                                type="checkbox"
-                                className="absolute opacity-0 w-0 h-0"
-                                checked={
-                                  Array.isArray(field.value) && field.value.includes("stripe")
-                                }
-                                onChange={(e) => {
-                                  const current = Array.isArray(field.value) ? field.value : [];
-                                  if (e.target.checked) {
-                                    const next = Array.from(new Set([...current, "stripe"]));
-                                    field.onChange(next);
-                                  } else {
-                                    // 参加者がいる場合、既存の決済方法は解除できない
-                                    if (hasAttendees && event.payment_methods?.includes("stripe")) {
-                                      return;
-                                    }
-                                    const next = current.filter((m) => m !== "stripe");
-                                    field.onChange(next);
-                                  }
-                                }}
-                                disabled={
-                                  isPending ||
-                                  (!canUseOnlinePayments && !field.value?.includes("stripe")) ||
-                                  !restrictions.isFieldEditable("payment_methods")
-                                }
-                              />
-                              <div className="flex items-center gap-3 pr-8">
-                                <div
-                                  className={cn(
-                                    "flex size-10 items-center justify-center rounded-md border",
-                                    Array.isArray(field.value) && field.value.includes("stripe")
-                                      ? "border-primary/20 bg-primary/10 text-primary"
-                                      : "border-border bg-muted/40 text-muted-foreground"
-                                  )}
-                                >
-                                  <CreditCardIcon className="w-5 h-5" />
-                                </div>
-                                <div>
-                                  <span className="block text-sm font-semibold text-foreground">
-                                    オンライン
-                                  </span>
-                                  <span className="mt-0.5 block text-xs text-muted-foreground">
-                                    クレジットカード、Apple Pay、Google Payなど
-                                  </span>
-                                </div>
-                              </div>
-                              {Array.isArray(field.value) && field.value.includes("stripe") && (
-                                <div className="absolute right-3 top-3 flex size-5 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground duration-200 zoom-in-50">
-                                  <CheckIcon className="w-3.5 h-3.5 stroke-[3]" />
-                                </div>
-                              )}
-                            </label>
-                          </div>
-
-                          {!canUseOnlinePayments && (
-                            <p className="mt-2 text-xs text-muted-foreground">
-                              「オンライン」を選択するにはオンライン集金設定が必要です。
-                              <Link
-                                href="/settings/payments"
-                                className="ml-1 font-medium underline underline-offset-4"
+                              {/* 現金払い */}
+                              <label
+                                className={cn(
+                                  "relative flex min-h-[5.25rem] items-center rounded-lg border p-4 transition-colors sm:min-h-24",
+                                  isCashDisabled
+                                    ? "opacity-70 cursor-not-allowed"
+                                    : "cursor-pointer",
+                                  isCashSelected
+                                    ? "border-primary/50 bg-primary/5"
+                                    : cn(
+                                        "border-border bg-background",
+                                        !isCashDisabled && "hover:border-primary/30"
+                                      )
+                                )}
                               >
-                                設定に進む
-                              </Link>
-                            </p>
-                          )}
-                          {!restrictions.isFieldEditable("payment_methods") && (
-                            <p className="mt-2 text-xs text-amber-600">
-                              参加者がいるため、集金方法の解除はできません
-                            </p>
-                          )}
-                          <FormMessage />
-                        </FormItem>
-                      )}
+                                <input
+                                  type="checkbox"
+                                  className="absolute opacity-0 w-0 h-0"
+                                  checked={isCashSelected}
+                                  onChange={(e) => {
+                                    const current = Array.isArray(field.value) ? field.value : [];
+                                    if (e.target.checked) {
+                                      const next = Array.from(new Set([...current, "cash"]));
+                                      field.onChange(next);
+                                    } else {
+                                      if (isCashRemovalLocked) {
+                                        return;
+                                      }
+                                      const next = current.filter((m) => m !== "cash");
+                                      field.onChange(next);
+                                    }
+                                  }}
+                                  disabled={isCashDisabled}
+                                />
+                                <div className="flex items-center gap-3 pr-8">
+                                  <div
+                                    className={cn(
+                                      "flex size-10 items-center justify-center rounded-md border",
+                                      isCashSelected
+                                        ? "border-primary/20 bg-primary/10 text-primary"
+                                        : "border-border bg-muted/40 text-muted-foreground"
+                                    )}
+                                  >
+                                    <WalletIcon className="w-5 h-5" />
+                                  </div>
+                                  <div>
+                                    <span className="block text-sm font-semibold text-foreground">
+                                      現金
+                                    </span>
+                                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                                      {isCashRemovalLocked
+                                        ? "参加者がいるため解除不可"
+                                        : "当日現地などで集金"}
+                                    </span>
+                                  </div>
+                                </div>
+                                {isCashSelected && (
+                                  <div className="absolute right-3 top-3 flex size-5 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground duration-200 zoom-in-50">
+                                    <CheckIcon className="w-3.5 h-3.5 stroke-[3]" />
+                                  </div>
+                                )}
+                              </label>
+
+                              {/* オンライン決済 */}
+                              <label
+                                className={cn(
+                                  "relative flex min-h-[5.25rem] items-center rounded-lg border p-4 transition-colors sm:min-h-24",
+                                  isStripeDisabled
+                                    ? "opacity-60 cursor-not-allowed"
+                                    : "cursor-pointer",
+                                  isStripeSelected
+                                    ? "border-primary/50 bg-primary/5"
+                                    : cn(
+                                        "border-border bg-background",
+                                        !isStripeDisabled && "hover:border-primary/30"
+                                      )
+                                )}
+                              >
+                                <input
+                                  type="checkbox"
+                                  className="absolute opacity-0 w-0 h-0"
+                                  checked={isStripeSelected}
+                                  onChange={(e) => {
+                                    const current = Array.isArray(field.value) ? field.value : [];
+                                    if (e.target.checked) {
+                                      const next = Array.from(new Set([...current, "stripe"]));
+                                      field.onChange(next);
+                                    } else {
+                                      if (isStripeRemovalLocked) {
+                                        return;
+                                      }
+                                      const next = current.filter((m) => m !== "stripe");
+                                      field.onChange(next);
+                                    }
+                                  }}
+                                  disabled={isStripeDisabled}
+                                />
+                                <div className="flex items-center gap-3 pr-8">
+                                  <div
+                                    className={cn(
+                                      "flex size-10 items-center justify-center rounded-md border",
+                                      isStripeSelected
+                                        ? "border-primary/20 bg-primary/10 text-primary"
+                                        : "border-border bg-muted/40 text-muted-foreground"
+                                    )}
+                                  >
+                                    <CreditCardIcon className="w-5 h-5" />
+                                  </div>
+                                  <div>
+                                    <span className="block text-sm font-semibold text-foreground">
+                                      オンライン
+                                    </span>
+                                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                                      {isStripeRemovalLocked
+                                        ? "参加者がいるため解除不可"
+                                        : "クレジットカード、Apple Pay、Google Payなど"}
+                                    </span>
+                                  </div>
+                                </div>
+                                {isStripeSelected && (
+                                  <div className="absolute right-3 top-3 flex size-5 animate-in items-center justify-center rounded-full bg-primary text-primary-foreground duration-200 zoom-in-50">
+                                    <CheckIcon className="w-3.5 h-3.5 stroke-[3]" />
+                                  </div>
+                                )}
+                              </label>
+                            </div>
+
+                            {!canUseOnlinePayments && !hasOriginalStripe && (
+                              <p className="mt-2 text-xs text-muted-foreground">
+                                「オンライン」を選択するにはオンライン集金設定が必要です。
+                                <Link
+                                  href="/settings/payments"
+                                  className="ml-1 font-medium underline underline-offset-4"
+                                >
+                                  設定に進む
+                                </Link>
+                              </p>
+                            )}
+                            {hasLockedPaymentMethod && (
+                              <p className="mt-2 text-xs text-amber-600">
+                                参加者がいるため、既存の集金方法は解除できません。追加は可能です。
+                              </p>
+                            )}
+                            <FormMessage />
+                          </FormItem>
+                        );
+                      }}
                     />
                   )}
 

--- a/features/events/components/SinglePageEventEditForm.tsx
+++ b/features/events/components/SinglePageEventEditForm.tsx
@@ -257,7 +257,11 @@ export function SinglePageEventEditForm({
           return;
         }
 
-        if (restriction.evaluation.status === "warning" && !restriction.evaluation.isRestricted) {
+        if (
+          restriction.rule.level === "advisory" &&
+          restriction.evaluation.status === "warning" &&
+          !restriction.evaluation.isRestricted
+        ) {
           if (!advisoryWarnings.includes(message)) {
             advisoryWarnings.push(message);
           }

--- a/features/events/components/SinglePageEventEditForm.tsx
+++ b/features/events/components/SinglePageEventEditForm.tsx
@@ -405,7 +405,7 @@ export function SinglePageEventEditForm({
                     render={({ field }) => (
                       <FormItem>
                         <div className="flex items-center gap-2">
-                          <FormLabel className="text-sm font-medium">開催場所（任意）</FormLabel>
+                          <FormLabel className="text-sm font-medium">場所（任意）</FormLabel>
                           {isChanged("location") && (
                             <Badge variant="outline" className={changedBadgeClass}>
                               変更あり

--- a/features/events/components/SinglePageEventEditForm.tsx
+++ b/features/events/components/SinglePageEventEditForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useMemo, type JSX } from "react";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import { format } from "date-fns";
 import {
@@ -124,6 +125,8 @@ export function SinglePageEventEditForm({
   updateEventAction,
   feeEstimateConfig = null,
 }: SinglePageEventEditFormProps): JSX.Element {
+  const router = useRouter();
+
   useMobileBottomOverlay(true);
 
   const { form, isPending, hasAttendees, changes, actions, restrictions, isFreeEvent } =
@@ -265,7 +268,10 @@ export function SinglePageEventEditForm({
   const handleConfirmChanges = async () => {
     setShowConfirmDialog(false);
     const formData = form.getValues();
-    await actions.submitFormWithChanges(formData, pendingChanges);
+    const result = await actions.submitFormWithChanges(formData, pendingChanges);
+    if (result.success && result.meta?.redirectUrl) {
+      router.push(result.meta.redirectUrl);
+    }
   };
 
   // 変更検知ヘルパー

--- a/features/events/components/UnifiedRestrictionNoticeV2.tsx
+++ b/features/events/components/UnifiedRestrictionNoticeV2.tsx
@@ -209,8 +209,8 @@ function CombinedRestrictionsValidation({
   const totalCount = sections.reduce((acc, sec) => acc + sec.restrictions.length, 0);
 
   // 初期状態: 常に閉じた状態
-  const hasBlockingIssues = sections.some(
-    (s) => s.level === "structural" || s.level === "conditional"
+  const hasBlockingIssues = sections.some((section) =>
+    section.restrictions.some((restriction) => restriction.evaluation.isRestricted)
   );
   const [isOpen, setIsOpen] = useState(false);
 

--- a/features/events/hooks/useEventChanges.ts
+++ b/features/events/hooks/useEventChanges.ts
@@ -2,15 +2,110 @@
 
 import { useCallback, useMemo } from "react";
 
+import { PAYMENT_METHOD_LABELS } from "@core/constants/status-labels";
 import type { Event } from "@core/types/event";
+import type { PaymentMethod } from "@core/types/statuses";
 import { formatUtcToDatetimeLocal } from "@core/utils/timezone";
 import type { EventFormData } from "@core/validation/event";
 
-import { ChangeItem } from "@/components/ui/change-confirmation-dialog";
+import type { ChangeItem } from "@/components/ui/change-confirmation-dialog";
 
 interface UseEventChangesProps {
   event: Event;
   formData: EventFormData;
+}
+
+const EVENT_CHANGE_FIELD_LABELS: Record<string, string> = {
+  title: "イベント名",
+  description: "説明・備考",
+  location: "場所",
+  date: "開催日時",
+  fee: "参加費",
+  capacity: "定員",
+  show_participant_count: "参加人数の表示",
+  show_capacity: "定員の表示",
+  payment_methods: "決済方法",
+  registration_deadline: "出欠回答期限",
+  payment_deadline: "オンライン支払い期限",
+  allow_payment_after_deadline: "締切後もオンライン決済を許可",
+  grace_period_days: "猶予期間",
+};
+
+function getEventChangeFieldLabel(field: string): string {
+  return EVENT_CHANGE_FIELD_LABELS[field] ?? field;
+}
+
+function isPaymentMethod(value: string): value is PaymentMethod {
+  return Object.prototype.hasOwnProperty.call(PAYMENT_METHOD_LABELS, value);
+}
+
+function formatPaymentMethods(value: unknown): string {
+  const methods = Array.isArray(value) ? value : [];
+  if (methods.length === 0) return "選択なし";
+
+  return methods
+    .map((method) => {
+      const methodString = String(method);
+      return isPaymentMethod(methodString) ? PAYMENT_METHOD_LABELS[methodString] : methodString;
+    })
+    .join(" / ");
+}
+
+function formatNumber(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") return Number(value || 0);
+  if (value == null) return 0;
+  return Number(value);
+}
+
+function formatDatetimeLocalForDisplay(value: unknown): string {
+  const dateTime = typeof value === "string" ? value : "";
+  if (!dateTime) return "未設定";
+
+  const match = dateTime.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/);
+  if (!match) return dateTime;
+
+  const [, year, month, day, hour, minute] = match;
+  return `${year}年${month}月${day}日 ${hour}:${minute}`;
+}
+
+function formatEventChangeValue(field: string, value: unknown): string {
+  switch (field) {
+    case "payment_methods":
+      return formatPaymentMethods(value);
+
+    case "date":
+    case "registration_deadline":
+    case "payment_deadline":
+      return formatDatetimeLocalForDisplay(value);
+
+    case "fee": {
+      const amount = formatNumber(value);
+      return amount === 0 ? "無料" : `${amount.toLocaleString("ja-JP")}円`;
+    }
+
+    case "capacity": {
+      if (value === "" || value == null) return "未設定";
+      return `${formatNumber(value).toLocaleString("ja-JP")}人`;
+    }
+
+    case "grace_period_days": {
+      const days = formatNumber(value);
+      return days === 0 ? "なし" : `${days.toLocaleString("ja-JP")}日`;
+    }
+
+    case "allow_payment_after_deadline":
+      return Boolean(value) ? "許可する" : "許可しない";
+
+    case "show_capacity":
+    case "show_participant_count":
+      return Boolean(value) ? "表示する" : "表示しない";
+
+    default: {
+      const text = (value ?? "").toString();
+      return text || "未設定";
+    }
+  }
 }
 
 export function useEventChanges({ event, formData }: UseEventChangesProps) {
@@ -31,8 +126,8 @@ export function useEventChanges({ event, formData }: UseEventChangesProps) {
       if (originalPaymentMethods.length > 0 && currentPaymentMethods.length === 0) {
         secondaryChanges.push({
           field: "payment_methods",
-          fieldName: "決済方法",
-          oldValue: originalPaymentMethods.join(", "),
+          fieldName: getEventChangeFieldLabel("payment_methods"),
+          oldValue: formatEventChangeValue("payment_methods", originalPaymentMethods),
           newValue: "（無料化により自動クリア）",
         });
       }
@@ -47,8 +142,11 @@ export function useEventChanges({ event, formData }: UseEventChangesProps) {
       ) {
         secondaryChanges.push({
           field: "payment_deadline",
-          fieldName: "オンライン支払い期限",
-          oldValue: formatUtcToDatetimeLocal(originalPaymentDeadline),
+          fieldName: getEventChangeFieldLabel("payment_deadline"),
+          oldValue: formatEventChangeValue(
+            "payment_deadline",
+            formatUtcToDatetimeLocal(originalPaymentDeadline)
+          ),
           newValue: "（無料化により自動クリア）",
         });
       }
@@ -60,8 +158,8 @@ export function useEventChanges({ event, formData }: UseEventChangesProps) {
       if (originalAllowAfter && !currentAllowAfter) {
         secondaryChanges.push({
           field: "allow_payment_after_deadline",
-          fieldName: "締切後決済許可",
-          oldValue: "許可",
+          fieldName: getEventChangeFieldLabel("allow_payment_after_deadline"),
+          oldValue: formatEventChangeValue("allow_payment_after_deadline", originalAllowAfter),
           newValue: "（無料化により自動クリア）",
         });
       }
@@ -76,8 +174,8 @@ export function useEventChanges({ event, formData }: UseEventChangesProps) {
       if (originalGrace > 0 && currentGrace === 0) {
         secondaryChanges.push({
           field: "grace_period_days",
-          fieldName: "猶予期間",
-          oldValue: originalGrace.toString(),
+          fieldName: getEventChangeFieldLabel("grace_period_days"),
+          oldValue: formatEventChangeValue("grace_period_days", originalGrace),
           newValue: "（無料化により自動クリア）",
         });
       }
@@ -100,8 +198,11 @@ export function useEventChanges({ event, formData }: UseEventChangesProps) {
       ) {
         secondaryChanges.push({
           field: "payment_deadline",
-          fieldName: "オンライン支払い期限",
-          oldValue: formatUtcToDatetimeLocal(originalPaymentDeadline),
+          fieldName: getEventChangeFieldLabel("payment_deadline"),
+          oldValue: formatEventChangeValue(
+            "payment_deadline",
+            formatUtcToDatetimeLocal(originalPaymentDeadline)
+          ),
           newValue: "（オンライン決済選択解除により自動クリア）",
         });
       }
@@ -113,8 +214,8 @@ export function useEventChanges({ event, formData }: UseEventChangesProps) {
       if (originalAllowAfter && !currentAllowAfter) {
         secondaryChanges.push({
           field: "allow_payment_after_deadline",
-          fieldName: "締切後決済許可",
-          oldValue: "許可",
+          fieldName: getEventChangeFieldLabel("allow_payment_after_deadline"),
+          oldValue: formatEventChangeValue("allow_payment_after_deadline", originalAllowAfter),
           newValue: "（オンライン決済選択解除により自動クリア）",
         });
       }
@@ -129,8 +230,8 @@ export function useEventChanges({ event, formData }: UseEventChangesProps) {
       if (originalGrace > 0 && currentGrace === 0) {
         secondaryChanges.push({
           field: "grace_period_days",
-          fieldName: "猶予期間",
-          oldValue: originalGrace.toString(),
+          fieldName: getEventChangeFieldLabel("grace_period_days"),
+          oldValue: formatEventChangeValue("grace_period_days", originalGrace),
           newValue: "（オンライン決済選択解除により自動クリア）",
         });
       }
@@ -196,124 +297,89 @@ export function useEventChanges({ event, formData }: UseEventChangesProps) {
         field: "title",
         oldValue: event.title || "",
         newValue: formData.title,
-        fieldName: "イベント名",
+        fieldName: getEventChangeFieldLabel("title"),
       },
       {
         field: "description",
         oldValue: event.description || "",
         newValue: formData.description,
-        fieldName: "説明",
+        fieldName: getEventChangeFieldLabel("description"),
       },
       {
         field: "location",
         oldValue: event.location || "",
         newValue: formData.location,
-        fieldName: "場所",
+        fieldName: getEventChangeFieldLabel("location"),
       },
       {
         field: "date",
         oldValue: formatUtcToDatetimeLocal(event.date),
         newValue: formData.date,
-        fieldName: "開催日時",
+        fieldName: getEventChangeFieldLabel("date"),
       },
       {
         field: "fee",
         oldValue: event.fee ?? 0,
         newValue: formData.fee || "0",
-        fieldName: "参加費",
+        fieldName: getEventChangeFieldLabel("fee"),
       },
       {
         field: "capacity",
         oldValue: event.capacity,
         newValue: formData.capacity || "",
-        fieldName: "定員",
+        fieldName: getEventChangeFieldLabel("capacity"),
       },
       {
         field: "show_participant_count",
         oldValue: event.show_participant_count ?? true,
         newValue: formData.show_participant_count ?? true,
-        fieldName: "参加人数の表示",
+        fieldName: getEventChangeFieldLabel("show_participant_count"),
       },
       {
         field: "show_capacity",
         oldValue: event.show_capacity,
         newValue: formData.show_capacity,
-        fieldName: "定員の表示",
+        fieldName: getEventChangeFieldLabel("show_capacity"),
       },
       {
         field: "payment_methods",
         oldValue: event.payment_methods || [],
         newValue: formData.payment_methods || [],
-        fieldName: "決済方法",
+        fieldName: getEventChangeFieldLabel("payment_methods"),
       },
       {
         field: "registration_deadline",
         oldValue: formatUtcToDatetimeLocal(event.registration_deadline || ""),
         newValue: formData.registration_deadline || "",
-        fieldName: "出欠回答期限",
+        fieldName: getEventChangeFieldLabel("registration_deadline"),
       },
       {
         field: "payment_deadline",
         oldValue: formatUtcToDatetimeLocal(event.payment_deadline || ""),
         newValue: formData.payment_deadline || "",
-        fieldName: "オンライン支払い期限",
+        fieldName: getEventChangeFieldLabel("payment_deadline"),
       },
       {
         field: "allow_payment_after_deadline",
         oldValue: event.allow_payment_after_deadline ?? false,
         newValue: formData.allow_payment_after_deadline ?? false,
-        fieldName: "締切後もオンライン決済を許可",
+        fieldName: getEventChangeFieldLabel("allow_payment_after_deadline"),
       },
       {
         field: "grace_period_days",
         oldValue: event.grace_period_days ?? 0,
         newValue: formData.grace_period_days ?? "0",
-        fieldName: "猶予（日）",
+        fieldName: getEventChangeFieldLabel("grace_period_days"),
       },
     ];
 
     fieldChecks.forEach(({ field, oldValue, newValue, fieldName }) => {
       if (isFieldChanged(field, oldValue, newValue)) {
-        // 表示用の値を生成（統一された形式）
-        let displayOldValue: string;
-        let displayNewValue: string;
-
-        if (field === "payment_methods") {
-          displayOldValue = Array.isArray(oldValue) ? oldValue.join(", ") : "";
-          displayNewValue = Array.isArray(newValue) ? newValue.join(", ") : "";
-        } else if (field === "fee") {
-          displayOldValue = (
-            typeof oldValue === "number" ? oldValue : Number(oldValue || 0)
-          ).toString();
-          displayNewValue = (
-            typeof newValue === "string" ? Number(newValue || 0) : newValue || 0
-          ).toString();
-        } else if (field === "capacity") {
-          displayOldValue = oldValue === null ? "" : oldValue.toString();
-          displayNewValue = newValue === "" || newValue == null ? "" : newValue.toString();
-        } else if (field === "allow_payment_after_deadline") {
-          displayOldValue = Boolean(oldValue) ? "許可" : "禁止";
-          displayNewValue = Boolean(newValue) ? "許可" : "禁止";
-        } else if (field === "show_capacity" || field === "show_participant_count") {
-          displayOldValue = Boolean(oldValue) ? "表示" : "非表示";
-          displayNewValue = Boolean(newValue) ? "表示" : "非表示";
-        } else if (field === "grace_period_days") {
-          displayOldValue = (
-            typeof oldValue === "number" ? oldValue : Number(oldValue || 0)
-          ).toString();
-          displayNewValue = (
-            typeof newValue === "string" ? Number(newValue || 0) : newValue || 0
-          ).toString();
-        } else {
-          displayOldValue = (oldValue ?? "").toString();
-          displayNewValue = (newValue ?? "").toString();
-        }
-
         changes.push({
           field,
           fieldName,
-          oldValue: displayOldValue,
-          newValue: displayNewValue,
+          oldValue: formatEventChangeValue(field, oldValue),
+          newValue: formatEventChangeValue(field, newValue),
         });
       }
     });

--- a/features/events/hooks/useEventChanges.ts
+++ b/features/events/hooks/useEventChanges.ts
@@ -11,17 +11,9 @@ import { ChangeItem } from "@/components/ui/change-confirmation-dialog";
 interface UseEventChangesProps {
   event: Event;
   formData: EventFormData;
-  hasValidationErrors?: boolean;
-  // フィールドが編集可能かを判定する関数（未指定時は全て編集可能とみなす）
-  isFieldEditable?: (field: string) => boolean;
 }
 
-export function useEventChanges({
-  event,
-  formData,
-  hasValidationErrors = false,
-  isFieldEditable,
-}: UseEventChangesProps) {
+export function useEventChanges({ event, formData }: UseEventChangesProps) {
   // 副次的クリアの検出機能
   const detectSecondaryChanges = useCallback((): ChangeItem[] => {
     const secondaryChanges: ChangeItem[] = [];
@@ -281,10 +273,6 @@ export function useEventChanges({
     ];
 
     fieldChecks.forEach(({ field, oldValue, newValue, fieldName }) => {
-      // 編集不可フィールドは検出対象から除外
-      if (typeof isFieldEditable === "function" && !isFieldEditable(field)) {
-        return;
-      }
       if (isFieldChanged(field, oldValue, newValue)) {
         // 表示用の値を生成（統一された形式）
         let displayOldValue: string;
@@ -347,13 +335,12 @@ export function useEventChanges({
     }
 
     return Array.from(mergedChangesByField.values());
-  }, [event, formData, isFieldEditable, detectSecondaryChanges]);
+  }, [event, formData, detectSecondaryChanges]);
 
-  // 変更があるかどうかをメモ化（バリデーションエラーがある場合は変更なし扱い）
+  // 変更があるかどうかをメモ化
   const hasChanges = useMemo(() => {
-    if (hasValidationErrors) return false;
     return detectChanges().length > 0;
-  }, [detectChanges, hasValidationErrors]);
+  }, [detectChanges]);
 
   // 特定フィールドに変更があるかチェック
   const hasFieldChanged = useCallback(

--- a/features/events/hooks/useEventEditForm.ts
+++ b/features/events/hooks/useEventEditForm.ts
@@ -19,7 +19,11 @@ import { useErrorHandler } from "@/core/hooks/useErrorHandler";
 import { createEventEditFormSchema, type EventEditFormDataRHF } from "../validation";
 
 import { useEventChanges } from "./useEventChanges";
-import { useEventSubmission, type UpdateEventAction } from "./useEventSubmission";
+import {
+  useEventSubmission,
+  type SubmissionActionMeta,
+  type UpdateEventAction,
+} from "./useEventSubmission";
 import {
   useUnifiedRestrictions,
   useRestrictionContext,
@@ -257,7 +261,7 @@ export function useEventEditForm({
   // フォーム送信処理
   const handleSubmit = useCallback(
     async (data: EventEditFormDataRHF) => {
-      return new Promise<AppResult<void>>((resolve) => {
+      return new Promise<AppResult<Event, SubmissionActionMeta>>((resolve) => {
         startTransition(async () => {
           try {
             const formData = toEventFormData(data);
@@ -296,11 +300,11 @@ export function useEventEditForm({
             });
 
             if (result.success) {
-              resolve(okResult());
+              resolve(okResult(result.data, result.meta));
               return;
             }
 
-            resolve(errResult(result.error));
+            resolve(errResult(result.error, result.meta));
           } catch (error) {
             const appError = handleError(error, {
               category: "event_management",
@@ -322,52 +326,54 @@ export function useEventEditForm({
   // 変更リストを指定して送信する関数
   const submitFormWithChanges = useCallback(
     async (data: EventEditFormDataRHF, changeList: ChangeItem[]) => {
-      const submissionResultPromise = new Promise<AppResult<void>>((resolve) => {
-        startTransition(async () => {
-          try {
-            const fullFormData = toEventFormData(data);
+      const submissionResultPromise = new Promise<AppResult<Event, SubmissionActionMeta>>(
+        (resolve) => {
+          startTransition(async () => {
+            try {
+              const fullFormData = toEventFormData(data);
 
-            // 確認された変更のみを含むフォームデータを作成
-            const selectedFormData = submission.prepareSubmissionData(fullFormData, changeList);
+              // 確認された変更のみを含むフォームデータを作成
+              const selectedFormData = submission.prepareSubmissionData(fullFormData, changeList);
 
-            // 実際の送信処理（選択された変更のみ）
-            const submissionResult = await submission.submitForm(selectedFormData, (errors) => {
-              // エラーをreact-hook-formに設定
-              Object.entries(errors).forEach(([field, message]) => {
-                if (field === "general") {
-                  form.setError("root", {
-                    type: "manual",
-                    message: message,
-                  });
-                } else {
-                  form.setError(field as keyof EventEditFormDataRHF, {
-                    type: "manual",
-                    message: message,
-                  });
-                }
+              // 実際の送信処理（選択された変更のみ）
+              const submissionResult = await submission.submitForm(selectedFormData, (errors) => {
+                // エラーをreact-hook-formに設定
+                Object.entries(errors).forEach(([field, message]) => {
+                  if (field === "general") {
+                    form.setError("root", {
+                      type: "manual",
+                      message: message,
+                    });
+                  } else {
+                    form.setError(field as keyof EventEditFormDataRHF, {
+                      type: "manual",
+                      message: message,
+                    });
+                  }
+                });
               });
-            });
 
-            if (submissionResult.success) {
-              resolve(okResult());
-              return;
+              if (submissionResult.success) {
+                resolve(okResult(submissionResult.data, submissionResult.meta));
+                return;
+              }
+
+              resolve(errResult(submissionResult.error, submissionResult.meta));
+            } catch (error) {
+              const appError = handleError(error, {
+                category: "event_management",
+                action: "event_update_error",
+                eventId: event.id,
+              });
+              form.setError("root", {
+                type: "manual",
+                message: appError.userMessage || "更新に失敗しました。もう一度お試しください。",
+              });
+              resolve(errResult(appError));
             }
-
-            resolve(errResult(submissionResult.error));
-          } catch (error) {
-            const appError = handleError(error, {
-              category: "event_management",
-              action: "event_update_error",
-              eventId: event.id,
-            });
-            form.setError("root", {
-              type: "manual",
-              message: appError.userMessage || "更新に失敗しました。もう一度お試しください。",
-            });
-            resolve(errResult(appError));
-          }
-        });
-      });
+          });
+        }
+      );
 
       return submissionResultPromise;
     },

--- a/features/events/hooks/useEventEditForm.ts
+++ b/features/events/hooks/useEventEditForm.ts
@@ -218,9 +218,6 @@ export function useEventEditForm({
   const changes = useEventChanges({
     event,
     formData: currentFormData,
-    hasValidationErrors: !form.formState.isValid,
-    isFieldEditable: (field: string) =>
-      isRestrictableField(field) ? unifiedRestrictions.isFieldEditable(field) : true,
   });
   const submission = useEventSubmission({ eventId: event.id, onSubmit, updateEventAction });
 

--- a/features/events/hooks/useEventSubmission.ts
+++ b/features/events/hooks/useEventSubmission.ts
@@ -2,8 +2,6 @@
 
 import { useCallback } from "react";
 
-import { useRouter } from "next/navigation";
-
 import { AppError } from "@core/errors";
 import {
   toAppResultFromActionResult,
@@ -17,7 +15,7 @@ import type { EventFormData } from "@core/validation/event";
 
 import { ChangeItem } from "@/components/ui/change-confirmation-dialog";
 
-type SubmissionActionMeta = {
+export type SubmissionActionMeta = {
   message?: string;
   redirectUrl?: string;
   needsVerification?: boolean;
@@ -56,8 +54,6 @@ export function useEventSubmission({
   onSubmit,
   updateEventAction,
 }: UseEventSubmissionProps) {
-  const router = useRouter();
-
   const extractFormErrorsFromAppError = useCallback((error: AppError): FormErrors => {
     const errors: FormErrors = {};
     const details = error.details as Record<string, unknown> | undefined;
@@ -101,7 +97,10 @@ export function useEventSubmission({
   }, []);
 
   const processSubmissionResult = useCallback(
-    (result: SubmissionActionResult, setErrors: (errors: FormErrors) => void): AppResult<Event> => {
+    (
+      result: SubmissionActionResult,
+      setErrors: (errors: FormErrors) => void
+    ): AppResult<Event, SubmissionActionMeta> => {
       if (result.success) {
         if (!result.data) {
           const appError = new AppError("INTERNAL_ERROR", {
@@ -118,10 +117,8 @@ export function useEventSubmission({
         };
         if (onSubmit) {
           onSubmit(dataWithStatus);
-        } else {
-          router.push(`/events/${eventId}`);
         }
-        return okResult(dataWithStatus);
+        return okResult(dataWithStatus, result.meta);
       }
 
       const errorMessage = result.error.userMessage || "エラーが発生しました";
@@ -132,9 +129,9 @@ export function useEventSubmission({
       }
 
       setErrors(errors);
-      return errResult(result.error);
+      return errResult(result.error, result.meta);
     },
-    [eventId, extractFormErrorsFromAppError, onSubmit, router]
+    [extractFormErrorsFromAppError, onSubmit]
   );
 
   const createFormDataFromSubmission = useCallback(
@@ -180,7 +177,7 @@ export function useEventSubmission({
     async (
       formData: EventFormData | Partial<EventFormData>,
       setErrors: (errors: FormErrors) => void
-    ): Promise<AppResult<Event>> => {
+    ): Promise<AppResult<Event, SubmissionActionMeta>> => {
       try {
         const formDataObj = createFormDataFromSubmission(formData);
 
@@ -282,14 +279,19 @@ export function useEventSubmission({
 
   // レスポンス処理
   const handleSubmissionResponse = useCallback(
-    (result: SubmissionActionResult, setErrors: (errors: FormErrors) => void): AppResult<Event> =>
-      processSubmissionResult(result, setErrors),
+    (
+      result: SubmissionActionResult,
+      setErrors: (errors: FormErrors) => void
+    ): AppResult<Event, SubmissionActionMeta> => processSubmissionResult(result, setErrors),
     [processSubmissionResult]
   );
 
   // エラーハンドリング
   const handleSubmissionError = useCallback(
-    (error: unknown, setErrors: (errors: FormErrors) => void): AppResult<Event> => {
+    (
+      error: unknown,
+      setErrors: (errors: FormErrors) => void
+    ): AppResult<Event, SubmissionActionMeta> => {
       const appError = handleClientError(error, {
         category: "event_management",
         action: "event_submission_failed",
@@ -304,7 +306,7 @@ export function useEventSubmission({
   );
 
   // 送信状況の監視
-  const getSubmissionStatus = useCallback((result: AppResult<Event>) => {
+  const getSubmissionStatus = useCallback((result: AppResult<Event, SubmissionActionMeta>) => {
     return {
       isLoading: false, // 実際の実装では状態管理が必要
       isSuccess: result.success,

--- a/features/events/hooks/useUnifiedRestrictions.ts
+++ b/features/events/hooks/useUnifiedRestrictions.ts
@@ -16,6 +16,7 @@ import {
   RestrictionEngine,
   createRestrictionEngine,
   FieldRestrictionMap,
+  ActiveRestriction,
 } from "@core/domain/event-edit-restrictions";
 import { logger } from "@core/logging/app-logger";
 import { handleClientError } from "@core/utils/error-handler.client";
@@ -50,6 +51,8 @@ export interface UseUnifiedRestrictionsResult {
   isFieldEditable: (field: RestrictableField) => boolean;
   /** フィールドの制限メッセージを取得 */
   getFieldMessage: (field: RestrictableField) => string | null;
+  /** フィールドで有効な制限をすべて取得 */
+  getFieldActiveRestrictions: (field: RestrictableField) => ActiveRestriction[];
   /** フィールドの制限レベルを取得 */
   getFieldRestrictionLevel: (
     field: RestrictableField
@@ -311,6 +314,14 @@ export function useUnifiedRestrictions(
     [state.fieldRestrictions]
   );
 
+  const getFieldActiveRestrictions = useCallback(
+    (field: RestrictableField): ActiveRestriction[] => {
+      const summary = state.fieldRestrictions.get(field);
+      return summary?.activeRestrictions ?? [];
+    },
+    [state.fieldRestrictions]
+  );
+
   // ---------------------------------------------------------------------------
   // Control Functions
   // ---------------------------------------------------------------------------
@@ -341,6 +352,7 @@ export function useUnifiedRestrictions(
     isFieldRestricted,
     isFieldEditable,
     getFieldMessage,
+    getFieldActiveRestrictions,
     getFieldRestrictionLevel,
 
     // 状態管理

--- a/features/events/validation.ts
+++ b/features/events/validation.ts
@@ -272,7 +272,7 @@ export const eventEditFormSchemaBase = z
     show_capacity: z.boolean(),
     show_participant_count: z.boolean(),
     payment_methods: z.array(z.string()),
-    registration_deadline: z.string().optional(),
+    registration_deadline: z.string().min(1, "出欠回答期限を設定してください"),
     payment_deadline: z.string().optional(),
     allow_payment_after_deadline: z.boolean().optional(),
     grace_period_days: z.string().optional(),

--- a/tests/e2e/event-edit.spec.ts
+++ b/tests/e2e/event-edit.spec.ts
@@ -57,7 +57,7 @@ test.describe("イベント編集（E2E）", () => {
     await expect(page).toHaveURL(`/events/${event.id}`);
 
     // 変更が反映されていることを確認
-    await expect(page.getByText("新しい会場A").first()).toBeVisible(); // 開催場所
+    await expect(page.getByText("新しい会場A").first()).toBeVisible(); // 場所
     await expect(page.getByText("更新済みの説明テキストA")).toBeVisible(); // 詳細説明
   });
 });

--- a/tests/unit/events/event-restrictions.v2.test.ts
+++ b/tests/unit/events/event-restrictions.v2.test.ts
@@ -140,6 +140,47 @@ describe("event edit restrictions v2 (domain)", () => {
     expect(addViolations).toHaveLength(0);
   });
 
+  test("hasAttendees=true でもStripe集金済みなしの無料化では payment_methods の自動クリアを許可する", async () => {
+    const event = createEvent(
+      { fee: 1000, payment_methods: ["stripe", "cash"] as any },
+      [{ id: "a1" } as any]
+    );
+    const context = buildRestrictionContext(
+      {
+        fee: event.fee,
+        capacity: event.capacity,
+        payment_methods: event.payment_methods ?? [],
+        title: event.title,
+      },
+      { hasAttendees: true, attendeeCount: 1, hasStripePaid: false },
+      "upcoming"
+    );
+
+    const freeFormData = createFormDataSnapshot({
+      ...event,
+      fee: 0,
+      payment_methods: [],
+    } as any);
+    const freeViolations = await evaluateEventEditViolations({
+      context,
+      formData: freeFormData,
+      patch: { fee: 0, payment_methods: [] },
+    });
+    expect(freeViolations).toHaveLength(0);
+
+    const paidFormData = createFormDataSnapshot({
+      ...event,
+      fee: 1000,
+      payment_methods: [],
+    } as any);
+    const paidViolations = await evaluateEventEditViolations({
+      context,
+      formData: paidFormData,
+      patch: { payment_methods: [] },
+    });
+    expect(paidViolations.find((v: FieldViolation) => v.field === "payment_methods")).toBeTruthy();
+  });
+
   test("capacity は参加者数未満にできない（null は許可）", async () => {
     const event = createEvent(
       { capacity: 20 },

--- a/tests/unit/events/rules.test.ts
+++ b/tests/unit/events/rules.test.ts
@@ -101,7 +101,7 @@ describe("ATTENDEE_PAYMENT_METHODS_RESTRICTION", () => {
       originalEvent: { fee: 1000, capacity: null, payment_methods: ["stripe"] },
     });
     // 追加のみ（OK）
-    const addOnly = createTestFormData({ payment_methods: ["stripe", "cash"] });
+    const addOnly = createTestFormData({ fee: 1000, payment_methods: ["stripe", "cash"] });
     const addOnlyResult = await Promise.resolve(
       ATTENDEE_PAYMENT_METHODS_RESTRICTION.evaluate(context, addOnly)
     );
@@ -111,12 +111,60 @@ describe("ATTENDEE_PAYMENT_METHODS_RESTRICTION", () => {
     );
 
     // 解除を含む（NG）
-    const removal = createTestFormData({ payment_methods: ["cash"] });
+    const removal = createTestFormData({ fee: 1000, payment_methods: ["cash"] });
     const removalResult = await Promise.resolve(
       ATTENDEE_PAYMENT_METHODS_RESTRICTION.evaluate(context, removal)
     );
     expect(removalResult.isRestricted).toBe(true);
     expect(removalResult.message).toBe("参加者がいるため、既存の決済方法は解除できません");
+  });
+
+  it("参加者がいてもStripe集金済みがなく無料化する場合は決済方法の自動クリアを許可する", async () => {
+    const context = createTestContext({
+      hasAttendees: true,
+      hasStripePaid: false,
+      originalEvent: { fee: 1000, capacity: null, payment_methods: ["stripe", "cash"] },
+    });
+    const formData = createTestFormData({ fee: 0, payment_methods: [] });
+
+    const result = await Promise.resolve(
+      ATTENDEE_PAYMENT_METHODS_RESTRICTION.evaluate(context, formData)
+    );
+
+    expect(result.isRestricted).toBe(false);
+    expect(result.message).toBe("制限なし");
+  });
+
+  it("参加者がいて有料のまま既存の決済方法を解除する場合は制限あり", async () => {
+    const context = createTestContext({
+      hasAttendees: true,
+      hasStripePaid: false,
+      originalEvent: { fee: 1000, capacity: null, payment_methods: ["stripe", "cash"] },
+    });
+    const formData = createTestFormData({ fee: 1000, payment_methods: [] });
+
+    const result = await Promise.resolve(
+      ATTENDEE_PAYMENT_METHODS_RESTRICTION.evaluate(context, formData)
+    );
+
+    expect(result.isRestricted).toBe(true);
+    expect(result.message).toBe("参加者がいるため、既存の決済方法は解除できません");
+  });
+
+  it("Stripe集金済みがある場合は無料化でも決済方法の解除を制限する", async () => {
+    const context = createTestContext({
+      hasAttendees: true,
+      hasStripePaid: true,
+      originalEvent: { fee: 1000, capacity: null, payment_methods: ["stripe"] },
+    });
+    const formData = createTestFormData({ fee: 0, payment_methods: [] });
+
+    const result = await Promise.resolve(
+      ATTENDEE_PAYMENT_METHODS_RESTRICTION.evaluate(context, formData)
+    );
+
+    expect(result.isRestricted).toBe(true);
+    expect(result.message).toBe("参加者がいるため、既存の決済方法は解除できません");
   });
 });
 


### PR DESCRIPTION
## 概要

イベント編集画面の差分確認・集金方法変更・更新後遷移まわりの挙動を改善しました。

## 変更内容

- 差分確認モーダルの表示文言を日本語化
- 変更前後の値を、金額・日時・決済方法などフィールドごとに見やすく整形
- 参加者がいるイベントでも、Stripe集金済みがなく無料化する場合は集金方法の自動クリアを許可
- 有料のまま既存の集金方法を解除する場合は引き続き制限
- payment_deadline の必須チェックを更新処理側に寄せ、差分更新時の誤検知を修正
- イベント更新後のリダイレクトを強化
- 定員・集金方法まわりの編集UXと制限表示を調整
- 関連する unit / e2e テストを更新・追加

## テスト

- 集金方法制限の unit test を追加
- イベント編集制限の unit test を追加
- イベント編集 E2E の文言変更に追従