### PR TITLE
fix: GA4 Measurement Protocolの送信処理を改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ docs/analysis/
 app/debug/
 
 .codex
+.antigravitycli/

--- a/app/api/analytics/ga4-exception/route.ts
+++ b/app/api/analytics/ga4-exception/route.ts
@@ -1,0 +1,74 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { z } from "zod";
+
+import { ga4Server } from "@core/analytics/ga4-server";
+import { respondWithCode, respondWithProblem } from "@core/errors/adapters/http-adapter";
+import { extractClientIdFromGaCookie } from "@core/utils/ga-cookie";
+
+const API_INSTANCE = "/api/analytics/ga4-exception";
+
+const exceptionEventSchema = z.object({
+  description: z.string().min(1).max(500),
+  fatal: z.boolean(),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch (error) {
+    return respondWithCode("INVALID_JSON", {
+      instance: API_INSTANCE,
+      detail: "Invalid JSON in request body",
+      logContext: {
+        category: "system",
+        action: "ga4_exception_invalid_json",
+        actorType: "anonymous",
+        additionalData: {
+          error_message: error instanceof Error ? error.message : String(error),
+        },
+      },
+    });
+  }
+
+  const parsed = exceptionEventSchema.safeParse(body);
+  if (!parsed.success) {
+    return respondWithCode("VALIDATION_ERROR", {
+      instance: API_INSTANCE,
+      detail: "Invalid request body",
+      logContext: {
+        category: "system",
+        action: "ga4_exception_invalid_request",
+        actorType: "anonymous",
+      },
+    });
+  }
+
+  try {
+    const cookieStore = await cookies();
+    const clientId = extractClientIdFromGaCookie(cookieStore.get("_ga")?.value);
+
+    await ga4Server.sendEvent(
+      {
+        name: "exception",
+        params: parsed.data,
+      },
+      clientId ?? undefined
+    );
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return respondWithProblem(error, {
+      instance: API_INSTANCE,
+      defaultCode: "GA4_TRACKING_FAILED",
+      logContext: {
+        category: "system",
+        action: "ga4_exception_tracking",
+        actorType: "anonymous",
+      },
+    });
+  }
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -8,8 +8,6 @@
 
 import { useEffect } from "react";
 
-import { ga4Client } from "@core/analytics/ga4-client";
-
 import { ErrorLayout } from "@/components/errors/ErrorLayout";
 
 interface GlobalErrorProps {
@@ -17,16 +15,33 @@ interface GlobalErrorProps {
   reset: () => void;
 }
 
+function reportGlobalException(error: Error & { digest?: string }) {
+  const payload = JSON.stringify({
+    description: `Global Error: ${error.message}${error.digest ? ` (${error.digest})` : ""}`,
+    fatal: true,
+  });
+
+  if (navigator.sendBeacon) {
+    const sent = navigator.sendBeacon(
+      "/api/analytics/ga4-exception",
+      new Blob([payload], { type: "application/json" })
+    );
+    if (sent) {
+      return;
+    }
+  }
+
+  void fetch("/api/analytics/ga4-exception", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    keepalive: true,
+  });
+}
+
 export default function GlobalError({ error, reset }: GlobalErrorProps) {
   useEffect(() => {
-    // グローバルエラーをGA4に送信
-    ga4Client.sendEvent({
-      name: "exception",
-      params: {
-        description: `Global Error: ${error.message}${error.digest ? ` (${error.digest})` : ""}`,
-        fatal: true,
-      },
-    });
+    reportGlobalException(error);
 
     // グローバルエラーの発生をトラッキング
     // 本番環境では重要度が最高レベル

--- a/app/guest/[token]/GuestPageClient.tsx
+++ b/app/guest/[token]/GuestPageClient.tsx
@@ -115,14 +115,18 @@ export function GuestPageClient({
       };
 
       // GA4 Client IDを取得
-      const gaClientId = await ga4Client.getClientId();
+      const [gaClientId, gaSessionId] = await Promise.all([
+        ga4Client.getClientId(),
+        ga4Client.getSessionId(),
+      ]);
 
       // 2. Server Actionを開始 (非同期)
       const sessionCreationPromise = createGuestStripeSessionAction({
         guestToken: attendance.guest_token,
         successUrl: buildRedirectUrl("success"),
         cancelUrl: buildRedirectUrl("canceled"),
-        gaClientId: gaClientId ?? undefined,
+        ...(gaClientId ? { gaClientId } : {}),
+        ...(gaSessionId ? { gaSessionId } : {}),
       });
 
       // 3. GA4イベント送信 (Fire and Forget)

--- a/core/analytics/README.md
+++ b/core/analytics/README.md
@@ -270,7 +270,7 @@ NEXT_PUBLIC_GA4_DEBUG=true
 [GA4] Event sent: purchase
 [GA4] Retrying after error (attempt: 1, delay: 1234ms)
 [GA4] Truncated parameter description from 150 to 100 characters
-[GA4] Batch sent successfully (batch_index: 0, event_count: 25)
+[GA4] Batch accepted by endpoint (batch_index: 0, event_count: 25)
 ```
 
 ## マイグレーションガイド
@@ -469,12 +469,13 @@ Client IDを検証します。
 - **clientId**: 検証するClient ID
 - **戻り値**: 検証結果
 
-#### `static validateAndSanitizeParams(params: Record<string, unknown>, debug?: boolean): ValidationResult`
+#### `static validateAndSanitizeParams(params: Record<string, unknown>, debug?: boolean, eventName?: string): ValidationResult`
 
 イベントパラメータを検証・サニタイズします。
 
 - **params**: 検証するパラメータ
 - **debug**: デバッグログを出力するか
+- **eventName**: イベント固有の必須パラメータを検証する場合のイベント名
 - **戻り値**: 検証結果とサニタイズ済みパラメータ
 
 ## ライセンス

--- a/core/analytics/README.md
+++ b/core/analytics/README.md
@@ -229,31 +229,17 @@ console.log('エラー:', result.errors);
 
 ### エラーハンドリング
 
-#### GA4Errorの使用
+#### 送信結果の使用
 
 ```typescript
-import { GA4Error, GA4ErrorCode } from '@core/analytics';
+const result = await ga4Server.sendEvent(event, invalidClientId);
 
-try {
-  await ga4Server.sendEvent(event, invalidClientId);
-} catch (error) {
-  if (error instanceof GA4Error) {
-    console.error('GA4エラー:', error.code);
-    console.error('メッセージ:', error.message);
-    console.error('コンテキスト:', error.context);
+if (result.status === "skipped") {
+  console.warn("GA4送信スキップ:", result.reason);
+}
 
-    switch (error.code) {
-      case GA4ErrorCode.INVALID_CLIENT_ID:
-        // Client ID検証エラーの処理
-        break;
-      case GA4ErrorCode.RETRY_EXHAUSTED:
-        // リトライ失敗の処理
-        break;
-      case GA4ErrorCode.API_ERROR:
-        // APIエラーの処理
-        break;
-    }
-  }
+if (result.status === "failed") {
+  console.error("GA4送信失敗:", result.code, result.error);
 }
 ```
 
@@ -291,7 +277,7 @@ NEXT_PUBLIC_GA4_DEBUG=true
 
 ### 既存コードからの移行
 
-既存のGA4実装からの移行は段階的に行えます。新しいAPIは後方互換性を維持しているため、既存のコードは引き続き動作します。
+既存のGA4実装からの移行は段階的に行えます。`sendEvent` の戻り値を確認することで、送信・スキップ・失敗を判定できます。
 
 #### Phase 1: タイムアウト処理の追加
 
@@ -313,17 +299,10 @@ try {
   console.error('Error:', error);
 }
 
-// 新コード（構造化エラー）
-try {
-  await ga4Server.sendEvent(event, clientId);
-} catch (error) {
-  if (error instanceof GA4Error) {
-    logger.error('GA4 error', {
-      code: error.code,
-      message: error.message,
-      context: error.context,
-    });
-  }
+// 新コード（結果型）
+const result = await ga4Server.sendEvent(event, clientId);
+if (result.status !== "sent") {
+  logger.warn("GA4 event was not sent", result);
 }
 ```
 
@@ -362,7 +341,8 @@ await ga4Server.sendEvents(events, clientId);
 
 ### 破壊的変更
 
-このアップデートには破壊的変更はありません。すべての既存APIは引き続き動作します。
+- `sendEvent` は `Promise<void>` ではなく `Promise<GA4SendEventResult>` を返します。
+- Web streamのMeasurement Protocolに合わせ、Client IDがないイベントは送信されません。User IDはClient IDの代替ではなく補助フィールドとして扱います。
 
 ### 推奨される移行手順
 
@@ -462,15 +442,16 @@ Client IDを取得します。`window.gtag` が利用可能になるまでポー
 
 ### GA4ServerService
 
-#### `sendEvent(event: GA4Event, clientId?: string, userId?: string, sessionId?: number, engagementTimeMsec?: number): Promise<void>`
+#### `sendEvent(event: GA4Event, clientId?: string, userId?: string, sessionId?: number, engagementTimeMsec?: number): Promise<GA4SendEventResult>`
 
 サーバー側でイベントを送信します。
 
 - **event**: 送信するイベント
-- **clientId**: Client ID（オプション）
-- **userId**: User ID（オプション）
+- **clientId**: Client ID（Web streamのMeasurement Protocolでは必須）
+- **userId**: User ID（オプション、有効なClient IDがある場合のみ同梱）
 - **sessionId**: Session ID（オプション）
 - **engagementTimeMsec**: エンゲージメント時間（オプション）
+- **戻り値**: `{ status: "sent" }`、`{ status: "skipped", reason }`、または `{ status: "failed", code, error }`
 
 #### `sendEvents(events: GA4Event[], clientId: string): Promise<void>`
 

--- a/core/analytics/ga4-client.ts
+++ b/core/analytics/ga4-client.ts
@@ -69,7 +69,7 @@ export class GA4ClientService {
     }
 
     try {
-      sendGAEvent(event.name, event.params);
+      sendGAEvent("event", event.name, event.params);
 
       if (this.config.debug) {
         this.logger.debug("[GA4] Event sent", {
@@ -152,16 +152,17 @@ export class GA4ClientService {
       const checkGtag = () => {
         if (typeof window !== "undefined" && window.gtag) {
           try {
-            window.gtag("get", this.config.measurementId, "client_id", (clientId: string) => {
+            window.gtag("get", this.config.measurementId, "client_id", (clientId: unknown) => {
+              const rawClientId = typeof clientId === "string" ? clientId : String(clientId ?? "");
               // プレフィックス（GA1.1.など）を除去してサニタイズ
-              const sanitizedClientId = GA4Validator.sanitizeClientId(clientId);
+              const sanitizedClientId = GA4Validator.sanitizeClientId(rawClientId);
 
               // Client ID検証
               const validation = GA4Validator.validateClientId(sanitizedClientId);
               if (!validation.isValid) {
                 if (this.config.debug) {
                   this.logger.debug("[GA4] Invalid client ID received", {
-                    original_client_id: clientId,
+                    original_client_id: rawClientId,
                     sanitized_client_id: sanitizedClientId,
                     errors: validation.errors,
                     outcome: "failure",
@@ -173,7 +174,7 @@ export class GA4ClientService {
 
               if (this.config.debug) {
                 this.logger.debug("[GA4] Client ID retrieved", {
-                  original_client_id: clientId,
+                  original_client_id: rawClientId,
                   sanitized_client_id: sanitizedClientId,
                   outcome: "success",
                 });
@@ -199,6 +200,99 @@ export class GA4ClientService {
       // 即時チェック
       if (!checkGtag()) {
         // 利用できない場合はポーリング開始 (100ms間隔)
+        intervalId = setInterval(() => {
+          if (checkGtag()) {
+            if (intervalId) clearInterval(intervalId);
+          }
+        }, 100);
+      }
+    });
+  }
+
+  /**
+   * GA4 Session IDを取得する（Measurement Protocol連携用）
+   *
+   * タイムアウトまたは検証失敗時はnullを返します。
+   *
+   * @param timeoutMs - タイムアウト時間（ミリ秒）、デフォルトは1000ms
+   * @returns Promise<number | null> Session ID、取得できない場合はnull
+   */
+  async getSessionId(timeoutMs: number = 1000): Promise<number | null> {
+    if (!this.config.enabled) {
+      if (this.config.debug) {
+        this.logger.debug("[GA4] Session ID request skipped (disabled)", {
+          outcome: "success",
+        });
+      }
+      return null;
+    }
+
+    return new Promise((resolve) => {
+      let resolved = false;
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      let intervalId: ReturnType<typeof setInterval> | null = null;
+
+      const safeResolve = (value: number | null) => {
+        if (!resolved) {
+          resolved = true;
+          if (timeoutId) clearTimeout(timeoutId);
+          if (intervalId) clearInterval(intervalId);
+          resolve(value);
+        }
+      };
+
+      timeoutId = setTimeout(() => {
+        if (this.config.debug) {
+          this.logger.debug("[GA4] Session ID retrieval timed out", {
+            outcome: "failure",
+          });
+        }
+        safeResolve(null);
+      }, timeoutMs);
+
+      const checkGtag = () => {
+        if (typeof window !== "undefined" && window.gtag) {
+          try {
+            window.gtag("get", this.config.measurementId, "session_id", (sessionId: unknown) => {
+              const normalizedSessionId =
+                typeof sessionId === "number" ? sessionId : Number(sessionId);
+
+              if (!Number.isSafeInteger(normalizedSessionId) || normalizedSessionId <= 0) {
+                if (this.config.debug) {
+                  this.logger.debug("[GA4] Invalid session ID received", {
+                    session_id: sessionId,
+                    outcome: "failure",
+                  });
+                }
+                safeResolve(null);
+                return;
+              }
+
+              if (this.config.debug) {
+                this.logger.debug("[GA4] Session ID retrieved", {
+                  session_id: normalizedSessionId,
+                  outcome: "success",
+                });
+              }
+              safeResolve(normalizedSessionId);
+            });
+          } catch (error) {
+            handleClientError("GA4_TRACKING_FAILED", {
+              category: "system",
+              action: "ga4_get_session_id",
+              actorType: "user",
+              additionalData: {
+                error_message: error instanceof Error ? error.message : String(error),
+              },
+            });
+            safeResolve(null);
+          }
+          return true;
+        }
+        return false;
+      };
+
+      if (!checkGtag()) {
         intervalId = setInterval(() => {
           if (checkGtag()) {
             if (intervalId) clearInterval(intervalId);
@@ -288,7 +382,7 @@ export class GA4ClientService {
         },
       };
 
-      sendGAEvent(eventWithCallback.name, eventWithCallback.params);
+      sendGAEvent("event", eventWithCallback.name, eventWithCallback.params);
 
       if (this.config.debug) {
         this.logger.debug("[GA4] Event with callback sent", {
@@ -360,7 +454,7 @@ declare global {
       command: "get" | "config" | "event",
       targetId: string,
       config?: string | object,
-      callback?: (value: string) => void
+      callback?: (value: unknown) => void
     ) => void;
   }
 }

--- a/core/analytics/ga4-server.ts
+++ b/core/analytics/ga4-server.ts
@@ -40,6 +40,7 @@ export class GA4ServerService {
   private readonly MAX_RETRY_DELAY = 10000;
   private readonly MAX_JITTER = 1000;
   private readonly MAX_EVENTS_PER_BATCH = 25;
+  private readonly MAX_EVENT_PARAMS = 25;
 
   /**
    * 設定を動的に取得するgetter
@@ -165,11 +166,13 @@ export class GA4ServerService {
     // パラメータ検証とサニタイズ（GA4Validator使用）
     const paramValidation = GA4Validator.validateAndSanitizeParams(
       event.params as Record<string, unknown>,
-      this.config.debug
+      this.config.debug,
+      event.name
     );
 
-    // sanitizedParamsが存在しない、または元のパラメータが空でないのにサニタイズ後が空の場合はエラー
+    // sanitizedParamsが存在しない、検証エラーがある、または元のパラメータが空でないのにサニタイズ後が空の場合はエラー
     if (
+      !paramValidation.isValid ||
       !paramValidation.sanitizedParams ||
       (Object.keys(event.params).length > 0 &&
         Object.keys(paramValidation.sanitizedParams).length === 0)
@@ -194,6 +197,16 @@ export class GA4ServerService {
     }
     if (engagementTimeMsec !== undefined && engagementTimeMsec >= 0) {
       eventParams.engagement_time_msec = engagementTimeMsec;
+    }
+
+    if (Object.keys(eventParams).length > this.MAX_EVENT_PARAMS) {
+      this.logger.warn("[GA4] Event parameters validation failed", {
+        event_name: event.name,
+        original_param_count: Object.keys(event.params).length,
+        sanitized_param_count: Object.keys(eventParams).length,
+        errors: [`Too many event parameters: ${Object.keys(eventParams).length}`],
+      });
+      return { status: "skipped", reason: "invalid_params" };
     }
 
     // ペイロードを構築（Web streamのMPではclient_idが必須）
@@ -236,7 +249,7 @@ export class GA4ServerService {
         );
       }
 
-      this.logger.info("[GA4] Server event sent successfully", {
+      this.logger.info("[GA4] Server event accepted by endpoint", {
         event_name: event.name,
         client_id: validClientId,
         user_id: userId,
@@ -329,11 +342,13 @@ export class GA4ServerService {
       .map((event) => {
         const paramValidation = GA4Validator.validateAndSanitizeParams(
           event.params as Record<string, unknown>,
-          this.config.debug
+          this.config.debug,
+          event.name
         );
 
-        // sanitizedParamsが存在し、かつ元のパラメータが空でないのにサニタイズ後が空でない場合のみ有効
+        // sanitizedParamsが存在し、検証エラーがなく、かつ元のパラメータが空でないのにサニタイズ後が空でない場合のみ有効
         if (
+          paramValidation.isValid &&
           paramValidation.sanitizedParams &&
           !(
             Object.keys(event.params).length > 0 &&
@@ -472,7 +487,7 @@ export class GA4ServerService {
         );
       }
 
-      this.logger.info("[GA4] Batch sent successfully", {
+      this.logger.info("[GA4] Batch accepted by endpoint", {
         batch_index: batchIndex,
         batch_size: batch.length,
         event_names: batch.map((e) => e.name).join(", "),

--- a/core/analytics/ga4-server.ts
+++ b/core/analytics/ga4-server.ts
@@ -12,8 +12,24 @@ import { handleServerError } from "@core/utils/error-handler.server";
 
 import { getGA4Config } from "./config";
 import type { GA4Event } from "./event-types";
-import { GA4Error, GA4ErrorCode } from "./ga4-error";
+import { GA4Error, GA4ErrorCode, type GA4ErrorCodeType } from "./ga4-error";
 import { GA4Validator } from "./ga4-validator";
+
+export type GA4SendEventResult =
+  | { status: "sent" }
+  | {
+      status: "skipped";
+      reason:
+        | "disabled"
+        | "missing_api_secret"
+        | "invalid_or_missing_client_id"
+        | "invalid_params";
+    }
+  | {
+      status: "failed";
+      code: GA4ErrorCodeType;
+      error: string;
+    };
 
 /**
  * GA4サーバー側サービスクラス
@@ -63,11 +79,11 @@ export class GA4ServerService {
    *
    * Client IDとイベントパラメータの検証を自動的に実行します。
    * 5xxエラーの場合は自動的にリトライします（最大3回、指数バックオフ）。
-   * Client IDまたはUser IDのいずれかが必須です。
+   * Web streamのMeasurement Protocolでは有効なClient IDが必須です。
    *
    * @param event - 送信するGA4イベント
    * @param clientId - GA4 Client ID（オプショナル、_ga Cookieから取得した値）
-   * @param userId - ユーザーID（オプショナル、clientIdがない場合のフォールバック）
+   * @param userId - ユーザーID（オプショナル、clientIdが有効な場合のみ同梱）
    * @param sessionId - セッションID（オプショナル、正の整数）
    * @param engagementTimeMsec - エンゲージメント時間（ミリ秒、オプショナル）
    *
@@ -86,10 +102,10 @@ export class GA4ServerService {
    *   '1234567890.0987654321'
    * );
    *
-   * // User IDとセッション情報を使用
+   * // User IDとセッション情報を同梱
    * await ga4Server.sendEvent(
    *   event,
-   *   undefined,
+   *   '1234567890.0987654321',
    *   'user123',
    *   1234567890,
    *   5000
@@ -102,14 +118,23 @@ export class GA4ServerService {
     userId?: string,
     sessionId?: number,
     engagementTimeMsec?: number
-  ): Promise<void> {
-    if (!this.config.enabled || !this.config.apiSecret) {
+  ): Promise<GA4SendEventResult> {
+    if (!this.config.enabled) {
       this.logger.debug("[GA4] Server event skipped (disabled or no API secret)", {
         event_name: event.name,
         client_id: clientId,
         user_id: userId,
       });
-      return;
+      return { status: "skipped", reason: "disabled" };
+    }
+
+    if (!this.config.apiSecret) {
+      this.logger.debug("[GA4] Server event skipped (disabled or no API secret)", {
+        event_name: event.name,
+        client_id: clientId,
+        user_id: userId,
+      });
+      return { status: "skipped", reason: "missing_api_secret" };
     }
 
     // Client ID検証（GA4Validator使用）
@@ -128,14 +153,13 @@ export class GA4ServerService {
       }
     }
 
-    // Client IDもUserIdもない場合は送信できない
-    if (!validClientId && !userId) {
-      this.logger.warn("[GA4] Neither valid client ID nor user ID provided", {
+    if (!validClientId) {
+      this.logger.warn("[GA4] No valid client ID provided", {
         client_id: clientId,
         user_id: userId,
         event_name: event.name,
       });
-      return;
+      return { status: "skipped", reason: "invalid_or_missing_client_id" };
     }
 
     // パラメータ検証とサニタイズ（GA4Validator使用）
@@ -158,7 +182,7 @@ export class GA4ServerService {
           : 0,
         errors: paramValidation.errors,
       });
-      return;
+      return { status: "skipped", reason: "invalid_params" };
     }
 
     const url = `${this.MEASUREMENT_PROTOCOL_URL}?measurement_id=${this.config.measurementId}&api_secret=${this.config.apiSecret}`;
@@ -172,15 +196,16 @@ export class GA4ServerService {
       eventParams.engagement_time_msec = engagementTimeMsec;
     }
 
-    // ペイロードを構築（client_id優先、なければuser_id）
+    // ペイロードを構築（Web streamのMPではclient_idが必須）
     const payload: {
-      client_id?: string;
+      client_id: string;
       user_id?: string;
       events: Array<{
         name: string;
         params: Record<string, unknown>;
       }>;
     } = {
+      client_id: validClientId,
       events: [
         {
           name: event.name,
@@ -189,9 +214,7 @@ export class GA4ServerService {
       ],
     };
 
-    if (validClientId) {
-      payload.client_id = validClientId;
-    } else if (userId) {
+    if (userId) {
       payload.user_id = userId;
     }
 
@@ -227,7 +250,11 @@ export class GA4ServerService {
           payload: JSON.stringify(payload),
         });
       }
+      return { status: "sent" };
     } catch (error) {
+      const errorMessage = error instanceof GA4Error ? error.message : String(error);
+      const errorCode = error instanceof GA4Error ? error.code : GA4ErrorCode.API_ERROR;
+
       handleServerError("GA4_TRACKING_FAILED", {
         category: "system",
         action: "ga4_send_event",
@@ -236,8 +263,8 @@ export class GA4ServerService {
           event_name: event.name,
           client_id: validClientId,
           user_id: userId,
-          error: error instanceof GA4Error ? error.message : String(error),
-          error_code: error instanceof GA4Error ? error.code : undefined,
+          error: errorMessage,
+          error_code: errorCode,
         },
       });
 
@@ -248,6 +275,8 @@ export class GA4ServerService {
           payload: JSON.stringify(payload),
         });
       }
+
+      return { status: "failed", code: errorCode, error: errorMessage };
     }
   }
 

--- a/core/analytics/ga4-validator.ts
+++ b/core/analytics/ga4-validator.ts
@@ -24,14 +24,69 @@ export class GA4Validator {
   /** Pattern for valid GA4 client IDs: numbers.numbers (variable length) */
   private static readonly CLIENT_ID_PATTERN = /^\d+\.\d+$/;
 
-  /** Pattern for valid parameter names: alphanumeric and underscores, 1-40 characters */
-  private static readonly PARAM_NAME_PATTERN = /^[a-zA-Z0-9_]{1,40}$/;
+  /** Pattern for valid parameter names: start with a letter, then alphanumeric and underscores, 1-40 characters */
+  private static readonly PARAM_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_]{0,39}$/;
+
+  /** Maximum number of event parameters per event */
+  private static readonly MAX_EVENT_PARAMS = 25;
+
+  /** Maximum number of custom item-scoped parameters per item */
+  private static readonly MAX_CUSTOM_ITEM_PARAMS = 27;
 
   /** Maximum length for string parameter values */
   private static readonly MAX_STRING_LENGTH = 100;
 
   /** Invalid client ID prefixes that should be rejected */
   private static readonly INVALID_CLIENT_ID_PREFIXES = ["GA1.", "1.."];
+
+  /** Reserved parameter names and prefixes that GA4 does not accept for custom params */
+  private static readonly RESERVED_PARAM_NAMES = new Set([
+    "firebase_conversion",
+    "firebase_error",
+    "firebase_error_value",
+    "firebase_screen",
+    "firebase_screen_class",
+    "firebase_screen_id",
+    "ga_error",
+    "ga_error_value",
+    "ga_session_id",
+    "ga_session_number",
+    "google_conversion",
+    "google_conversion_id",
+    "google_conversion_label",
+    "google_conversion_value",
+  ]);
+
+  private static readonly RESERVED_PARAM_PREFIXES = ["ga_", "google_", "firebase_", "_"];
+
+  private static readonly REQUIRED_PARAMS_BY_EVENT: Record<string, string[]> = {
+    begin_checkout: ["currency", "value", "items"],
+    purchase: ["transaction_id", "currency", "value", "items"],
+    sign_up: ["method"],
+    login: ["method"],
+    exception: ["description", "fatal"],
+  };
+
+  private static readonly STANDARD_ITEM_PARAMS = new Set([
+    "item_id",
+    "item_name",
+    "affiliation",
+    "coupon",
+    "discount",
+    "index",
+    "item_brand",
+    "item_category",
+    "item_category2",
+    "item_category3",
+    "item_category4",
+    "item_category5",
+    "item_list_id",
+    "item_list_name",
+    "item_variant",
+    "location_id",
+    "price",
+    "quantity",
+  ]);
 
   /**
    * Validates a GA4 client ID
@@ -109,12 +164,15 @@ export class GA4Validator {
   /**
    * Validates and sanitizes event parameters according to GA4 specifications
    *
-   *- Parameter names must be alphanumeric with underscores, max 40 characters
+   * - Parameter names must start with a letter and contain alphanumeric characters or underscores, max 40 characters
+   * - Reserved parameter names and prefixes are rejected
+   * - Event-specific required parameters are validated when eventName is provided
    * - String values are truncated to 100 characters
    * - Invalid parameters are excluded from the result
    *
    * @param params - The event parameters to validate and sanitize
    * @param debug - Whether to log debug information
+   * @param eventName - Optional GA4 event name for event-specific validation
    * @returns Validation result with sanitized parameters
    *
    * @example
@@ -128,14 +186,23 @@ export class GA4Validator {
    */
   static validateAndSanitizeParams(
     params: Record<string, unknown>,
-    debug: boolean = false
+    debug: boolean = false,
+    eventName?: string
   ): ValidationResult {
     const errors: string[] = [];
     const sanitizedParams: Record<string, unknown> = {};
 
+    if (Object.keys(params).length > this.MAX_EVENT_PARAMS) {
+      errors.push(`Too many event parameters: ${Object.keys(params).length}`);
+    }
+
+    if (eventName) {
+      this.validateRequiredParams(eventName, params, errors);
+    }
+
     for (const [key, value] of Object.entries(params)) {
       // Validate parameter name
-      if (!this.PARAM_NAME_PATTERN.test(key)) {
+      if (!this.isValidParamName(key)) {
         errors.push(`Invalid parameter name: ${key}`);
         if (debug) {
           // eslint-disable-next-line no-console
@@ -144,8 +211,12 @@ export class GA4Validator {
         continue;
       }
 
-      // Sanitize string values by truncating if necessary
-      if (typeof value === "string") {
+      if (key === "items" && (eventName === "purchase" || eventName === "begin_checkout")) {
+        if (this.validateItems(value, errors)) {
+          sanitizedParams[key] = value;
+        }
+      } else if (typeof value === "string") {
+        // Sanitize string values by truncating if necessary
         if (value.length > this.MAX_STRING_LENGTH) {
           sanitizedParams[key] = value.substring(0, this.MAX_STRING_LENGTH);
           if (debug) {
@@ -165,9 +236,79 @@ export class GA4Validator {
 
     // 空のパラメータも有効とする（GA4はパラメータなしのイベントを許可）
     return {
-      isValid: true,
+      isValid: errors.length === 0,
       errors,
       sanitizedParams,
     };
+  }
+
+  private static isValidParamName(name: string): boolean {
+    if (!this.PARAM_NAME_PATTERN.test(name)) {
+      return false;
+    }
+    if (this.RESERVED_PARAM_NAMES.has(name)) {
+      return false;
+    }
+    return !this.RESERVED_PARAM_PREFIXES.some((prefix) => name.startsWith(prefix));
+  }
+
+  private static validateRequiredParams(
+    eventName: string,
+    params: Record<string, unknown>,
+    errors: string[]
+  ): void {
+    const requiredParams = this.REQUIRED_PARAMS_BY_EVENT[eventName];
+    if (!requiredParams) {
+      return;
+    }
+
+    for (const param of requiredParams) {
+      if (params[param] === undefined || params[param] === null || params[param] === "") {
+        errors.push(`Missing required parameter for ${eventName}: ${param}`);
+      }
+    }
+  }
+
+  private static validateItems(value: unknown, errors: string[]): boolean {
+    if (!Array.isArray(value)) {
+      errors.push("items must be an array");
+      return false;
+    }
+    if (value.length === 0) {
+      errors.push("items must contain at least one item");
+      return false;
+    }
+
+    let isValid = true;
+    for (const [index, item] of value.entries()) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        errors.push(`items[${index}] must be an object`);
+        isValid = false;
+        continue;
+      }
+
+      const itemParams = item as Record<string, unknown>;
+      if (!itemParams.item_id && !itemParams.item_name) {
+        errors.push(`items[${index}] must include item_id or item_name`);
+        isValid = false;
+      }
+
+      const customItemParams = Object.keys(itemParams).filter(
+        (key) => !this.STANDARD_ITEM_PARAMS.has(key)
+      );
+      if (customItemParams.length > this.MAX_CUSTOM_ITEM_PARAMS) {
+        errors.push(`items[${index}] has too many custom parameters: ${customItemParams.length}`);
+        isValid = false;
+      }
+
+      for (const key of Object.keys(itemParams)) {
+        if (!this.isValidParamName(key)) {
+          errors.push(`Invalid item parameter name at items[${index}]: ${key}`);
+          isValid = false;
+        }
+      }
+    }
+
+    return isValid;
   }
 }

--- a/core/ports/payments.ts
+++ b/core/ports/payments.ts
@@ -45,6 +45,8 @@ export interface CreateStripeSessionParams {
   cancelUrl: string;
   /** GA4 Client ID（アナリティクス追跡用） */
   gaClientId?: string;
+  /** GA4 Session ID（アナリティクス追跡用） */
+  gaSessionId?: number;
   transferGroup?: string;
   /**
    * Destination charges用パラメータ

--- a/core/stripe/destination-charges.ts
+++ b/core/stripe/destination-charges.ts
@@ -19,6 +19,7 @@ interface CreateDestinationCheckoutParams {
   cancelUrl: string;
   actorId: string; // idempotency_key生成用（認証ユーザー=users.id / ゲスト=attendances.id）
   gaClientId?: string; // GA4 Client ID（アナリティクス追跡用）
+  gaSessionId?: number; // GA4 Session ID（アナリティクス追跡用）
   metadata?: Record<string, string>;
   setupFutureUsage?: "off_session";
   idempotencyKey?: string; // 既存キーの再利用用（任意）
@@ -39,6 +40,7 @@ export async function createDestinationCheckoutSession(
     cancelUrl,
     actorId,
     gaClientId,
+    gaSessionId,
     metadata = {},
     setupFutureUsage,
     idempotencyKey,
@@ -56,6 +58,7 @@ export async function createDestinationCheckoutSession(
     event_id: eventId,
     actor_id: actorId,
     ...(gaClientId ? { ga_client_id: gaClientId } : {}),
+    ...(gaSessionId ? { ga_session_id: String(gaSessionId) } : {}),
     ...metadata,
   };
 

--- a/features/guest/actions/create-stripe-session.ts
+++ b/features/guest/actions/create-stripe-session.ts
@@ -89,7 +89,7 @@ export async function createGuestStripeSessionAction(
       userMessage: "入力データが無効です。",
     });
   }
-  const { guestToken, successUrl, cancelUrl, gaClientId } = parsed.data;
+  const { guestToken, successUrl, cancelUrl, gaClientId, gaSessionId } = parsed.data;
 
   // 2. guestToken 検証 & 参加データ取得
   const tokenResult = await validateGuestToken(guestToken);
@@ -208,7 +208,8 @@ export async function createGuestStripeSessionAction(
       successUrl,
       cancelUrl,
       destinationCharges: destinationChargesConfig,
-      gaClientId, // GA4 Client IDを渡す
+      ...(gaClientId ? { gaClientId } : {}),
+      ...(gaSessionId ? { gaSessionId } : {}),
     });
 
     return ok({

--- a/features/guest/validation.ts
+++ b/features/guest/validation.ts
@@ -5,4 +5,5 @@ export const guestStripeSessionInputSchema = z.object({
   successUrl: z.string().url(),
   cancelUrl: z.string().url(),
   gaClientId: z.string().optional(), // GA4 Client ID（アナリティクス追跡用）
+  gaSessionId: z.number().int().positive().optional(), // GA4 Session ID（アナリティクス追跡用）
 });

--- a/features/payments/services/analytics/payment-analytics.ts
+++ b/features/payments/services/analytics/payment-analytics.ts
@@ -115,7 +115,7 @@ export class PaymentAnalyticsService {
         return;
       }
 
-      logger.info("[Payment Analytics] Purchase event tracked successfully", {
+      logger.info("[Payment Analytics] Purchase event submitted to GA4 endpoint", {
         category: "payment",
         action: "payment_analytics",
         actor_type: "system",

--- a/features/payments/services/analytics/payment-analytics.ts
+++ b/features/payments/services/analytics/payment-analytics.ts
@@ -26,6 +26,8 @@ export interface TrackPurchaseCompletionParams {
   eventTitle: string;
   /** 金額（円） */
   amount: number;
+  /** GA4 Session ID */
+  sessionId?: number;
 }
 
 /**
@@ -41,7 +43,7 @@ export class PaymentAnalyticsService {
    * @param params - 購入完了追跡のパラメータ
    */
   async trackPurchaseCompletion(params: TrackPurchaseCompletionParams): Promise<void> {
-    const { clientId, transactionId, eventId, eventTitle, amount } = params;
+    const { clientId, transactionId, eventId, eventTitle, amount, sessionId } = params;
 
     // パラメータのバリデーション
     if (!clientId || !transactionId || !eventId || !eventTitle) {
@@ -88,7 +90,13 @@ export class PaymentAnalyticsService {
 
     try {
       // GA4サーバーサービスを使用してイベントを送信
-      await ga4Server.sendEvent({ name: "purchase", params: purchaseParams }, clientId);
+      await ga4Server.sendEvent(
+        { name: "purchase", params: purchaseParams },
+        clientId,
+        undefined,
+        sessionId,
+        sessionId ? 1 : undefined
+      );
 
       logger.info("[Payment Analytics] Purchase event tracked successfully", {
         category: "payment",

--- a/features/payments/services/analytics/payment-analytics.ts
+++ b/features/payments/services/analytics/payment-analytics.ts
@@ -90,13 +90,30 @@ export class PaymentAnalyticsService {
 
     try {
       // GA4サーバーサービスを使用してイベントを送信
-      await ga4Server.sendEvent(
+      const result = await ga4Server.sendEvent(
         { name: "purchase", params: purchaseParams },
         clientId,
         undefined,
         sessionId,
         sessionId ? 1 : undefined
       );
+
+      if (result.status !== "sent") {
+        logger.warn("[Payment Analytics] Purchase event tracking did not complete", {
+          category: "payment",
+          action: "payment_analytics",
+          actor_type: "system",
+          transaction_id: transactionId,
+          event_id: eventId,
+          amount,
+          outcome: "failure",
+          ga4_status: result.status,
+          ga4_reason: result.status === "skipped" ? result.reason : undefined,
+          ga4_error_code: result.status === "failed" ? result.code : undefined,
+          ga4_error: result.status === "failed" ? result.error : undefined,
+        });
+        return;
+      }
 
       logger.info("[Payment Analytics] Purchase event tracked successfully", {
         category: "payment",

--- a/features/payments/services/stripe-session/create-stripe-session.ts
+++ b/features/payments/services/stripe-session/create-stripe-session.ts
@@ -117,7 +117,8 @@ export async function createStripeSession(
       successUrl: params.successUrl,
       cancelUrl: params.cancelUrl,
       actorId: params.actorId,
-      gaClientId: params.gaClientId, // GA4 Client IDを渡す
+      ...(params.gaClientId ? { gaClientId: params.gaClientId } : {}),
+      ...(params.gaSessionId ? { gaSessionId: params.gaSessionId } : {}),
       metadata: {
         payment_id: targetPaymentId,
         attendance_id: params.attendanceId,

--- a/features/payments/services/webhook/handlers/checkout-session-handler.ts
+++ b/features/payments/services/webhook/handlers/checkout-session-handler.ts
@@ -140,6 +140,7 @@ export class CheckoutSessionHandler {
         attendanceId: payment.attendance_id,
         sessionId,
         gaClientId,
+        gaSessionId: metadata?.["ga_session_id"],
         amount: payment.amount,
       });
 

--- a/features/payments/services/webhook/services/payment-analytics-service.ts
+++ b/features/payments/services/webhook/services/payment-analytics-service.ts
@@ -17,6 +17,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function parseGaSessionId(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const sessionId = Number(value);
+  return Number.isSafeInteger(sessionId) && sessionId > 0 ? sessionId : undefined;
+}
+
 function extractEventFromAttendance(attendance: unknown): { id: string; title: string } | null {
   if (!isRecord(attendance)) {
     return null;
@@ -51,9 +60,10 @@ export class PaymentAnalyticsWebhookService {
     attendanceId: string;
     sessionId: string;
     gaClientId: string;
+    gaSessionId?: string;
     amount: number;
   }): Promise<void> {
-    const { paymentId, attendanceId, sessionId, gaClientId, amount } = params;
+    const { paymentId, attendanceId, sessionId, gaClientId, gaSessionId, amount } = params;
 
     try {
       const { data: attendance, error: attendanceError } = await this.supabase
@@ -93,6 +103,7 @@ export class PaymentAnalyticsWebhookService {
         eventId: eventData.id,
         eventTitle: eventData.title,
         amount,
+        sessionId: parseGaSessionId(gaSessionId),
       });
     } catch (error) {
       handleServerError("GA4_TRACKING_FAILED", {

--- a/features/payments/validation.ts
+++ b/features/payments/validation.ts
@@ -33,6 +33,7 @@ const createStripeSessionParamsSchema = z.object({
   successUrl: z.string().url("成功時URLは有効なURLである必要があります"),
   cancelUrl: z.string().url("キャンセル時URLは有効なURLである必要があります"),
   gaClientId: z.string().optional(),
+  gaSessionId: z.number().int().positive().optional(),
 });
 
 // 現金払い用スキーマ（内部使用専用）

--- a/tests/integration/core/analytics/ga4-integration.test.ts
+++ b/tests/integration/core/analytics/ga4-integration.test.ts
@@ -488,7 +488,7 @@ describe("GA4 Analytics - 統合テスト", () => {
       expect(body.events[0].params.long_param).toHaveLength(100);
     });
 
-    test("無効なパラメータ名は除外される", async () => {
+    test("無効なパラメータ名を含むイベントは送信されない", async () => {
       // Arrange
       const testEvent: GA4Event = asGA4Event({
         name: "test_event",
@@ -500,18 +500,11 @@ describe("GA4 Analytics - 統合テスト", () => {
       });
 
       // Act
-      await ga4Server.sendEvent(testEvent, "1234567890.0987654321");
+      const result = await ga4Server.sendEvent(testEvent, "1234567890.0987654321");
 
       // Assert
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-
-      const callArgs = mockFetch.mock.calls[0];
-      const body = JSON.parse(callArgs[1]?.body as string);
-      expect(body.events[0].params).toEqual({
-        valid_param: "valid",
-        another_valid: "valid",
-      });
-      expect(body.events[0].params).not.toHaveProperty("invalid-param");
+      expect(result).toEqual({ status: "skipped", reason: "invalid_params" });
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     test("セッションIDとエンゲージメント時間が正しく追加される", async () => {

--- a/tests/integration/core/analytics/ga4-integration.test.ts
+++ b/tests/integration/core/analytics/ga4-integration.test.ts
@@ -118,11 +118,10 @@ describe("GA4 Analytics - 統合テスト", () => {
       const clientId = await ga4Client.getClientId();
       expect(clientId).toBe(mockClientId);
 
-      if (clientId) {
-        await ga4Server.sendEvent(testEvent, clientId);
-      }
+      const result = clientId ? await ga4Server.sendEvent(testEvent, clientId) : null;
 
       // Assert
+      expect(result).toEqual({ status: "sent" });
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("measurement_id=G-TEST123456"),
@@ -147,6 +146,34 @@ describe("GA4 Analytics - 統合テスト", () => {
             },
           },
         ],
+      });
+    });
+
+    test("有効なClient IDがある場合、User IDを同梱できる", async () => {
+      // Arrange
+      const testEvent: GA4Event = {
+        name: "login",
+        params: {
+          method: "password",
+        },
+      };
+
+      // Act
+      const result = await ga4Server.sendEvent(
+        testEvent,
+        "1234567890.0987654321",
+        "user-123"
+      );
+
+      // Assert
+      expect(result).toEqual({ status: "sent" });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1]?.body as string);
+      expect(body).toMatchObject({
+        client_id: "1234567890.0987654321",
+        user_id: "user-123",
       });
     });
 
@@ -179,9 +206,10 @@ describe("GA4 Analytics - 統合テスト", () => {
       };
 
       // Act
-      await ga4Server.sendEvent(testEvent, invalidClientId);
+      const result = await ga4Server.sendEvent(testEvent, invalidClientId);
 
       // Assert - 無効なClient IDのため、fetchは呼ばれない
+      expect(result).toEqual({ status: "skipped", reason: "invalid_or_missing_client_id" });
       expect(mockFetch).not.toHaveBeenCalled();
     });
   });
@@ -216,9 +244,10 @@ describe("GA4 Analytics - 統合テスト", () => {
       });
 
       // Act
-      await ga4Server.sendEvent(testEvent, "1234567890.0987654321");
+      const result = await ga4Server.sendEvent(testEvent, "1234567890.0987654321");
 
       // Assert - 3回呼ばれる（2回失敗 + 1回成功）
+      expect(result).toEqual({ status: "sent" });
       expect(mockFetch).toHaveBeenCalledTimes(3);
       expect(callCount).toBe(3);
     });
@@ -238,13 +267,14 @@ describe("GA4 Analytics - 統合テスト", () => {
         },
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { logger } = require("@core/logging/app-logger");
-
       // Act
-      await ga4Server.sendEvent(testEvent, "1234567890.0987654321");
+      const result = await ga4Server.sendEvent(testEvent, "1234567890.0987654321");
 
       // Assert - 最大リトライ回数（3回）呼ばれる
+      expect(result).toMatchObject({
+        status: "failed",
+        code: "GA4_RETRY_EXHAUSTED",
+      });
       expect(mockFetch).toHaveBeenCalledTimes(3);
       // handleServerError 経由でエラーが記録される（新形式）
       // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -274,9 +304,13 @@ describe("GA4 Analytics - 統合テスト", () => {
       });
 
       // Act
-      await ga4Server.sendEvent(testEvent, "1234567890.0987654321");
+      const result = await ga4Server.sendEvent(testEvent, "1234567890.0987654321");
 
       // Assert - 1回のみ呼ばれる（リトライしない）
+      expect(result).toMatchObject({
+        status: "failed",
+        code: "GA4_API_ERROR",
+      });
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
@@ -528,18 +562,19 @@ describe("GA4 Analytics - 統合テスト", () => {
       const { logger } = require("@core/logging/app-logger");
 
       // Act
-      await ga4Server.sendEvent(testEvent);
+      const result = await ga4Server.sendEvent(testEvent);
 
       // Assert
+      expect(result).toEqual({ status: "skipped", reason: "invalid_or_missing_client_id" });
       expect(mockFetch).not.toHaveBeenCalled();
       // withContextで返されるロガーのwarnを確認
       expect(logger.withContext().warn).toHaveBeenCalledWith(
-        expect.stringContaining("Neither valid client ID nor user ID provided"),
+        expect.stringContaining("No valid client ID provided"),
         expect.any(Object)
       );
     });
 
-    test("User IDのみでイベントを送信できる", async () => {
+    test("User IDのみの場合、送信をスキップする", async () => {
       // Arrange
       const testEvent: GA4Event = asGA4Event({
         name: "test_event",
@@ -551,25 +586,11 @@ describe("GA4 Analytics - 統合テスト", () => {
       const userId = "user123";
 
       // Act
-      await ga4Server.sendEvent(testEvent, undefined, userId);
+      const result = await ga4Server.sendEvent(testEvent, undefined, userId);
 
       // Assert
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-
-      const callArgs = mockFetch.mock.calls[0];
-      const body = JSON.parse(callArgs[1]?.body as string);
-      expect(body).toEqual({
-        user_id: userId,
-        events: [
-          {
-            name: "test_event",
-            params: {
-              test_param: "test_value",
-            },
-          },
-        ],
-      });
-      expect(body).not.toHaveProperty("client_id");
+      expect(result).toEqual({ status: "skipped", reason: "invalid_or_missing_client_id" });
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     test("全てのイベントが無効な場合、バッチ送信をスキップする", async () => {

--- a/tests/unit/core/analytics/ga4-client.test.ts
+++ b/tests/unit/core/analytics/ga4-client.test.ts
@@ -235,12 +235,87 @@ describe("GA4ClientService", () => {
     });
   });
 
+  describe("getSessionId", () => {
+    describe("正常系", () => {
+      test("有効なSession IDを取得できる", async () => {
+        const validSessionId = 1699999999;
+
+        (global as any).window.gtag = jest.fn((command, targetId, config, callback) => {
+          if (command === "get" && config === "session_id" && typeof callback === "function") {
+            callback(validSessionId);
+          }
+        });
+
+        const result = await service.getSessionId();
+
+        expect(result).toBe(validSessionId);
+        expect((global as any).window.gtag).toHaveBeenCalledWith(
+          "get",
+          "G-TEST123",
+          "session_id",
+          expect.any(Function)
+        );
+      });
+
+      test("文字列のSession IDを数値に変換できる", async () => {
+        (global as any).window.gtag = jest.fn((command, targetId, config, callback) => {
+          if (command === "get" && config === "session_id" && typeof callback === "function") {
+            callback("1699999999");
+          }
+        });
+
+        const result = await service.getSessionId();
+
+        expect(result).toBe(1699999999);
+      });
+    });
+
+    describe("エラーハンドリング", () => {
+      test("無効なSession IDの場合はnullを返す", async () => {
+        (global as any).window.gtag = jest.fn((command, targetId, config, callback) => {
+          if (command === "get" && config === "session_id" && typeof callback === "function") {
+            callback("invalid-session-id");
+          }
+        });
+
+        const result = await service.getSessionId();
+
+        expect(result).toBeNull();
+      });
+
+      test("タイムアウト時にnullを返す", async () => {
+        mockGtag.mockImplementation(() => {
+          // コールバックを呼ばない
+        });
+
+        const result = await service.getSessionId(100);
+
+        expect(result).toBeNull();
+      });
+
+      test("GA4が無効な場合はnullを返す", async () => {
+        jest.spyOn(configModule, "getGA4Config").mockReturnValue({
+          enabled: false,
+          measurementId: "G-TEST123",
+          apiSecret: "test-secret",
+          debug: false,
+        });
+        service = new GA4ClientService();
+
+        const result = await service.getSessionId();
+
+        expect(result).toBeNull();
+        expect(mockGtag).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("sendEventWithCallback", () => {
     describe("正常系", () => {
       test("イベント送信後にコールバックが実行される", (done) => {
         const event = { name: "test_event", params: { value: 1 } } as any;
 
-        sendGAEvent.mockImplementation((name: string, params: any) => {
+        sendGAEvent.mockImplementation((command: string, name: string, params: any) => {
           // event_callbackを即座に実行
           if (params.event_callback) {
             params.event_callback();
@@ -249,6 +324,7 @@ describe("GA4ClientService", () => {
 
         service.sendEventWithCallback(event, () => {
           expect(sendGAEvent).toHaveBeenCalledWith(
+            "event",
             "test_event",
             expect.objectContaining({
               value: 1,
@@ -262,7 +338,7 @@ describe("GA4ClientService", () => {
       test("カスタムタイムアウトを指定できる", (done) => {
         const event = { name: "test_event", params: {} } as any;
 
-        sendGAEvent.mockImplementation((name: string, params: any) => {
+        sendGAEvent.mockImplementation((command: string, name: string, params: any) => {
           if (params.event_callback) {
             params.event_callback();
           }
@@ -288,7 +364,7 @@ describe("GA4ClientService", () => {
         const event = { name: "test_event", params: {} } as any;
         let callbackCount = 0;
 
-        sendGAEvent.mockImplementation((name: string, params: any) => {
+        sendGAEvent.mockImplementation((command: string, name: string, params: any) => {
           // 少し遅延してコールバックを実行（タイムアウトと競合）
           setTimeout(() => {
             if (params.event_callback) {
@@ -350,7 +426,7 @@ describe("GA4ClientService", () => {
 
       service.sendEvent(event);
 
-      expect(sendGAEvent).toHaveBeenCalledWith("test_event", { value: 1 });
+      expect(sendGAEvent).toHaveBeenCalledWith("event", "test_event", { value: 1 });
     });
 
     test("GA4が無効な場合は送信しない", () => {

--- a/tests/unit/core/analytics/ga4-server.test.ts
+++ b/tests/unit/core/analytics/ga4-server.test.ts
@@ -101,11 +101,12 @@ describe("GA4ServerService", () => {
             statusText: "OK",
           } as Response);
 
-        await service.sendEvent(
+        const result = await service.sendEvent(
           { name: "sign_up", params: { method: "password" } },
           "1234567890.0987654321"
         );
 
+        expect(result).toEqual({ status: "sent" });
         expect(mockFetch).toHaveBeenCalledTimes(3);
       });
 
@@ -116,11 +117,15 @@ describe("GA4ServerService", () => {
           statusText: "Internal Server Error",
         } as Response);
 
-        await service.sendEvent(
+        const result = await service.sendEvent(
           { name: "sign_up", params: { method: "password" } },
           "1234567890.0987654321"
         );
 
+        expect(result).toMatchObject({
+          status: "failed",
+          code: "GA4_RETRY_EXHAUSTED",
+        });
         expect(mockFetch).toHaveBeenCalledTimes(3);
       });
 
@@ -131,11 +136,15 @@ describe("GA4ServerService", () => {
           statusText: "Bad Request",
         } as Response);
 
-        await service.sendEvent(
+        const result = await service.sendEvent(
           { name: "sign_up", params: { method: "password" } },
           "1234567890.0987654321"
         );
 
+        expect(result).toMatchObject({
+          status: "failed",
+          code: "GA4_API_ERROR",
+        });
         expect(mockFetch).toHaveBeenCalledTimes(1);
       });
     });
@@ -150,11 +159,12 @@ describe("GA4ServerService", () => {
           statusText: "OK",
         } as Response);
 
-        await service.sendEvent(
+        const result = await service.sendEvent(
           { name: "sign_up", params: { method: "email" } },
           "1234567890.0987654321"
         );
 
+        expect(result).toEqual({ status: "sent" });
         expect(mockFetch).toHaveBeenCalledWith(
           expect.stringContaining("measurement_id=G-TEST123"),
           expect.objectContaining({
@@ -190,19 +200,26 @@ describe("GA4ServerService", () => {
         expect(body.events[0].params.method).toBe("email");
       });
 
-      test("User IDでイベントを送信できる", async () => {
+      test("Client IDとUser IDでイベントを送信できる", async () => {
         mockFetch.mockResolvedValue({
           ok: true,
           status: 200,
           statusText: "OK",
         } as Response);
 
-        await service.sendEvent(
+        const result = await service.sendEvent(
           { name: "login", params: { method: "password" } },
-          undefined,
+          "1234567890.0987654321",
           "user-123"
         );
 
+        expect(result).toEqual({ status: "sent" });
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            body: expect.stringContaining('"client_id":"1234567890.0987654321"'),
+          })
+        );
         expect(mockFetch).toHaveBeenCalledWith(
           expect.any(String),
           expect.objectContaining({
@@ -243,11 +260,12 @@ describe("GA4ServerService", () => {
           debug: false,
         });
 
-        await service.sendEvent(
+        const result = await service.sendEvent(
           { name: "sign_up", params: { method: "password" } },
           "1234567890.0987654321"
         );
 
+        expect(result).toEqual({ status: "skipped", reason: "disabled" });
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
@@ -259,28 +277,45 @@ describe("GA4ServerService", () => {
           debug: false,
         });
 
-        await service.sendEvent(
+        const result = await service.sendEvent(
           { name: "sign_up", params: { method: "password" } },
           "1234567890.0987654321"
         );
 
+        expect(result).toEqual({ status: "skipped", reason: "missing_api_secret" });
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
       test("Client IDもUser IDもない場合は送信しない", async () => {
-        await service.sendEvent({ name: "logout", params: {} });
+        const result = await service.sendEvent({ name: "logout", params: {} });
 
+        expect(result).toEqual({ status: "skipped", reason: "invalid_or_missing_client_id" });
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
       test("無効なClient IDの場合は送信しない", async () => {
-        await service.sendEvent({ name: "logout", params: {} }, "invalid-client-id");
+        const result = await service.sendEvent(
+          { name: "logout", params: {} },
+          "invalid-client-id"
+        );
 
+        expect(result).toEqual({ status: "skipped", reason: "invalid_or_missing_client_id" });
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      test("User IDのみの場合は送信しない", async () => {
+        const result = await service.sendEvent(
+          { name: "login", params: { method: "password" } },
+          undefined,
+          "user-123"
+        );
+
+        expect(result).toEqual({ status: "skipped", reason: "invalid_or_missing_client_id" });
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
       test("無効なパラメータ名を含む場合は送信しない", async () => {
-        await service.sendEvent(
+        const result = await service.sendEvent(
           {
             name: "sign_up",
             params: { "invalid-param": "value" } as any, // ハイフンは無効
@@ -288,11 +323,12 @@ describe("GA4ServerService", () => {
           "1234567890.0987654321"
         );
 
+        expect(result).toEqual({ status: "skipped", reason: "invalid_params" });
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
       test("全てのパラメータが無効な場合は送信しない", async () => {
-        await service.sendEvent(
+        const result = await service.sendEvent(
           {
             name: "sign_up",
             params: {
@@ -303,6 +339,7 @@ describe("GA4ServerService", () => {
           "1234567890.0987654321"
         );
 
+        expect(result).toEqual({ status: "skipped", reason: "invalid_params" });
         expect(mockFetch).not.toHaveBeenCalled();
       });
     });

--- a/tests/unit/core/analytics/ga4-server.test.ts
+++ b/tests/unit/core/analytics/ga4-server.test.ts
@@ -342,6 +342,58 @@ describe("GA4ServerService", () => {
         expect(result).toEqual({ status: "skipped", reason: "invalid_params" });
         expect(mockFetch).not.toHaveBeenCalled();
       });
+
+      test("purchaseイベントの必須パラメータが不足している場合は送信しない", async () => {
+        const result = await service.sendEvent(
+          {
+            name: "purchase",
+            params: {
+              currency: "JPY",
+              value: 1000,
+              items: [{ item_id: "event-1" }],
+            } as any,
+          },
+          "1234567890.0987654321"
+        );
+
+        expect(result).toEqual({ status: "skipped", reason: "invalid_params" });
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      test("purchaseイベントのitemsが不正な場合は送信しない", async () => {
+        const result = await service.sendEvent(
+          {
+            name: "purchase",
+            params: {
+              transaction_id: "cs_test_123",
+              currency: "JPY",
+              value: 1000,
+              items: [{ price: 1000, quantity: 1 }],
+            } as any,
+          },
+          "1234567890.0987654321"
+        );
+
+        expect(result).toEqual({ status: "skipped", reason: "invalid_params" });
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      test("共通パラメータ追加後に25個を超える場合は送信しない", async () => {
+        const params = Object.fromEntries(
+          Array.from({ length: 24 }, (_, i) => [`param_${i}`, i])
+        );
+
+        const result = await service.sendEvent(
+          { name: "logout", params: params as any },
+          "1234567890.0987654321",
+          undefined,
+          12345,
+          1
+        );
+
+        expect(result).toEqual({ status: "skipped", reason: "invalid_params" });
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -509,7 +561,9 @@ describe("GA4ServerService", () => {
         } as Response);
 
         const longString = "a".repeat(150);
-        const events = [{ name: "sign_up" as const, params: { description: longString } as any }];
+        const events = [
+          { name: "sign_up" as const, params: { method: "email", description: longString } as any },
+        ];
 
         await service.sendEvents(events as any, "1234567890.0987654321");
 

--- a/tests/unit/core/analytics/ga4-validator.test.ts
+++ b/tests/unit/core/analytics/ga4-validator.test.ts
@@ -203,7 +203,7 @@ describe("GA4Validator", () => {
 
         const result = GA4Validator.validateAndSanitizeParams(params);
 
-        expect(result.isValid).toBe(true);
+        expect(result.isValid).toBe(false);
         expect(result.errors.length).toBe(3);
         expect(result.sanitizedParams).toEqual({ valid_name: "value4" });
       });
@@ -217,7 +217,7 @@ describe("GA4Validator", () => {
 
         const result = GA4Validator.validateAndSanitizeParams(params);
 
-        expect(result.isValid).toBe(true);
+        expect(result.isValid).toBe(false);
         expect(result.sanitizedParams).toEqual({ short_name: "value" });
       });
 
@@ -231,6 +231,40 @@ describe("GA4Validator", () => {
 
         expect(result.isValid).toBe(true);
         expect(result.sanitizedParams).toHaveProperty(exactName);
+      });
+
+      test("予約済みprefixと予約名を拒否する", () => {
+        const params = {
+          valid_param: "value",
+          ga_custom: "blocked",
+          google_custom: "blocked",
+          firebase_custom: "blocked",
+          _private: "blocked",
+        };
+
+        const result = GA4Validator.validateAndSanitizeParams(params);
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toEqual(
+          expect.arrayContaining([
+            "Invalid parameter name: ga_custom",
+            "Invalid parameter name: google_custom",
+            "Invalid parameter name: firebase_custom",
+            "Invalid parameter name: _private",
+          ])
+        );
+        expect(result.sanitizedParams).toEqual({ valid_param: "value" });
+      });
+
+      test("25個を超えるイベントパラメータを拒否する", () => {
+        const params = Object.fromEntries(
+          Array.from({ length: 26 }, (_, i) => [`param_${i}`, i])
+        );
+
+        const result = GA4Validator.validateAndSanitizeParams(params);
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain("Too many event parameters: 26");
       });
     });
 
@@ -343,8 +377,7 @@ describe("GA4Validator", () => {
 
         const result = GA4Validator.validateAndSanitizeParams(params);
 
-        // 無効なパラメータは除外されるが、空の結果も有効（パラメータなしのイベント）
-        expect(result.isValid).toBe(true);
+        expect(result.isValid).toBe(false);
         expect(result.sanitizedParams).toEqual({});
       });
 
@@ -423,11 +456,110 @@ describe("GA4Validator", () => {
 
         const result = GA4Validator.validateAndSanitizeParams(params);
 
-        expect(result.isValid).toBe(true);
+        expect(result.isValid).toBe(false);
         expect(result.sanitizedParams).toEqual({
           valid_param: "value",
           another_valid: 123,
         });
+      });
+
+      test("正常なpurchaseイベントを受け入れる", () => {
+        const params = {
+          transaction_id: "cs_test_123",
+          event_id: "event-1",
+          currency: "JPY",
+          value: 1000,
+          items: [{ item_id: "event-1", item_name: "Test Event", price: 1000, quantity: 1 }],
+        };
+
+        const result = GA4Validator.validateAndSanitizeParams(params, false, "purchase");
+
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+        expect(result.sanitizedParams).toEqual(params);
+      });
+
+      test("purchaseイベントの必須パラメータ欠落を拒否する", () => {
+        const result = GA4Validator.validateAndSanitizeParams(
+          {
+            currency: "JPY",
+            value: 1000,
+            items: [{ item_id: "event-1" }],
+          },
+          false,
+          "purchase"
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain("Missing required parameter for purchase: transaction_id");
+      });
+
+      test("正常なbegin_checkoutイベントを受け入れる", () => {
+        const params = {
+          event_id: "event-1",
+          currency: "JPY",
+          value: 1000,
+          items: [{ item_name: "Test Event", price: 1000, quantity: 1 }],
+        };
+
+        const result = GA4Validator.validateAndSanitizeParams(params, false, "begin_checkout");
+
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+        expect(result.sanitizedParams).toEqual(params);
+      });
+
+      test("purchaseイベントのitems不正を拒否する", () => {
+        const result = GA4Validator.validateAndSanitizeParams(
+          {
+            transaction_id: "cs_test_123",
+            currency: "JPY",
+            value: 1000,
+            items: [{ price: 1000, quantity: 1, "invalid-item-param": "value" }],
+          },
+          false,
+          "purchase"
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toEqual(
+          expect.arrayContaining([
+            "items[0] must include item_id or item_name",
+            "Invalid item parameter name at items[0]: invalid-item-param",
+          ])
+        );
+      });
+
+      test("purchaseイベントのitemsが配列でない場合は拒否する", () => {
+        const result = GA4Validator.validateAndSanitizeParams(
+          {
+            transaction_id: "cs_test_123",
+            currency: "JPY",
+            value: 1000,
+            items: "not-array",
+          },
+          false,
+          "purchase"
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain("items must be an array");
+      });
+
+      test("purchaseイベントのitemsが空配列の場合は拒否する", () => {
+        const result = GA4Validator.validateAndSanitizeParams(
+          {
+            transaction_id: "cs_test_123",
+            currency: "JPY",
+            value: 1000,
+            items: [],
+          },
+          false,
+          "purchase"
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain("items must contain at least one item");
       });
     });
   });

--- a/tests/unit/features/payments/services/analytics/payment-analytics.test.ts
+++ b/tests/unit/features/payments/services/analytics/payment-analytics.test.ts
@@ -1,0 +1,108 @@
+import { ga4Server } from "@core/analytics/ga4-server";
+import { logger } from "@core/logging/app-logger";
+import { PaymentAnalyticsService } from "@features/payments/services/analytics/payment-analytics";
+
+jest.mock("@core/analytics/ga4-server", () => ({
+  ga4Server: {
+    sendEvent: jest.fn(),
+    isMeasurementProtocolAvailable: jest.fn(),
+  },
+}));
+
+jest.mock("@core/logging/app-logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock("@core/utils/error-handler.server", () => ({
+  handleServerError: jest.fn(),
+}));
+
+const validParams = {
+  clientId: "1234567890.0987654321",
+  transactionId: "cs_test_123",
+  eventId: "event-1",
+  eventTitle: "Test Event",
+  amount: 1000,
+  sessionId: 1699999999,
+};
+
+describe("PaymentAnalyticsService", () => {
+  let service: PaymentAnalyticsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PaymentAnalyticsService();
+  });
+
+  test("GA4送信がsentの場合のみsuccess logを出す", async () => {
+    (ga4Server.sendEvent as jest.Mock).mockResolvedValue({ status: "sent" });
+
+    await service.trackPurchaseCompletion(validParams);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "[Payment Analytics] Purchase event tracked successfully",
+      expect.objectContaining({
+        transaction_id: "cs_test_123",
+        event_id: "event-1",
+        outcome: "success",
+      })
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "[Payment Analytics] Purchase event tracking did not complete",
+      expect.any(Object)
+    );
+  });
+
+  test("GA4送信がskippedの場合はsuccess logを出さない", async () => {
+    (ga4Server.sendEvent as jest.Mock).mockResolvedValue({
+      status: "skipped",
+      reason: "invalid_or_missing_client_id",
+    });
+
+    await service.trackPurchaseCompletion(validParams);
+
+    expect(logger.info).not.toHaveBeenCalledWith(
+      "[Payment Analytics] Purchase event tracked successfully",
+      expect.any(Object)
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Payment Analytics] Purchase event tracking did not complete",
+      expect.objectContaining({
+        transaction_id: "cs_test_123",
+        event_id: "event-1",
+        outcome: "failure",
+        ga4_status: "skipped",
+        ga4_reason: "invalid_or_missing_client_id",
+      })
+    );
+  });
+
+  test("GA4送信がfailedの場合はsuccess logを出さない", async () => {
+    (ga4Server.sendEvent as jest.Mock).mockResolvedValue({
+      status: "failed",
+      code: "GA4_API_ERROR",
+      error: "HTTP 400: Bad Request",
+    });
+
+    await service.trackPurchaseCompletion(validParams);
+
+    expect(logger.info).not.toHaveBeenCalledWith(
+      "[Payment Analytics] Purchase event tracked successfully",
+      expect.any(Object)
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Payment Analytics] Purchase event tracking did not complete",
+      expect.objectContaining({
+        transaction_id: "cs_test_123",
+        event_id: "event-1",
+        outcome: "failure",
+        ga4_status: "failed",
+        ga4_error_code: "GA4_API_ERROR",
+        ga4_error: "HTTP 400: Bad Request",
+      })
+    );
+  });
+});

--- a/tests/unit/features/payments/services/analytics/payment-analytics.test.ts
+++ b/tests/unit/features/payments/services/analytics/payment-analytics.test.ts
@@ -43,7 +43,7 @@ describe("PaymentAnalyticsService", () => {
     await service.trackPurchaseCompletion(validParams);
 
     expect(logger.info).toHaveBeenCalledWith(
-      "[Payment Analytics] Purchase event tracked successfully",
+      "[Payment Analytics] Purchase event submitted to GA4 endpoint",
       expect.objectContaining({
         transaction_id: "cs_test_123",
         event_id: "event-1",
@@ -65,7 +65,7 @@ describe("PaymentAnalyticsService", () => {
     await service.trackPurchaseCompletion(validParams);
 
     expect(logger.info).not.toHaveBeenCalledWith(
-      "[Payment Analytics] Purchase event tracked successfully",
+      "[Payment Analytics] Purchase event submitted to GA4 endpoint",
       expect.any(Object)
     );
     expect(logger.warn).toHaveBeenCalledWith(
@@ -90,7 +90,7 @@ describe("PaymentAnalyticsService", () => {
     await service.trackPurchaseCompletion(validParams);
 
     expect(logger.info).not.toHaveBeenCalledWith(
-      "[Payment Analytics] Purchase event tracked successfully",
+      "[Payment Analytics] Purchase event submitted to GA4 endpoint",
       expect.any(Object)
     );
     expect(logger.warn).toHaveBeenCalledWith(

--- a/tests/unit/features/payments/services/webhook/payment-analytics-service.test.ts
+++ b/tests/unit/features/payments/services/webhook/payment-analytics-service.test.ts
@@ -1,0 +1,56 @@
+import { PaymentAnalyticsWebhookService } from "@features/payments/services/webhook/services/payment-analytics-service";
+import { paymentAnalytics } from "@features/payments/services/analytics/payment-analytics";
+
+jest.mock("@features/payments/services/analytics/payment-analytics", () => ({
+  paymentAnalytics: {
+    trackPurchaseCompletion: jest.fn(),
+  },
+}));
+
+jest.mock("@core/utils/error-handler.server", () => ({
+  handleServerError: jest.fn(),
+}));
+
+describe("PaymentAnalyticsWebhookService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("ga_session_id metadataをpurchase送信まで渡す", async () => {
+    const single = jest.fn().mockResolvedValue({
+      data: {
+        event: {
+          id: "event-1",
+          title: "Test Event",
+        },
+      },
+      error: null,
+    });
+    const eq = jest.fn().mockReturnValue({ single });
+    const select = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ select });
+
+    const service = new PaymentAnalyticsWebhookService({
+      supabase: { from } as never,
+      logger: { warn: jest.fn() } as never,
+    });
+
+    await service.trackCheckoutCompletion({
+      paymentId: "payment-1",
+      attendanceId: "attendance-1",
+      sessionId: "cs_test_123",
+      gaClientId: "1234567890.0987654321",
+      gaSessionId: "1699999999",
+      amount: 1000,
+    });
+
+    expect(paymentAnalytics.trackPurchaseCompletion).toHaveBeenCalledWith({
+      clientId: "1234567890.0987654321",
+      transactionId: "cs_test_123",
+      eventId: "event-1",
+      eventTitle: "Test Event",
+      amount: 1000,
+      sessionId: 1699999999,
+    });
+  });
+});


### PR DESCRIPTION
## 概要
GA4 Measurement Protocol連携の送信契約・検証処理・決済計測を改善しました。

## 変更内容
- GA4サーバー送信で `sent / skipped / failed` の結果を返すように変更
- Web streamのMeasurement Protocolに合わせ、有効なClient IDがない場合は送信をスキップ
- GA4パラメータ名、予約語、必須パラメータ、items構造の検証を強化
- GA4 Session IDを取得し、Stripe Checkout metadata経由でpurchaseイベントに引き継ぐ処理を追加
- global-errorのexceptionイベントをサーバーAPI経由で送信するように変更
- 関連するREADMEとテストを更新
