### PR TITLE
perf: app shell の初期表示を改善

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 
 import { redirect } from "next/navigation";
 
@@ -15,9 +15,11 @@ import { DemoBanner } from "@features/demo";
 
 import { AppAnnouncementBanner } from "@components/layout/AppAnnouncementBanner";
 import { AppSidebar } from "@components/layout/AppSidebar";
+import { AppSidebarFallback } from "@components/layout/AppSidebarFallback";
 import { Header } from "@components/layout/Header";
 import { MobileChromeProvider } from "@components/layout/mobile-chrome-context";
 import { MobileAppChrome } from "@components/layout/MobileAppChrome";
+import { MobileAppChromeFallback } from "@components/layout/MobileAppChromeFallback";
 
 import { dismissPayoutRequestInAppBannerAction } from "@/app/(app)/announcement-banner/actions";
 import { logoutAction } from "@/app/(auth)/actions";
@@ -26,13 +28,46 @@ import { ensureFeaturesRegistered } from "@/app/_init/feature-registrations";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 
 /**
- * アプリケーションレイアウト
- *
- * 認証済みユーザー向けアプリケーション領域のレイアウト。
- * アプリケーションサイドバー（AppSidebar）とメインコンテンツエリアを提供します。
+ * 認証済みユーザー向けアプリケーション領域の静的な外枠。
+ * workspace 解決前でも shell と子ページの loading UI を stream できるようにする。
  */
-export default async function AppLayout({ children }: { children: ReactNode }) {
-  ensureFeaturesRegistered();
+function StaticAppShell({
+  children,
+  sidebar,
+  mobileChrome,
+  banners = null,
+}: {
+  children: ReactNode;
+  sidebar: ReactNode;
+  mobileChrome: ReactNode;
+  banners?: ReactNode;
+}) {
+  return (
+    <SidebarProvider>
+      <MobileChromeProvider>
+        {sidebar}
+        <SidebarInset>
+          {banners}
+          <Header />
+          {mobileChrome}
+          <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col p-2 pb-[calc(var(--app-mobile-tabbar-height)+env(safe-area-inset-bottom))] sm:p-4 sm:pb-[calc(var(--app-mobile-tabbar-height)+env(safe-area-inset-bottom))] md:pb-4">
+            {children}
+          </main>
+        </SidebarInset>
+      </MobileChromeProvider>
+    </SidebarProvider>
+  );
+}
+
+function AppShellFallback({ children }: { children: ReactNode }) {
+  return (
+    <StaticAppShell sidebar={<AppSidebarFallback />} mobileChrome={<MobileAppChromeFallback />}>
+      {children}
+    </StaticAppShell>
+  );
+}
+
+async function WorkspaceAppShell({ children }: { children: ReactNode }) {
   const workspace = await resolveAppWorkspaceForServerComponent();
 
   if (workspace.isCommunityEmptyState) {
@@ -45,14 +80,23 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   );
 
   return (
-    <SidebarProvider>
-      <MobileChromeProvider>
+    <StaticAppShell
+      sidebar={
         <AppSidebar
           workspace={workspaceShell}
           logoutAction={logoutAction}
           createExpressDashboardLoginLinkAction={createExpressDashboardLoginLinkAction}
         />
-        <SidebarInset>
+      }
+      mobileChrome={
+        <MobileAppChrome
+          workspace={workspaceShell}
+          logoutAction={logoutAction}
+          createExpressDashboardLoginLinkAction={createExpressDashboardLoginLinkAction}
+        />
+      }
+      banners={
+        <>
           <DemoBanner />
           {showPayoutRequestBanner && (
             <AppAnnouncementBanner
@@ -60,17 +104,20 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
               dismissAction={dismissPayoutRequestInAppBannerAction}
             />
           )}
-          <Header />
-          <MobileAppChrome
-            workspace={workspaceShell}
-            logoutAction={logoutAction}
-            createExpressDashboardLoginLinkAction={createExpressDashboardLoginLinkAction}
-          />
-          <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col p-2 pb-[calc(var(--app-mobile-tabbar-height)+env(safe-area-inset-bottom))] sm:p-4 sm:pb-[calc(var(--app-mobile-tabbar-height)+env(safe-area-inset-bottom))] md:pb-4">
-            {children}
-          </main>
-        </SidebarInset>
-      </MobileChromeProvider>
-    </SidebarProvider>
+        </>
+      }
+    >
+      {children}
+    </StaticAppShell>
+  );
+}
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+  ensureFeaturesRegistered();
+
+  return (
+    <Suspense fallback={<AppShellFallback>{children}</AppShellFallback>}>
+      <WorkspaceAppShell>{children}</WorkspaceAppShell>
+    </Suspense>
   );
 }

