### PR TITLE
fix: checkout.session.expired は pending 維持にする

### DIFF
--- a/features/payments/services/webhook/handlers/checkout-session-handler.ts
+++ b/features/payments/services/webhook/handlers/checkout-session-handler.ts
@@ -2,10 +2,8 @@ import Stripe from "stripe";
 
 import { okResult } from "@core/errors";
 import { getMetadata, getPaymentIntentId } from "@core/stripe/guards";
-import type { PaymentStatus } from "@core/types/statuses";
 import { handleServerError } from "@core/utils/error-handler.server";
 import { maskSessionId } from "@core/utils/mask";
-import { canPromoteStatus } from "@core/utils/payments/status-rank";
 
 import type { WebhookContextLogger } from "../context/webhook-handler-context";
 import { createWebhookDbError } from "../errors/webhook-error-factory";
@@ -176,23 +174,34 @@ export class CheckoutSessionHandler {
 
       logStripeAccountSnapshotMismatch({ event, payment, logger: this.logger });
 
-      if (!canPromoteStatus(payment.status as PaymentStatus, "failed")) {
-        this.logger.info("Status promotion rule preventing update", {
+      if (payment.status !== "pending") {
+        this.logger.info("Checkout session expiration ignored for non-pending payment", {
           event_id: event.id,
           ...getPaymentWebhookLogContext(payment),
           current_status: payment.status,
+          session_id: maskSessionId(sessionId),
           outcome: "success",
         });
         return okResult();
       }
 
-      const { error: updateError } =
-        await this.paymentRepository.updateStatusFailedFromCheckoutSession({
-          paymentId: payment.id,
-          eventId: event.id,
-          checkoutSessionId: sessionId,
-          paymentIntentId,
+      if (payment.stripe_checkout_session_id !== sessionId) {
+        this.logger.info("Stale checkout session expiration ignored", {
+          event_id: event.id,
+          ...getPaymentWebhookLogContext(payment),
+          session_id: maskSessionId(sessionId),
+          current_session_id: payment.stripe_checkout_session_id
+            ? maskSessionId(payment.stripe_checkout_session_id)
+            : undefined,
+          outcome: "success",
         });
+        return okResult(undefined, buildPaymentWebhookMeta({ eventId: event.id, payment }));
+      }
+
+      const { error: updateError } = await this.paymentRepository.clearExpiredCheckoutSession({
+        paymentId: payment.id,
+        checkoutSessionId: sessionId,
+      });
       if (updateError) {
         handleServerError("STRIPE_CHECKOUT_SESSION_EXPIRED_UPDATE_FAILED", {
           action: "processCheckoutSessionExpired",
@@ -206,12 +215,12 @@ export class CheckoutSessionHandler {
         });
         return createWebhookDbError({
           code: "STRIPE_CHECKOUT_SESSION_EXPIRED_UPDATE_FAILED",
-          reason: "checkout_status_update_failed",
+          reason: "checkout_session_expiration_clear_failed",
           eventId: event.id,
           paymentId: payment.id,
           payoutProfileId: payment.payout_profile_id,
           stripeAccountId: payment.stripe_account_id,
-          userMessage: "決済ステータス更新に失敗しました",
+          userMessage: "期限切れCheckout Sessionの更新に失敗しました",
           dbError: updateError,
           details: {
             eventId: event.id,

--- a/features/payments/services/webhook/repositories/payment-webhook-repository.ts
+++ b/features/payments/services/webhook/repositories/payment-webhook-repository.ts
@@ -41,11 +41,9 @@ interface UpdateStatusFailedFromPaymentIntentParams {
   stripePaymentIntentId: string;
 }
 
-interface UpdateStatusFailedFromCheckoutSessionParams {
+interface ClearExpiredCheckoutSessionParams {
   paymentId: string;
-  eventId: string;
   checkoutSessionId: string;
-  paymentIntentId: string | null;
 }
 
 interface UpdateStatusPaidFromChargeSnapshotParams {
@@ -440,24 +438,19 @@ export class PaymentWebhookRepository {
       .eq("id", paymentId);
   }
 
-  async updateStatusFailedFromCheckoutSession({
+  async clearExpiredCheckoutSession({
     paymentId,
-    eventId,
     checkoutSessionId,
-    paymentIntentId,
-  }: UpdateStatusFailedFromCheckoutSessionParams) {
+  }: ClearExpiredCheckoutSessionParams) {
     const now = nowIso();
     return this.supabase
       .from("payments")
       .update({
-        status: "failed",
-        webhook_event_id: eventId,
-        webhook_processed_at: now,
         updated_at: now,
-        stripe_checkout_session_id: checkoutSessionId,
-        ...(paymentIntentId ? { stripe_payment_intent_id: paymentIntentId } : {}),
+        stripe_checkout_session_id: null,
       })
-      .eq("id", paymentId);
+      .eq("id", paymentId)
+      .eq("stripe_checkout_session_id", checkoutSessionId);
   }
 
   async updateStatusPaidFromChargeSnapshot({

--- a/tests/integration/api/workers/stripe-webhook.expired-and-charge.test.ts
+++ b/tests/integration/api/workers/stripe-webhook.expired-and-charge.test.ts
@@ -49,7 +49,7 @@ describe("/api/workers/stripe-webhook (expired & charge)", () => {
     mockChargeRetrieve.mockReset();
   });
 
-  it("checkout.session.expired は 204 を返す（failed 昇格パスを実行）", async () => {
+  it("checkout.session.expired は 204 を返す", async () => {
     const evt = {
       ...webhookEventFixtures.checkoutCompleted(),
       type: "checkout.session.expired",

--- a/tests/integration/payments/webhook/checkout-session-expired/edge-cases.test.ts
+++ b/tests/integration/payments/webhook/checkout-session-expired/edge-cases.test.ts
@@ -71,7 +71,7 @@ describe("🎯 境界値・エッジケース", () => {
     }
   });
 
-  test("空文字のPaymentIntent IDは制約エラー", async () => {
+  test("空文字のPaymentIntent IDはpendingのままCheckout Sessionリンクを解除", async () => {
     // Arrange
     const sessionId = "cs_test_empty_pi_" + Date.now();
 
@@ -100,11 +100,17 @@ describe("🎯 境界値・エッジケース", () => {
     const handler = new StripeWebhookEventHandler();
     const result = await handler.handleEvent(event);
 
-    // Assert: データベース制約違反によりエラー
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.message).toContain("payments_stripe_intent_required");
-    }
+    expect(result.success).toBe(true);
+
+    const { data: updatedPayment } = await setup.adminClient
+      .from("payments")
+      .select("*")
+      .eq("id", payment.id)
+      .single();
+
+    expect(updatedPayment.status).toBe("pending");
+    expect(updatedPayment.stripe_checkout_session_id).toBeNull();
+    expect(updatedPayment.stripe_payment_intent_id).toBeNull();
   });
 
   test("metadata.payment_id が空文字の場合は無視", async () => {
@@ -161,7 +167,7 @@ describe("🎯 境界値・エッジケース", () => {
     );
   });
 
-  test("非文字列型のPaymentIntentは制約エラー", async () => {
+  test("非文字列型のPaymentIntentはpendingのままCheckout Sessionリンクを解除", async () => {
     // Arrange
     const sessionId = "cs_test_non_string_pi_" + Date.now();
 
@@ -190,10 +196,16 @@ describe("🎯 境界値・エッジケース", () => {
     const handler = new StripeWebhookEventHandler();
     const result = await handler.handleEvent(event);
 
-    // Assert: データベース制約違反によりエラー
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.message).toContain("payments_stripe_intent_required");
-    }
+    expect(result.success).toBe(true);
+
+    const { data: updatedPayment } = await setup.adminClient
+      .from("payments")
+      .select("*")
+      .eq("id", payment.id)
+      .single();
+
+    expect(updatedPayment.status).toBe("pending");
+    expect(updatedPayment.stripe_checkout_session_id).toBeNull();
+    expect(updatedPayment.stripe_payment_intent_id).toBeNull();
   });
 });

--- a/tests/integration/payments/webhook/checkout-session-expired/idempotency.test.ts
+++ b/tests/integration/payments/webhook/checkout-session-expired/idempotency.test.ts
@@ -5,7 +5,6 @@
 import { describe, test, expect, beforeAll, afterAll } from "@jest/globals";
 
 import { logger } from "../../../../../core/logging/app-logger";
-import { canPromoteStatus } from "../../../../../core/utils/payments/status-rank";
 import { StripeWebhookEventHandler } from "../../../../../features/payments/services/webhook/webhook-event-handler";
 import {
   createTestAttendance,
@@ -16,13 +15,20 @@ import { createWebhookTestSetup, type WebhookTestSetup } from "../../../../setup
 import { createTestWebhookEvent } from "../../../../setup/stripe-test-helpers";
 
 // 外部依存のモック（統合テストなので最小限）
-jest.mock("../../../../../core/logging/app-logger", () => ({
-  logger: {
+jest.mock("../../../../../core/logging/app-logger", () => {
+  const mockMethods = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
-  },
-}));
+    debug: jest.fn(),
+  };
+  return {
+    logger: {
+      ...mockMethods,
+      withContext: jest.fn(() => mockMethods),
+    },
+  };
+});
 
 /**
  * Checkout Session Expired イベントを作成
@@ -97,8 +103,10 @@ describe("⚙️ 冪等性保証", () => {
     // Assert: 初回は正常処理
     expect(firstResult).toMatchObject({
       success: true,
-      eventId: event.id,
-      paymentId: payment.id,
+      meta: {
+        eventId: event.id,
+        paymentId: payment.id,
+      },
     });
 
     // Act: 同一イベントで再処理
@@ -112,14 +120,11 @@ describe("⚙️ 冪等性保証", () => {
     );
 
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "Webhook security event",
+      "Duplicate webhook event acknowledged via ledger",
       expect.objectContaining({
-        event_action: "webhook_duplicate_processing_prevented",
-        details: expect.objectContaining({
-          eventId: event.id,
-          paymentId: payment.id,
-          currentStatus: "failed",
-        }),
+        event_id: event.id,
+        event_type: "checkout.session.expired",
+        outcome: "success",
       })
     );
 
@@ -130,22 +135,47 @@ describe("⚙️ 冪等性保証", () => {
       .eq("id", payment.id)
       .single();
 
-    expect(finalPayment.status).toBe("failed");
-    expect(finalPayment.webhook_event_id).toBe(event.id);
+    expect(finalPayment.status).toBe("pending");
+    expect(finalPayment.stripe_checkout_session_id).toBeNull();
+    expect(finalPayment.webhook_event_id).toBeNull();
   });
 
-  test("ステータスランク違反による冪等性", async () => {
-    // canPromoteStatus関数のロジックを直接テスト
-    const statusTests = [
-      { current: "paid", target: "failed", expected: false },
-      { current: "received", target: "failed", expected: false },
-      { current: "refunded", target: "failed", expected: false },
-      { current: "pending", target: "failed", expected: true },
-      { current: "failed", target: "failed", expected: true }, // 同一ステータス（冪等性）
-    ];
-
-    statusTests.forEach(({ current, target, expected }) => {
-      expect(canPromoteStatus(current as any, target as any)).toBe(expected);
+  test("期限切れ処理後に同じpaymentへ別セッションを紐づけられる", async () => {
+    const sessionId = "cs_test_recreate_" + Date.now();
+    const nextSessionId = "cs_test_recreate_next_" + Date.now();
+    const dedicatedAttendance = await createTestAttendance(setup.testEvent.id);
+    const payment = await createPendingTestPayment(dedicatedAttendance.id, {
+      amount: 1500,
+      stripeAccountId: setup.testUser.stripeConnectAccountId,
     });
+
+    await setup.adminClient
+      .from("payments")
+      .update({
+        status: "pending",
+        stripe_checkout_session_id: sessionId,
+      })
+      .eq("id", payment.id);
+
+    const handler = new StripeWebhookEventHandler();
+    await handler.handleEvent(createCheckoutExpiredEvent(sessionId));
+
+    const { error } = await setup.adminClient
+      .from("payments")
+      .update({
+        stripe_checkout_session_id: nextSessionId,
+      })
+      .eq("id", payment.id);
+
+    expect(error).toBeNull();
+
+    const { data: updatedPayment } = await setup.adminClient
+      .from("payments")
+      .select("*")
+      .eq("id", payment.id)
+      .single();
+
+    expect(updatedPayment.status).toBe("pending");
+    expect(updatedPayment.stripe_checkout_session_id).toBe(nextSessionId);
   });
 });

--- a/tests/integration/payments/webhook/checkout-session-expired/logging.test.ts
+++ b/tests/integration/payments/webhook/checkout-session-expired/logging.test.ts
@@ -101,11 +101,10 @@ describe("🔍 ログ出力仕様検証", () => {
         },
       },
       {
-        name: "重複処理防止",
-        // 既に処理済みの場合は logger.info("Duplicate webhook event preventing double processing") が呼ばれる
+        name: "non-pending payment の無視",
         verifyFn: async (data: any) => {
           expect(logger.withContext().info).toHaveBeenCalledWith(
-            "Duplicate webhook event preventing double processing",
+            "Checkout session expiration ignored for non-pending payment",
             expect.objectContaining({
               event_id: data.event.id,
               payment_id: data.payment.id,

--- a/tests/integration/payments/webhook/checkout-session-expired/normal-flow.test.ts
+++ b/tests/integration/payments/webhook/checkout-session-expired/normal-flow.test.ts
@@ -1,26 +1,36 @@
 /**
  * checkout.session.expired Webhook 正常系テスト
  *
- * 正常系: pending → failed へのステータス遷移
+ * 正常系: pending 維持と Checkout Session リンク解除
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "@jest/globals";
 
 import { logger } from "../../../../../core/logging/app-logger";
 import { StripeWebhookEventHandler } from "../../../../../features/payments/services/webhook/webhook-event-handler";
-import { createPendingTestPayment } from "../../../../helpers/test-payment-data";
+import {
+  createPendingTestPayment,
+  createTestAttendance,
+} from "../../../../helpers/test-payment-data";
 import { setupLoggerMocks } from "../../../../setup/common-mocks";
 import { createWebhookTestSetup, type WebhookTestSetup } from "../../../../setup/common-test-setup";
 import { createTestWebhookEvent } from "../../../../setup/stripe-test-helpers";
 
 // 外部依存のモック（統合テストなので最小限）
-jest.mock("../../../../../core/logging/app-logger", () => ({
-  logger: {
+jest.mock("../../../../../core/logging/app-logger", () => {
+  const mockMethods = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
-  },
-}));
+    debug: jest.fn(),
+  };
+  return {
+    logger: {
+      ...mockMethods,
+      withContext: jest.fn(() => mockMethods),
+    },
+  };
+});
 
 /**
  * Checkout Session Expired イベントを作成
@@ -40,7 +50,7 @@ function createCheckoutExpiredEvent(
   });
 }
 
-describe("🔄 正常系: pending → failed 遷移", () => {
+describe("🔄 正常系: pending 維持", () => {
   let setup: WebhookTestSetup;
   let mockLogger: jest.Mocked<typeof logger>;
 
@@ -65,7 +75,7 @@ describe("🔄 正常系: pending → failed 遷移", () => {
     }
   });
 
-  test("stripe_checkout_session_idによる突合で決済レコードを更新", async () => {
+  test("stripe_checkout_session_idによる突合でCheckout Sessionリンクを解除", async () => {
     // Arrange: pending状態の決済レコードを準備
     const sessionId = "cs_test_expired_" + Date.now();
     const paymentIntentId = "pi_test_expired_" + Date.now();
@@ -94,10 +104,12 @@ describe("🔄 正常系: pending → failed 遷移", () => {
     const result = await handler.handleEvent(event);
 
     // Assert: レスポンス検証
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       success: true,
-      eventId: event.id,
-      paymentId: payment.id,
+      meta: {
+        eventId: event.id,
+        paymentId: payment.id,
+      },
     });
 
     // Assert: データベース更新検証
@@ -108,30 +120,27 @@ describe("🔄 正常系: pending → failed 遷移", () => {
       .single();
 
     expect(updatedPayment).toMatchObject({
-      status: "failed",
-      webhook_event_id: event.id,
-      stripe_checkout_session_id: sessionId,
-      stripe_payment_intent_id: paymentIntentId,
+      status: "pending",
+      stripe_checkout_session_id: null,
+      stripe_payment_intent_id: null,
     });
-    expect(updatedPayment.webhook_processed_at).toBeTruthy();
+    expect(updatedPayment.webhook_event_id).toBeNull();
+    expect(updatedPayment.webhook_processed_at).toBeNull();
     expect(updatedPayment.updated_at).toBeTruthy();
 
     // Assert: ログ出力検証
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "Webhook security event",
+      "Checkout session expiration processed",
       expect.objectContaining({
-        event_action: "webhook_checkout_expired_processed",
-        details: expect.objectContaining({
-          eventId: event.id,
-          paymentId: payment.id,
-          sessionId,
-          paymentIntentId,
-        }),
+        event_id: event.id,
+        payment_id: payment.id,
+        payment_intent_id: paymentIntentId,
+        outcome: "success",
       })
     );
   });
 
-  test("metadata.payment_id フォールバック突合で決済レコードを更新", async () => {
+  test("metadata.payment_id フォールバック突合で古いCheckout Session期限切れを無視", async () => {
     // Arrange: metadata経由での突合テスト用
     const sessionId = "cs_test_metadata_" + Date.now();
 
@@ -159,10 +168,12 @@ describe("🔄 正常系: pending → failed 遷移", () => {
     const result = await handler.handleEvent(event);
 
     // Assert: レスポンス検証
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       success: true,
-      eventId: event.id,
-      paymentId: payment.id,
+      meta: {
+        eventId: event.id,
+        paymentId: payment.id,
+      },
     });
 
     // Assert: データベース更新検証
@@ -173,13 +184,58 @@ describe("🔄 正常系: pending → failed 遷移", () => {
       .single();
 
     expect(updatedPayment).toMatchObject({
-      status: "failed",
-      webhook_event_id: event.id,
-      stripe_checkout_session_id: sessionId,
+      status: "pending",
+      stripe_checkout_session_id: null,
     });
+    expect(updatedPayment.webhook_event_id).toBeNull();
+    expect(updatedPayment.webhook_processed_at).toBeNull();
   });
 
-  test("PaymentIntent ID が null の場合はデータベース制約エラー", async () => {
+  test("古いCheckout Sessionの期限切れは現在のCheckout Sessionリンクを変更しない", async () => {
+    const expiredSessionId = "cs_test_expired_old_" + Date.now();
+    const currentSessionId = "cs_test_current_" + Date.now();
+    const dedicatedAttendance = await createTestAttendance(setup.testEvent.id);
+    const payment = await createPendingTestPayment(dedicatedAttendance.id, {
+      amount: 1500,
+      stripeAccountId: setup.testUser.stripeConnectAccountId,
+    });
+
+    await setup.adminClient
+      .from("payments")
+      .update({
+        status: "pending",
+        stripe_checkout_session_id: currentSessionId,
+      })
+      .eq("id", payment.id);
+
+    const event = createCheckoutExpiredEvent(expiredSessionId, {
+      metadata: { payment_id: payment.id },
+    });
+
+    const handler = new StripeWebhookEventHandler();
+    const result = await handler.handleEvent(event);
+
+    expect(result).toMatchObject({
+      success: true,
+      meta: {
+        eventId: event.id,
+        paymentId: payment.id,
+      },
+    });
+
+    const { data: updatedPayment } = await setup.adminClient
+      .from("payments")
+      .select("*")
+      .eq("id", payment.id)
+      .single();
+
+    expect(updatedPayment.status).toBe("pending");
+    expect(updatedPayment.stripe_checkout_session_id).toBe(currentSessionId);
+    expect(updatedPayment.webhook_event_id).toBeNull();
+    expect(updatedPayment.webhook_processed_at).toBeNull();
+  });
+
+  test("PaymentIntent ID が null の場合もpendingのままCheckout Sessionリンクを解除", async () => {
     // Arrange
     const sessionId = "cs_test_no_pi_" + Date.now();
 
@@ -205,13 +261,14 @@ describe("🔄 正常系: pending → failed 遷移", () => {
     const handler = new StripeWebhookEventHandler();
     const result = await handler.handleEvent(event);
 
-    // Assert: データベース制約違反によりエラー
-    expect(result).toEqual({
-      success: false,
-      error: expect.stringContaining("payments_stripe_intent_required"),
+    expect(result).toMatchObject({
+      success: true,
+      meta: {
+        eventId: event.id,
+        paymentId: payment.id,
+      },
     });
 
-    // Assert: 決済レコードは更新されていない
     const { data: unchangedPayment } = await setup.adminClient
       .from("payments")
       .select("*")
@@ -219,5 +276,7 @@ describe("🔄 正常系: pending → failed 遷移", () => {
       .single();
 
     expect(unchangedPayment.status).toBe("pending");
+    expect(unchangedPayment.stripe_checkout_session_id).toBeNull();
+    expect(unchangedPayment.stripe_payment_intent_id).toBeNull();
   });
 });

--- a/tests/integration/payments/webhook/checkout-session-expired/status-downgrade-prevention.test.ts
+++ b/tests/integration/payments/webhook/checkout-session-expired/status-downgrade-prevention.test.ts
@@ -1,13 +1,12 @@
 /**
- * checkout.session.expired Webhook ステータス降格防止テスト
+ * checkout.session.expired Webhook non-pending 保護テスト
  *
- * 異常系: ステータス降格防止
+ * 異常系: pending 以外は更新しない
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "@jest/globals";
 
 import { logger } from "../../../../../core/logging/app-logger";
-import { canPromoteStatus } from "../../../../../core/utils/payments/status-rank";
 import { StripeWebhookEventHandler } from "../../../../../features/payments/services/webhook/webhook-event-handler";
 import {
   createTestAttendance,
@@ -18,13 +17,20 @@ import { createWebhookTestSetup, type WebhookTestSetup } from "../../../../setup
 import { createTestWebhookEvent } from "../../../../setup/stripe-test-helpers";
 
 // 外部依存のモック（統合テストなので最小限）
-jest.mock("../../../../../core/logging/app-logger", () => ({
-  logger: {
+jest.mock("../../../../../core/logging/app-logger", () => {
+  const mockMethods = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
-  },
-}));
+    debug: jest.fn(),
+  };
+  return {
+    logger: {
+      ...mockMethods,
+      withContext: jest.fn(() => mockMethods),
+    },
+  };
+});
 
 /**
  * Checkout Session Expired イベントを作成
@@ -44,7 +50,7 @@ function createCheckoutExpiredEvent(
   });
 }
 
-describe("🚫 異常系: ステータス降格防止", () => {
+describe("🚫 異常系: non-pending 保護", () => {
   let setup: WebhookTestSetup;
   let mockLogger: jest.Mocked<typeof logger>;
 
@@ -75,7 +81,7 @@ describe("🚫 異常系: ステータス降格防止", () => {
     ["waived", 25],
     ["canceled", 35],
     ["refunded", 40],
-  ])("%s ステータス（ランク %d）からの降格を防止", async (currentStatus, _expectedRank) => {
+  ])("%s ステータス（ランク %d）のpaymentは更新しない", async (currentStatus, _expectedRank) => {
     // Arrange: 高位ステータスの決済レコード
     const sessionId = `cs_test_prevent_${currentStatus}_` + Date.now();
 
@@ -126,9 +132,11 @@ describe("🚫 異常系: ステータス降格防止", () => {
     const result = await handler.handleEvent(event);
 
     // Assert: 正常レスポンス（更新はスキップ）
-    expect(result).toEqual({
-      success: true,
-    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+      })
+    );
 
     // Assert: ステータス変更されていない
     const { data: unchangedPayment } = await setup.adminClient
@@ -139,24 +147,18 @@ describe("🚫 異常系: ステータス降格防止", () => {
 
     expect(unchangedPayment.status).toBe(currentStatus);
 
-    // Assert: 重複処理防止ログ
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "Webhook security event",
+      "Checkout session expiration ignored for non-pending payment",
       expect.objectContaining({
-        event_action: "webhook_duplicate_processing_prevented",
-        details: expect.objectContaining({
-          eventId: event.id,
-          paymentId: payment.id,
-          currentStatus: currentStatus,
-        }),
+        event_id: event.id,
+        payment_id: payment.id,
+        current_status: currentStatus,
+        outcome: "success",
       })
     );
-
-    // Assert: ステータスランク検証（仕様書との整合性）
-    expect(canPromoteStatus(currentStatus as any, "failed")).toBe(false);
   });
 
-  test("同一ステータス failed → failed の重複処理防止", async () => {
+  test("failed ステータスのpaymentは更新しない", async () => {
     // Arrange: 既にfailedステータス
     const sessionId = "cs_test_duplicate_failed_" + Date.now();
 
@@ -188,23 +190,19 @@ describe("🚫 異常系: ステータス降格防止", () => {
     const handler = new StripeWebhookEventHandler();
     const result = await handler.handleEvent(event);
 
-    // Assert: 正常レスポンス（重複処理防止）
     expect(result).toEqual(
       expect.objectContaining({
         success: true,
       })
     );
 
-    // Assert: 重複処理防止ログ
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "Webhook security event",
+      "Checkout session expiration ignored for non-pending payment",
       expect.objectContaining({
-        event_action: "webhook_duplicate_processing_prevented",
-        details: expect.objectContaining({
-          eventId: event.id,
-          paymentId: payment.id,
-          currentStatus: "failed",
-        }),
+        event_id: event.id,
+        payment_id: payment.id,
+        current_status: "failed",
+        outcome: "success",
       })
     );
   });


### PR DESCRIPTION
## 概要
- checkout.session.expired 処理で payment を failed に更新せず、pending のまま維持するよう変更
- 期限切れになった Checkout Session が現在紐付いている session の場合のみ、stripe_checkout_session_id を null に更新
- non-pending payment と古い Checkout Session の期限切れイベントは安全に無視
- checkout.session.expired 関連の正常系・冪等性・エッジケース・ログ検証テストを更新

## Context
checkout.session.expired は決済失敗ではなく、Checkout Session の期限切れとして扱うため、payment.status は pending のまま維持する。