### PR TITLE
Develop

### DIFF
--- a/app/(marketing)/_components/ParticipantFlowSection.tsx
+++ b/app/(marketing)/_components/ParticipantFlowSection.tsx
@@ -208,7 +208,7 @@ export const ParticipantFlowSection: React.FC = () => {
         </FadeIn>
 
         {/* ─── Phase 1: 招待ページ ─── */}
-        <div className="flex flex-col md:flex-row items-center gap-10 md:gap-16 mb-16 md:mb-20">
+        <div className="flex flex-col md:flex-row items-center gap-10 md:gap-16 mb-14 md:mb-16">
           {/* テキスト */}
           <FadeIn direction="right" delay={0.1} className="flex-1 order-1 md:order-1">
             <div className="flex items-center gap-3 mb-4">
@@ -259,7 +259,7 @@ export const ParticipantFlowSection: React.FC = () => {
         </div>
 
         {/* ─── 矢印コネクタ ─── */}
-        <FadeIn direction="up" className="flex justify-center mb-16 md:mb-20">
+        <FadeIn direction="up" className="flex justify-center mb-14 md:mb-16">
           <div className="flex flex-col items-center gap-2 text-slate-300">
             <div className="w-px h-8 bg-gradient-to-b from-transparent via-slate-300 to-slate-300" />
             <div className="bg-white border-2 border-slate-200 rounded-full px-5 py-2 text-xs font-bold text-slate-500 shadow-sm">

--- a/app/(marketing)/_components/PricingSection.tsx
+++ b/app/(marketing)/_components/PricingSection.tsx
@@ -87,7 +87,7 @@ export const PricingSection: React.FC = () => {
                 <div className="flex items-baseline justify-center md:justify-start gap-1">
                   <span className="text-4xl font-bold text-primary">4.9</span>
                   <span className="text-2xl font-bold text-slate-700">%</span>
-                  <span className="text-4xl font-bold text-slate-500">+ 50</span>
+                  <span className="text-4xl font-bold text-primary">+ 50</span>
                   <span className="text-2xl font-bold text-slate-700">円</span>
                 </div>
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,6 +6,7 @@ import {
   getMaintenancePageHTML,
 } from "@core/maintenance/maintenance-page";
 import { buildCsp } from "@core/security/csp";
+import { isUnauthenticatedAuthError } from "@core/supabase/auth-guards";
 import { createMiddlewareSupabaseClient } from "@core/supabase/middleware-client";
 
 const AFTER_LOGIN_REDIRECT_PATH = "/dashboard";
@@ -239,6 +240,39 @@ export async function middleware(request: NextRequest) {
 
   // 11. ログイン済みが認証ページへ来たらダッシュボードへ
   if (isAuth) {
+    let hasCurrentUser = false;
+    const signOutStaleSession = async () => {
+      try {
+        await supabase.auth.signOut();
+      } catch {
+        // stale cookie cleanup is best-effort here; the auth page remains reachable.
+      }
+    };
+
+    try {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+
+      if (user) {
+        hasCurrentUser = true;
+      } else if (!userError || isUnauthenticatedAuthError(userError)) {
+        await signOutStaleSession();
+      }
+    } catch (error) {
+      if (isUnauthenticatedAuthError(error)) {
+        await signOutStaleSession();
+      }
+    } finally {
+      response = getResponse();
+      applyCommonHeaders(response, { requestId, nonce, isDemo, csp, reportUrl });
+    }
+
+    if (!hasCurrentUser) {
+      return response;
+    }
+
     const dashboardUrl = new URL(AFTER_LOGIN_REDIRECT_PATH, request.url);
     const redirectResponse = NextResponse.redirect(dashboardUrl);
 

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -1,0 +1,214 @@
+import { jest } from "@jest/globals";
+import { AuthApiError } from "@supabase/supabase-js";
+
+type MockCookie = { name: string; value: string; [key: string]: unknown };
+
+function toHeaderRecord(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) {
+    const record: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      record[key] = value;
+    });
+    return record;
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return headers;
+}
+
+class MockNextResponse {
+  body: unknown;
+  status: number;
+  headers: Headers;
+  cookies: {
+    getAll: () => MockCookie[];
+    set: (cookieOrName: MockCookie | string, value?: string) => void;
+  };
+
+  private cookieStore: MockCookie[] = [];
+
+  constructor(body: unknown = null, init: ResponseInit = {}) {
+    this.body = body;
+    this.status = init.status ?? 200;
+    this.headers = new Headers(init.headers);
+    this.cookies = {
+      getAll: jest.fn(() => [...this.cookieStore]),
+      set: jest.fn((cookieOrName: MockCookie | string, value?: string) => {
+        if (typeof cookieOrName === "string") {
+          this.cookieStore.push({ name: cookieOrName, value: value ?? "" });
+          return;
+        }
+        this.cookieStore.push(cookieOrName);
+      }),
+    };
+  }
+
+  static next(init: { request?: { headers?: Headers }; status?: number } = {}) {
+    return new MockNextResponse(null, { status: init.status ?? 200 });
+  }
+
+  static redirect(url: URL | string, init: ResponseInit = {}) {
+    return new MockNextResponse(null, {
+      ...init,
+      status: init.status ?? 307,
+      headers: {
+        Location: String(url),
+        ...toHeaderRecord(init.headers),
+      },
+    });
+  }
+
+  static json(body: unknown, init: ResponseInit = {}) {
+    return new MockNextResponse(body, {
+      ...init,
+      status: init.status ?? 200,
+      headers: {
+        "Content-Type": "application/json",
+        ...toHeaderRecord(init.headers),
+      },
+    });
+  }
+}
+
+const mockGetClaims = jest.fn();
+const mockGetUser = jest.fn();
+const mockSignOut = jest.fn();
+const mockGetResponse = jest.fn();
+const mockCreateMiddlewareSupabaseClient = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: MockNextResponse,
+}));
+
+jest.mock("@core/supabase/middleware-client", () => ({
+  createMiddlewareSupabaseClient: mockCreateMiddlewareSupabaseClient,
+}));
+
+type MiddlewareModule = typeof import("../../middleware");
+
+function createRequest(pathname: string) {
+  return {
+    headers: new Headers({ "x-request-id": "rid-1" }),
+    nextUrl: new URL(`https://example.com${pathname}`),
+    url: `https://example.com${pathname}`,
+    cookies: {
+      getAll: jest.fn(() => []),
+      set: jest.fn(),
+    },
+  };
+}
+
+async function loadMiddleware(): Promise<MiddlewareModule> {
+  jest.resetModules();
+  let loadedModule: MiddlewareModule | undefined;
+
+  await jest.isolateModulesAsync(async () => {
+    loadedModule = await import("../../middleware");
+  });
+
+  if (!loadedModule) {
+    throw new Error("Failed to load middleware module");
+  }
+
+  return loadedModule;
+}
+
+describe("middleware auth redirects", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+    process.env.NEXT_PUBLIC_IS_DEMO = "false";
+
+    mockGetClaims.mockResolvedValue({ data: { claims: null }, error: null });
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    mockSignOut.mockResolvedValue({ error: null });
+    mockGetResponse.mockImplementation(() => new MockNextResponse());
+    mockCreateMiddlewareSupabaseClient.mockImplementation(() => ({
+      supabase: {
+        auth: {
+          getClaims: mockGetClaims,
+          getUser: mockGetUser,
+          signOut: mockSignOut,
+        },
+      },
+      getResponse: mockGetResponse,
+    }));
+  });
+
+  it("protected route で claims が無ければ login に redirect する", async () => {
+    const { middleware } = await loadMiddleware();
+
+    const response = await middleware(createRequest("/dashboard") as never);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://example.com/login?redirectTo=%2Fdashboard"
+    );
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("protected route で claims があれば getUser せず通す", async () => {
+    mockGetClaims.mockResolvedValue({ data: { claims: { sub: "user_1" } }, error: null });
+    const { middleware } = await loadMiddleware();
+
+    const response = await middleware(createRequest("/dashboard") as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("/login で claims が無ければ login page を表示する", async () => {
+    const { middleware } = await loadMiddleware();
+
+    const response = await middleware(createRequest("/login") as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("/login で claims と user があれば dashboard に redirect する", async () => {
+    mockGetClaims.mockResolvedValue({ data: { claims: { sub: "user_1" } }, error: null });
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user_1" } }, error: null });
+    const { middleware } = await loadMiddleware();
+
+    const response = await middleware(createRequest("/login") as never);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://example.com/dashboard");
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it("/login で claims があっても user_not_found なら signOut して login page を表示する", async () => {
+    mockGetClaims.mockResolvedValue({ data: { claims: { sub: "user_1" } }, error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: new AuthApiError("User from sub claim in JWT does not exist", 403, "user_not_found"),
+    });
+    const { middleware } = await loadMiddleware();
+
+    const response = await middleware(createRequest("/login") as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("/login で getUser が非未認証エラーなら signOut せず login page を表示する", async () => {
+    mockGetClaims.mockResolvedValue({ data: { claims: { sub: "user_1" } }, error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error("temporary auth api failure"),
+    });
+    const { middleware } = await loadMiddleware();
+
+    const response = await middleware(createRequest("/login") as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

* `/login` などの認証ページアクセス時に、claims が存在しても `getUser()` で実ユーザーを確認するよう修正
* ユーザーが存在しない stale session の場合は `signOut()` してログインページを表示
* middleware の認証リダイレクト挙動を unit test で追加検証