--- a/components/layout/AppSidebarFallback.tsx
+++ b/components/layout/AppSidebarFallback.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect, type ComponentProps } from "react";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { CircleHelp, MessageSquare, Plus } from "lucide-react";
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+  useSidebar,
+} from "@/components/ui/sidebar";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { navigationConfig } from "./GlobalHeader/navigation-config";
+
+export function AppSidebarFallback(props: ComponentProps<typeof Sidebar>) {
+  const pathname = usePathname();
+  const { isMobile, setOpenMobile } = useSidebar();
+
+  useEffect(() => {
+    if (isMobile) {
+      setOpenMobile(false);
+    }
+  }, [pathname, isMobile, setOpenMobile]);
+
+  if (isMobile) {
+    return null;
+  }
+
+  return (
+    <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader className="border-b border-sidebar-border/60 px-2.5 pb-2 pt-2">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <div className="flex min-h-[3.65rem] items-center gap-3 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/35 px-3 py-2 group-data-[collapsible=icon]:min-h-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:border-none group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:py-0">
+              <Skeleton className="size-7 shrink-0 rounded-lg bg-sidebar-accent" />
+              <div className="min-w-0 flex-1 space-y-1.5 group-data-[collapsible=icon]:hidden">
+                <Skeleton className="h-2.5 w-16 bg-sidebar-accent" />
+                <Skeleton className="h-3.5 w-32 bg-sidebar-accent" />
+              </div>
+            </div>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent className="px-2.5 py-3">
+        <SidebarGroup className="py-0 group-data-[collapsible=icon]:px-0">
+          <SidebarGroupContent>
+            <SidebarMenu className="gap-1">
+              {navigationConfig.app.map((item) => {
+                const isActive =
+                  pathname === item.href ||
+                  (item.exactMatch === false &&
+                    pathname.startsWith(item.href) &&
+                    item.href !== "/dashboard") ||
+                  (item.href === "/dashboard" && pathname === "/dashboard");
+
+                return (
+                  <SidebarMenuItem key={item.href}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={isActive}
+                      tooltip={item.label}
+                      className={[
+                        "relative h-10 rounded-xl px-3 text-[13px] font-medium transition-all duration-150",
+                        "text-sidebar-foreground/70 hover:bg-sidebar-accent/75 hover:text-sidebar-foreground",
+                        "group-data-[collapsible=icon]:justify-center",
+                        isActive
+                          ? "bg-sidebar-accent/95 font-semibold text-sidebar-accent-foreground shadow-[inset_0_0_0_1px_hsl(var(--sidebar-primary)/0.12),0_8px_18px_-14px_hsl(var(--sidebar-primary)/0.65)] hover:bg-sidebar-accent"
+                          : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                    >
+                      <Link href={item.href}>
+                        <span
+                          className={
+                            isActive
+                              ? "text-sidebar-primary"
+                              : "text-sidebar-foreground/45 transition-colors group-hover/menu-item:text-sidebar-foreground/70"
+                          }
+                        >
+                          {item.icon}
+                        </span>
+                        <span className="group-data-[collapsible=icon]:hidden">{item.label}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <div className="mx-2 my-2.5 h-px bg-sidebar-border/60 group-data-[collapsible=icon]:hidden" />
+
+        <SidebarGroup className="py-0 group-data-[collapsible=icon]:px-0">
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={pathname === "/events/create"}
+                  tooltip="新しいイベントを作成"
+                  className={[
+                    "h-10 rounded-xl border border-sidebar-primary/25 bg-gradient-to-r from-sidebar-primary/16 via-sidebar-primary/10 to-sidebar-primary/5 text-[13px] font-semibold text-sidebar-primary transition-all duration-150",
+                    "shadow-[inset_0_1px_0_hsl(var(--sidebar-primary-foreground)/0.4),0_10px_20px_-18px_hsl(var(--sidebar-primary)/0.9)] hover:border-sidebar-primary/45 hover:from-sidebar-primary/24 hover:via-sidebar-primary/16 hover:to-sidebar-primary/8 hover:shadow-[inset_0_1px_0_hsl(var(--sidebar-primary-foreground)/0.5),0_14px_26px_-18px_hsl(var(--sidebar-primary)/1)]",
+                    "group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center",
+                    pathname === "/events/create"
+                      ? "border-sidebar-primary/50 from-sidebar-primary/28 via-sidebar-primary/18 to-sidebar-primary/10"
+                      : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                >
+                  <Link href="/events/create">
+                    <Plus className="size-4" />
+                    <span className="group-data-[collapsible=icon]:hidden">
+                      新しいイベントを作成
+                    </span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarFooter className="border-t border-sidebar-border/60 px-2.5 py-3">
+        <SidebarMenu className="gap-1">
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              tooltip="サポート"
+              className={[
+                "h-9 rounded-xl px-3 text-[13px] font-medium transition-all duration-150",
+                "text-sidebar-foreground/55 hover:bg-sidebar-accent/65 hover:text-sidebar-foreground",
+                "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0",
+              ].join(" ")}
+            >
+              <Link href="/contact">
+                <CircleHelp className="size-4 text-sidebar-foreground/45" />
+                <span className="group-data-[collapsible=icon]:hidden">サポート</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              tooltip="フィードバック"
+              className={[
+                "h-9 rounded-xl px-3 text-[13px] font-medium transition-all duration-150",
+                "text-sidebar-foreground/55 hover:bg-sidebar-accent/65 hover:text-sidebar-foreground",
+                "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0",
+              ].join(" ")}
+            >
+              <Link href="/feedback">
+                <MessageSquare className="size-4 text-sidebar-foreground/45" />
+                <span className="group-data-[collapsible=icon]:hidden">要望・不具合</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+
+      <SidebarRail />
+    </Sidebar>
+  );
+}

--- a/components/layout/MobileAppChromeFallback.tsx
+++ b/components/layout/MobileAppChromeFallback.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { CircleHelp, CreditCard, LogOut, MessageSquare, Plus, SquareMenu } from "lucide-react";
+
+import { navigationConfig } from "@/components/layout/GlobalHeader/navigation-config";
+import { cn } from "@/components/ui/_lib/cn";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { useMobileChrome } from "./mobile-chrome-context";
+import { isMobileTabActive, resolveMobilePageConfig } from "./mobile-navigation";
+import { useMobileKeyboardOpen } from "./use-mobile-keyboard";
+
+export function MobileAppChromeFallback() {
+  const pathname = usePathname();
+  const pageConfig = useMemo(() => resolveMobilePageConfig(pathname), [pathname]);
+  const isKeyboardOpen = useMobileKeyboardOpen();
+  const { isBottomOverlayOpen } = useMobileChrome();
+  const [isMoreOpen, setIsMoreOpen] = useState(false);
+
+  const shouldShowTabs = pageConfig.showTabs && !isKeyboardOpen && !isBottomOverlayOpen;
+
+  return (
+    <>
+      <header className="sticky top-0 z-30 border-b border-border/60 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/90 md:hidden">
+        <div className="flex h-[var(--app-mobile-header-height)] items-center gap-2 px-3">
+          {pageConfig.backHref ? (
+            <Button asChild variant="ghost" size="icon" className="-ml-1 h-9 w-9 shrink-0">
+              <Link href={pageConfig.backHref} aria-label="戻る">
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 18l-6-6 6-6"
+                  />
+                </svg>
+              </Link>
+            </Button>
+          ) : (
+            <div className="w-1 shrink-0" aria-hidden="true" />
+          )}
+
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold text-foreground">{pageConfig.title}</p>
+          </div>
+
+          <div className="flex items-center">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9 shrink-0 rounded-full"
+              aria-label="メニュー"
+              onClick={() => setIsMoreOpen(true)}
+            >
+              <SquareMenu className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {shouldShowTabs ? (
+        <nav className="fixed bottom-[calc(1.25rem+env(safe-area-inset-bottom))] left-4 right-4 z-40 mx-auto max-w-lg md:hidden">
+          <div className="rounded-full border border-border/50 bg-background/80 px-2 py-2 shadow-2xl shadow-black/10 backdrop-blur-xl supports-[backdrop-filter]:bg-background/70">
+            <div className="flex items-center justify-around">
+              {navigationConfig.mobileTabs.map((item) => {
+                const isActive = isMobileTabActive(item.href, pageConfig.activeNav);
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={cn(
+                      "relative flex h-12 flex-1 flex-col items-center justify-center gap-0.5 rounded-full px-1 transition-all duration-300",
+                      isActive
+                        ? "text-primary"
+                        : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                    )}
+                    aria-current={isActive ? "page" : undefined}
+                  >
+                    {isActive && (
+                      <div className="absolute inset-0 z-0 rounded-full bg-primary/10 transition-all duration-500" />
+                    )}
+                    <span
+                      className={cn(
+                        "relative z-10 flex h-5 items-center justify-center transition-transform duration-300",
+                        isActive && "scale-110"
+                      )}
+                    >
+                      {item.icon}
+                    </span>
+                    <span className="relative z-10 text-[10px] font-medium leading-none">
+                      {item.label}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </nav>
+      ) : null}
+
+      <Sheet open={isMoreOpen} onOpenChange={setIsMoreOpen}>
+        <SheetContent
+          side="bottom"
+          className="rounded-t-3xl border-border/70 px-0 pb-[calc(1.5rem+env(safe-area-inset-bottom))] pt-6 md:hidden"
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>メニュー</SheetTitle>
+          </SheetHeader>
+
+          <div className="mt-5 space-y-4 px-5">
+            <section className="space-y-2">
+              <p className="px-1 text-xs font-medium text-muted-foreground">コミュニティ</p>
+              <div className="overflow-hidden rounded-lg border border-border/60 bg-card">
+                {Array.from({ length: 2 }).map((_, index) => (
+                  <div key={index} className="flex items-center gap-3 px-4 py-3">
+                    <Skeleton className="size-6 shrink-0 rounded-md" />
+                    <Skeleton className="h-4 flex-1" />
+                  </div>
+                ))}
+              </div>
+              <Link
+                href="/communities/create"
+                className="flex items-center gap-3 rounded-lg border border-dashed border-border/70 px-4 py-3 text-sm font-medium text-foreground transition-colors hover:bg-muted/40"
+                onClick={() => setIsMoreOpen(false)}
+              >
+                <Plus className="h-4 w-4 text-muted-foreground" />
+                コミュニティを作成
+              </Link>
+            </section>
+
+            <section className="space-y-2">
+              <p className="px-1 text-xs font-medium text-muted-foreground">運営ツール</p>
+              <button
+                type="button"
+                disabled
+                className="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left text-sm font-medium text-muted-foreground opacity-60"
+              >
+                <CreditCard className="h-4 w-4" />
+                <span className="flex-1">Stripeダッシュボード</span>
+              </button>
+            </section>
+
+            <section className="space-y-2">
+              <p className="px-1 text-xs font-medium text-muted-foreground">サポート</p>
+
+              <Link
+                href="/contact"
+                className="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted/60"
+                onClick={() => setIsMoreOpen(false)}
+              >
+                <CircleHelp className="h-4 w-4 text-muted-foreground" />
+                サポート
+              </Link>
+
+              <Link
+                href="/feedback"
+                className="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted/60"
+                onClick={() => setIsMoreOpen(false)}
+              >
+                <MessageSquare className="h-4 w-4 text-muted-foreground" />
+                要望・不具合を送る
+              </Link>
+            </section>
+
+            <section className="space-y-2">
+              <p className="px-1 text-xs font-medium text-muted-foreground">アカウント</p>
+              <button
+                type="button"
+                disabled
+                className="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left text-sm font-medium text-destructive opacity-60"
+              >
+                <LogOut className="h-4 w-4" />
+                ログアウト
+              </button>
+            </section>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}


### PR DESCRIPTION
## 概要

* AppLayout を Suspense 対応し、workspace 解決前に静的な shell を表示
* デスクトップ向けの `AppSidebarFallback` を追加
* モバイル向けの `MobileAppChromeFallback` を追加
* app shell と子ページの loading UI を早期に stream できるように改善

## 変更

* `StaticAppShell` / `WorkspaceAppShell` / `AppShellFallback` にレイアウト責務を分離
* fallback 中もサイドバー・モバイルヘッダー・タブ UI の骨組みを表示
* workspace 依存のメニューや操作は fallback では skeleton / disabled 表示に変更