### PR TITLE
fix: payout手数料ChargeのWebhook誤検知を防止

### DIFF
--- a/features/payments/services/webhook/handlers/charge-handler.ts
+++ b/features/payments/services/webhook/handlers/charge-handler.ts
@@ -16,6 +16,7 @@ import {
   StripeObjectFetchService,
 } from "../services/stripe-object-fetch-service";
 import type { WebhookProcessingResult } from "../types";
+import { isPayoutRequestSystemFeeCharge } from "../webhook-event-guards";
 import {
   buildPaymentWebhookMeta,
   getPaymentWebhookLogContext,
@@ -82,6 +83,18 @@ export class ChargeHandler {
     const charge = event.data.object;
 
     try {
+      if (isPayoutRequestSystemFeeCharge(charge)) {
+        this.logger.info("Payout request system fee charge skipped by payment webhook", {
+          event_id: event.id,
+          event_type: event.type,
+          charge_id: charge.id,
+          payout_request_id: charge.metadata.payout_request_id ?? undefined,
+          purpose: charge.metadata.purpose,
+          outcome: "success",
+        });
+        return okResult();
+      }
+
       this.logger.debug("Stripe object fetch policy applied", {
         event_id: event.id,
         trust_webhook_payload: STRIPE_OBJECT_FETCH_POLICY.trustWebhookPayload.join(","),
@@ -242,9 +255,21 @@ export class ChargeHandler {
 
   async handleFailed(event: Stripe.ChargeFailedEvent): Promise<WebhookProcessingResult> {
     const charge = event.data.object;
-    const stripePaymentIntentId = getPaymentIntentId(charge);
 
     try {
+      if (isPayoutRequestSystemFeeCharge(charge)) {
+        this.logger.info("Payout request system fee charge skipped by payment webhook", {
+          event_id: event.id,
+          event_type: event.type,
+          charge_id: charge.id,
+          payout_request_id: charge.metadata.payout_request_id ?? undefined,
+          purpose: charge.metadata.purpose,
+          outcome: "success",
+        });
+        return okResult();
+      }
+
+      const stripePaymentIntentId = getPaymentIntentId(charge);
       const payment = await this.paymentRepository.resolveByChargeOrFallback({
         paymentIntentId: stripePaymentIntentId,
         chargeId: charge.id,

--- a/features/payments/services/webhook/handlers/refund-handler.ts
+++ b/features/payments/services/webhook/handlers/refund-handler.ts
@@ -16,7 +16,10 @@ import {
 } from "../repositories/payment-webhook-repository";
 import { StripeObjectFetchService } from "../services/stripe-object-fetch-service";
 import type { WebhookProcessingResult } from "../types";
-import { getRefundFromWebhookEvent } from "../webhook-event-guards";
+import {
+  getRefundFromWebhookEvent,
+  isPayoutRequestSystemFeeCharge,
+} from "../webhook-event-guards";
 import {
   buildPaymentWebhookMeta,
   getPaymentWebhookLogContext,
@@ -154,6 +157,18 @@ export class RefundHandler {
     const charge = event.data.object;
 
     try {
+      if (isPayoutRequestSystemFeeCharge(charge)) {
+        this.logger.info("Payout request system fee charge skipped by payment webhook", {
+          event_id: event.id,
+          event_type: event.type,
+          charge_id: charge.id,
+          payout_request_id: charge.metadata.payout_request_id ?? undefined,
+          purpose: charge.metadata.purpose,
+          outcome: "success",
+        });
+        return okResult();
+      }
+
       const applied = await this.applyRefundAggregateFromCharge({
         charge,
         eventId: event.id,

--- a/features/payments/services/webhook/webhook-event-guards.ts
+++ b/features/payments/services/webhook/webhook-event-guards.ts
@@ -20,6 +20,8 @@ const REFUND_FAILED_EVENT_TYPES: ReadonlySet<RefundFailedCompatibleEventType> = 
   "refund.failed",
 ]);
 
+const PAYOUT_REQUEST_SYSTEM_FEE_PURPOSE = "payout_request_system_fee";
+
 export function isRefundCreatedCompatibleEventType(
   eventType: string
 ): eventType is RefundCreatedCompatibleEventType {
@@ -36,6 +38,19 @@ export function isRefundFailedCompatibleEventType(
   eventType: string
 ): eventType is RefundFailedCompatibleEventType {
   return REFUND_FAILED_EVENT_TYPES.has(eventType as RefundFailedCompatibleEventType);
+}
+
+export function isPayoutRequestSystemFeeCharge(charge: unknown): boolean {
+  if (!charge || typeof charge !== "object") {
+    return false;
+  }
+
+  const metadata = (charge as { metadata?: unknown }).metadata;
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+
+  return (metadata as Record<string, unknown>).purpose === PAYOUT_REQUEST_SYSTEM_FEE_PURPOSE;
 }
 
 function isRefundObject(object: unknown): object is Stripe.Refund {

--- a/tests/unit/payments/webhook-event-guards.test.ts
+++ b/tests/unit/payments/webhook-event-guards.test.ts
@@ -3,12 +3,36 @@ import Stripe from "stripe";
 
 import {
   getRefundFromWebhookEvent,
+  isPayoutRequestSystemFeeCharge,
   isRefundCreatedCompatibleEventType,
   isRefundFailedCompatibleEventType,
   isRefundUpdatedCompatibleEventType,
 } from "@/features/payments/services/webhook/webhook-event-guards";
 
 describe("webhook-event-guards", () => {
+  describe("isPayoutRequestSystemFeeCharge", () => {
+    it("should identify payout request system fee charge", () => {
+      expect(
+        isPayoutRequestSystemFeeCharge({
+          id: "py_123",
+          metadata: { purpose: "payout_request_system_fee" },
+        })
+      ).toBe(true);
+    });
+
+    it.each([
+      undefined,
+      null,
+      {},
+      { metadata: null },
+      { metadata: {} },
+      { metadata: { purpose: "event_payment" } },
+      { metadata: { purpose: 123 } },
+    ])("should reject a non-system-fee charge: %p", (charge) => {
+      expect(isPayoutRequestSystemFeeCharge(charge)).toBe(false);
+    });
+  });
+
   describe("isRefundCreatedCompatibleEventType", () => {
     it("should identify refund.created event", () => {
       expect(isRefundCreatedCompatibleEventType("refund.created")).toBe(true);

--- a/tests/unit/payments/webhook/payout-system-fee-charge.test.ts
+++ b/tests/unit/payments/webhook/payout-system-fee-charge.test.ts
@@ -1,0 +1,128 @@
+import type Stripe from "stripe";
+
+import { ChargeHandler } from "@/features/payments/services/webhook/handlers/charge-handler";
+import { RefundHandler } from "@/features/payments/services/webhook/handlers/refund-handler";
+import { handleServerError } from "@core/utils/error-handler.server";
+
+jest.mock("@core/utils/error-handler.server", () => ({
+  handleServerError: jest.fn(),
+}));
+
+describe("payout request system fee charge webhook", () => {
+  const mockLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  const mockPaymentRepository = {
+    resolveByChargeOrFallback: jest.fn(),
+  };
+  const mockStripeObjectFetchService = {
+    getChargeSnapshotForChargeSucceeded: jest.fn(),
+    retrieveChargeForRefundAggregation: jest.fn(),
+  };
+  const mockPaymentNotificationService = {
+    sendPaymentCompletedNotification: jest.fn(),
+  };
+
+  const createChargeEvent = (type: string, purpose = "payout_request_system_fee"): Stripe.Event =>
+    ({
+      id: `evt_${type}`,
+      type,
+      data: {
+        object: {
+          id: "py_system_fee_123",
+          object: "charge",
+          metadata: {
+            purpose,
+            payout_request_id: "payout-request-123",
+          },
+        },
+      },
+    }) as unknown as Stripe.Event;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("charge.succeededを通常決済として処理しない", async () => {
+    const handler = new ChargeHandler({
+      paymentRepository: mockPaymentRepository as never,
+      stripeObjectFetchService: mockStripeObjectFetchService as never,
+      paymentNotificationService: mockPaymentNotificationService as never,
+      logger: mockLogger as never,
+    });
+
+    const result = await handler.handleSucceeded(
+      createChargeEvent("charge.succeeded") as Stripe.ChargeSucceededEvent
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockStripeObjectFetchService.getChargeSnapshotForChargeSucceeded).not.toHaveBeenCalled();
+    expect(mockPaymentRepository.resolveByChargeOrFallback).not.toHaveBeenCalled();
+    expect(mockPaymentNotificationService.sendPaymentCompletedNotification).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Payout request system fee charge skipped by payment webhook",
+      expect.objectContaining({
+        event_type: "charge.succeeded",
+        charge_id: "py_system_fee_123",
+        payout_request_id: "payout-request-123",
+        outcome: "success",
+      })
+    );
+  });
+
+  it("charge.failedを通常決済として処理しない", async () => {
+    const handler = new ChargeHandler({
+      paymentRepository: mockPaymentRepository as never,
+      stripeObjectFetchService: mockStripeObjectFetchService as never,
+      paymentNotificationService: mockPaymentNotificationService as never,
+      logger: mockLogger as never,
+    });
+
+    const result = await handler.handleFailed(
+      createChargeEvent("charge.failed") as Stripe.ChargeFailedEvent
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPaymentRepository.resolveByChargeOrFallback).not.toHaveBeenCalled();
+  });
+
+  it("charge.refundedを通常決済として処理しない", async () => {
+    const handler = new RefundHandler({
+      paymentRepository: mockPaymentRepository as never,
+      stripeObjectFetchService: mockStripeObjectFetchService as never,
+      logger: mockLogger as never,
+    });
+
+    const result = await handler.handleChargeRefunded(
+      createChargeEvent("charge.refunded") as Stripe.ChargeRefundedEvent
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPaymentRepository.resolveByChargeOrFallback).not.toHaveBeenCalled();
+    expect(mockStripeObjectFetchService.retrieveChargeForRefundAggregation).not.toHaveBeenCalled();
+  });
+
+  it("通常Chargeが見つからない場合は未検出エラーを維持する", async () => {
+    mockPaymentRepository.resolveByChargeOrFallback.mockResolvedValue(null);
+    const handler = new ChargeHandler({
+      paymentRepository: mockPaymentRepository as never,
+      stripeObjectFetchService: mockStripeObjectFetchService as never,
+      paymentNotificationService: mockPaymentNotificationService as never,
+      logger: mockLogger as never,
+    });
+
+    const result = await handler.handleFailed(
+      createChargeEvent("charge.failed", "event_payment") as Stripe.ChargeFailedEvent
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockPaymentRepository.resolveByChargeOrFallback).toHaveBeenCalledTimes(1);
+    expect(handleServerError).toHaveBeenCalledWith(
+      "WEBHOOK_PAYMENT_NOT_FOUND",
+      expect.objectContaining({ action: "handleChargeFailed" })
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Payout申請時のシステム手数料回収で作成されるAccount Debit Chargeを、通常決済WebhookがPayment未検出としてSentry通知する問題を修正します。

## 変更内容

- metadata.purposeがpayout_request_system_feeのChargeを識別する共通判定を追加
- charge.succeeded、charge.failed、charge.refundedで通常決済処理前に正常スキップ
- スキップ時の追跡用infoログを追加
- 通常ChargeのWEBHOOK_PAYMENT_NOT_FOUNDは維持
- 判定と各Webhook経路のunit testを追加
